### PR TITLE
feat(recs): add freeform metadata field to Component

### DIFF
--- a/packages/recs/src/Component.ts
+++ b/packages/recs/src/Component.ts
@@ -16,13 +16,18 @@ import {
   World,
 } from "./types";
 
-export function defineComponent<T extends Schema>(world: World, schema: T, options?: { name?: string }): Component<T> {
+export function defineComponent<T extends Schema, S = Record<string, unknown>>(
+  world: World,
+  schema: T,
+  options?: { name?: string; metadata: S }
+): Component<T> {
   const component: AnyComponent = {
     id: options?.name || uuid(),
     values: {},
     entities: new Set<Entity>(),
     stream$: new Subject(),
     schema,
+    metadata: options?.metadata ?? {},
   };
 
   for (const [key, val] of Object.entries(schema)) {
@@ -140,6 +145,7 @@ export function cloneComponent<T extends Schema>(component: Component<T>): Compo
     entities: new Set<Entity>(...component.entities),
     stream$: new Subject(),
     schema: {},
+    metadata: {},
   };
 
   for (const key of Object.keys(component.values)) {

--- a/packages/recs/src/types.ts
+++ b/packages/recs/src/types.ts
@@ -31,13 +31,14 @@ export type ComponentValue<T extends Schema> = {
   [key in keyof T]: ValueType[T[key]];
 };
 
-export interface Component<T extends Schema> {
+export interface Component<T extends Schema, S = Record<string, unknown>> {
   id: string;
   values: { [key in keyof T]: Map<Entity, ValueType[T[key]]> };
   entities: Set<Entity>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stream$: Subject<any>;
   schema: Schema;
+  metadata: S;
 }
 
 export type Components = {


### PR DESCRIPTION
The first use case for this will be conditionally attaching `contractId` to Network layer Components.