### PR TITLE
feat(ri-client): pass requirement function result into updates functi…

### DIFF
--- a/packages/ri/client/src/layers/Headless/systems/ActionSystem/createActionSystem.ts
+++ b/packages/ri/client/src/layers/Headless/systems/ActionSystem/createActionSystem.ts
@@ -121,7 +121,7 @@ export function createActionSystem(
     updateComponent(Action, action.id, { state: ActionState.Executing });
 
     // Set all pending updates of this action
-    for (const { component, value, entity } of action.updates(action.componentsWithPendingUpdates)) {
+    for (const { component, value, entity } of action.updates(action.componentsWithPendingUpdates, requirementResult)) {
       componentsWithPendingUpdates[component as string].addOverride(action.id, { entity, value });
     }
 

--- a/packages/ri/client/src/layers/Headless/systems/ActionSystem/types.ts
+++ b/packages/ri/client/src/layers/Headless/systems/ActionSystem/types.ts
@@ -26,10 +26,10 @@ export interface ActionRequest<C extends Components, T> {
 
   // Declare effects this action will have on components.
   // Used to compute component values with pending updates for other requested actions.
-  updates: (componentsWithPendingUpdates: C) => ComponentUpdate<C>[];
+  updates: (componentsWithPendingUpdates: C, data: T) => ComponentUpdate<C>[];
 
   // Logic to be executed when the action is executed.
-  // If txHashes are returned, the action will only be completed (and pending updates removed)
+  // If txHashes are returned from the txQueue, the action will only be completed (and pending updates removed)
   // once all events from the given txHashes have been received and reduced.
   execute: (data: T) => Promise<{ txHashes: string[] }> | Promise<void> | void;
 }


### PR DESCRIPTION
…on in ActionRequest

Passing the ActionRequest requirement function's resulting return value as a parameter to the
updates function, similar to the execute function