### PR TITLE
fix(network): tx queue nonce management

### DIFF
--- a/packages/network/src/createSigner.ts
+++ b/packages/network/src/createSigner.ts
@@ -1,6 +1,6 @@
 import { Wallet } from "ethers";
-import { Providers } from "./types";
+import { Providers } from "./createProvider";
 
 export function createSigner(privateKey: string, providers: Providers) {
-  return new Wallet(privateKey, providers.ws || providers.json);
+  return new Wallet(privateKey, providers.json);
 }

--- a/packages/network/src/createTxQueue.ts
+++ b/packages/network/src/createTxQueue.ts
@@ -162,19 +162,45 @@ export function createTxQueue<C extends Contracts>(
     // Increase utilization to prevent executing more tx than allowed by capacity
     utilization++;
     const txResult = await submissionMutex.runExclusive(async () => {
+      // Define variables in scope visible to finally block
+      let error: any;
+      const stateMutability = txRequest.stateMutability;
+
       try {
         // Wait if nonce is not ready
         const { nonce } = await awaitValue(readyState);
         const resultPromise = txRequest.execute(nonce);
-        if (txRequest.stateMutability !== "view") incNonce();
         if (!options?.ignoreConfirmation) return await resultPromise;
       } catch (e: any) {
         console.warn("TXQUEUE EXECUTION FAILED", e);
+        // Nonce is handled centrally in finally block (for both failing and successful tx)
+        error = e;
+        throw e; // Rethrow the error to catch it in the action queue
+      } finally {
         // If the error includes information about the transaction,
         // then the transaction was submitted and the nonce needs to be
-        // increased regardless of the error;
-        if ("transaction" in e && txRequest.stateMutability !== "view") incNonce();
-        if ("code" in e && e.code === "NONCE_EXPIRED") await resetNonce();
+        // increased regardless of the error unless the error occured during
+        // gas estimation;
+        const isGasEstimationError = error && "code" in error && error.code === "UNPREDICTABLE_GAS_LIMIT";
+        const isNonViewTransaction = error && "transaction" in error && txRequest.stateMutability !== "view";
+        const shouldIncreaseNonce =
+          (!error && stateMutability !== "view") || (isNonViewTransaction && !isGasEstimationError);
+        const shouldResetNonce =
+          error &&
+          (("code" in error && error.code === "NONCE_EXPIRED") ||
+            JSON.stringify(error).includes("transaction already imported"));
+
+        console.log("TxQueue:", {
+          error,
+          isGasEstimationError,
+          isNonViewTransaction,
+          shouldIncreaseNonce,
+          shouldResetNonce,
+        });
+
+        // Nonce handeling
+        if (shouldIncreaseNonce) incNonce();
+        if (shouldResetNonce) await resetNonce();
       }
     });
 

--- a/packages/ri/client/src/layers/Headless/api/moveEntity.ts
+++ b/packages/ri/client/src/layers/Headless/api/moveEntity.ts
@@ -41,7 +41,7 @@ export function moveEntity(
     return;
   }
 
-  const actionID = `move ${Math.random()}` as EntityID;
+  const actionID = `move ${Date.now()}` as EntityID; // Date.now to have the actions ordered in the component browser
 
   actions.add<
     // Need to debug why typescript can't automatically infer these in this case, but for now manually typing removes the error


### PR DESCRIPTION
* We had an issue in the tx queue where the nonce was increased even if the tx execution failed (due to failing gas estimation or actual tx revert)