### PR TITLE
feat(solecs): create getUniqueEntityId function on World contract

### DIFF
--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -76,4 +76,15 @@ contract World is IWorld {
   function hasEntity(uint256 entity) public view returns (bool) {
     return Set(entities).has(entity);
   }
+
+  function getUniqueEntityId() public view returns (uint256) {
+    uint256 entityNum = getNumEntities();
+    uint256 id;
+    do {
+      entityNum++;
+      id = uint256(keccak256(abi.encodePacked(entityNum)));
+    } while (hasEntity(id));
+
+    return id;
+  }
 }


### PR DESCRIPTION
Allow Entity Ids to be created in the World contract. IDs are hashes of the number of entities currently present in the contract.