### PR TITLE
chore: update constants for lattice chain

### DIFF
--- a/packages/ri/client/src/layers/Network/constants.degen.ts
+++ b/packages/ri/client/src/layers/Network/constants.degen.ts
@@ -1,5 +1,6 @@
-export const RPC_URL = "https://degen-chain.lattice.xyz/";
-export const RPC_WS_URL = "wss://degen-chain.lattice.xyz/ws/";
-export const DEV_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-export const DIAMOND_ADDRESS = "0x39903eA6F367D765001A26f5C64264BEfd42D26f";
+export const RPC_URL = "https://follower.super-degen-chain.lattice.xyz/";
+export const RPC_WS_URL = "wss://follower.super-degen-chain.lattice.xyz/";
+export const DEV_PRIVATE_KEY = "0x26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48";
+export const DIAMOND_ADDRESS = "0xD83B554d44cBcDD8d5d6a80597A7d2f87cB187eF";
+export const CHECKPOINT_URL = "https://ecs-snapshot.super-degen-chain.lattice.xyz/";
 export const LAYER_NAME = "network";

--- a/packages/ri/contracts/hardhat.config.ts
+++ b/packages/ri/contracts/hardhat.config.ts
@@ -5,9 +5,9 @@ import "./tasks/compile";
 
 const degen = {
   live: true,
-  url: "https://degen-chain.lattice.xyz",
-  accounts: ["0xb20486f2dadf532076b54c65b945f7df6728945d8bff5df06088dc1286bee1c3"],
-  chainId: 6969,
+  url: "https://follower.super-degen-chain.lattice.xyz",
+  accounts: ["0x26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48"],
+  chainId: 4242,
 };
 
 // this is when connecting to a localhost hh instance, it doesn't actually configure the hh network. for this setup stuff in the 'hardhat' key.
@@ -83,7 +83,7 @@ const config: HardhatUserConfig = {
     "4242": {
       factory: "0xC39496f108A05b8111Ae5B283c114CfB0327B359",
       deployer: "0x16820E675fF74dC1DfB0a21f8735c291eEE61F1f",
-      funding: "0",
+      funding: "1000000000",
       signedTx:
         "0xf8a78085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3822147a0339736b46d151775b8649857c91ecc36b2e7f1c6fb78a07c8794abcb1ca5c826a002ddd269b8268ceeec100c69a4b467086a0f9541d29d979285cd0976c10d9963",
     },

--- a/packages/ri/scripting/src/constants.degen.ts
+++ b/packages/ri/scripting/src/constants.degen.ts
@@ -1,4 +1,4 @@
-export const RPC_URL = "https://degen-chain.lattice.xyz/";
-export const RPC_WS_URL = "wss://degen-chain.lattice.xyz/ws/";
-export const DEV_PRIVATE_KEY = "0xb20486f2dadf532076b54c65b945f7df6728945d8bff5df06088dc1286bee1c3";
-export const DIAMOND_ADDRESS = "0x39903eA6F367D765001A26f5C64264BEfd42D26f";
+export const RPC_URL = "https://follower.super-degen-chain.lattice.xyz/";
+export const RPC_WS_URL = "wss://follower.super-degen-chain.lattice.xyz/";
+export const DEV_PRIVATE_KEY = "0x26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48";
+export const DIAMOND_ADDRESS = "0xD83B554d44cBcDD8d5d6a80597A7d2f87cB187eF";


### PR DESCRIPTION
Steps to deploy to degen chain

1. Run `yarn hardhat:deploy:degen`
2. From above, get the address of `Diamond_DiamondProxy` from the logs
3. Update `DIAMOND_ADDRESS` in `constants.degen.ts` files with the updated world 

If you're syncing client don't forget to also switch the import to `degen.ts` instead of `local.ts`