### PR TITLE
feat: add indexers to recs

### DIFF
--- a/packages/recs/src/Component.ts
+++ b/packages/recs/src/Component.ts
@@ -6,12 +6,14 @@ import {
   Component,
   ComponentValue,
   EntityIndex,
+  Indexer,
   Metadata,
   OverridableComponent,
   Override,
   Schema,
   World,
 } from "./types";
+import { isFullComponentValue, isIndexer } from "./utils";
 
 export function defineComponent<S extends Schema, M extends Metadata>(
   world: World,
@@ -104,11 +106,16 @@ export function withValue<S extends Schema>(
   return [component, value];
 }
 
-// TODO: Trivial implementation, needs to be more efficient for performant HasValue queries
 export function getEntitiesWithValue<T extends Schema>(
-  component: Component<T>,
+  component: Component<T> | Indexer<T>,
   value: Partial<ComponentValue<T>>
 ): Set<EntityIndex> {
+  // Shortcut for indexers
+  if (isIndexer(component) && isFullComponentValue(component, value)) {
+    return component.getEntitiesWithValue(value);
+  }
+
+  // Trivial implementation for regular components
   const entities = new Set<EntityIndex>();
   for (const entity of getComponentEntities(component)) {
     const val = getComponentValue(component, entity);

--- a/packages/recs/src/Indexer.ts
+++ b/packages/recs/src/Indexer.ts
@@ -1,0 +1,54 @@
+import { getComponentEntities, getComponentValue } from "./Component";
+import { Component, ComponentValue, EntityIndex, Indexer, Schema, World } from "./types";
+
+// Simple implementation of a "reverse mapping" indexer.
+// Could be made more memory efficient by using a hash of the value as key.
+export function createIndexer<S extends Schema>(world: World, component: Component<S>): Indexer<S> {
+  const valueToEntities = new Map<string, Set<EntityIndex>>();
+
+  function getEntitiesWithValue(value: ComponentValue<S>) {
+    return valueToEntities.get(getValueKey(value)) ?? new Set<EntityIndex>();
+  }
+
+  function getValueKey(value: ComponentValue<S>): string {
+    return JSON.stringify(value);
+  }
+
+  function add(entity: EntityIndex, value: ComponentValue<S> | undefined) {
+    if (!value) return;
+    const valueKey = getValueKey(value);
+    let entitiesWithValue = valueToEntities.get(valueKey);
+    if (!entitiesWithValue) {
+      entitiesWithValue = new Set<EntityIndex>();
+      valueToEntities.set(valueKey, entitiesWithValue);
+    }
+    entitiesWithValue.add(entity);
+  }
+
+  function remove(entity: EntityIndex, value: ComponentValue<S> | undefined) {
+    if (!value) return;
+    const valueKey = getValueKey(value);
+    const entitiesWithValue = valueToEntities.get(valueKey);
+    if (!entitiesWithValue) return;
+    entitiesWithValue.delete(entity);
+  }
+
+  // Initial indexing
+  for (const entity of getComponentEntities(component)) {
+    const value = getComponentValue(component, entity);
+    add(entity, value);
+  }
+
+  // Keeping index up to date
+  const subscription = component.update$.subscribe(({ entity, value }) => {
+    // Remove from previous location
+    remove(entity, value[1]);
+
+    // Add to new location
+    add(entity, value[0]);
+  });
+
+  world.registerDisposer(() => subscription?.unsubscribe());
+
+  return { ...component, id: `index/${component.id}`, getEntitiesWithValue };
+}

--- a/packages/recs/src/types.ts
+++ b/packages/recs/src/types.ts
@@ -53,6 +53,10 @@ export interface Component<S extends Schema = Schema, M extends Metadata = Metad
   update$: Subject<ComponentUpdate<S>> & { observers: any };
 }
 
+export type Indexer<S extends Schema> = Component<S> & {
+  getEntitiesWithValue: (value: ComponentValue<S>) => Set<EntityIndex>;
+};
+
 export type Components = {
   [key: string]: Component<Schema>;
 };

--- a/packages/recs/src/utils.ts
+++ b/packages/recs/src/utils.ts
@@ -1,7 +1,7 @@
 import { map, pipe } from "rxjs";
 import { getComponentValue } from "./Component";
 import { UpdateType } from "./constants";
-import { Component, ComponentUpdate, EntityIndex, Schema } from "./types";
+import { Component, ComponentUpdate, ComponentValue, EntityIndex, Indexer, Schema } from "./types";
 
 export function isComponentUpdate<S extends Schema>(
   update: ComponentUpdate,
@@ -24,4 +24,15 @@ export function toUpdate<S extends Schema>(entity: EntityIndex, component: Compo
 
 export function toUpdateStream<S extends Schema>(component: Component<S>) {
   return pipe(map((entity: EntityIndex) => toUpdate(entity, component)));
+}
+
+export function isIndexer<S extends Schema>(c: Component<S> | Indexer<S>): c is Indexer<S> {
+  return "getEntitiesWithValue" in c;
+}
+
+export function isFullComponentValue<S extends Schema>(
+  component: Component<S>,
+  value: Partial<ComponentValue<S>>
+): value is ComponentValue<S> {
+  return Object.keys(component.schema).every((key) => key in value);
 }

--- a/packages/recs/tests/Indexer.spec.ts
+++ b/packages/recs/tests/Indexer.spec.ts
@@ -1,0 +1,288 @@
+import {
+  defineComponent,
+  setComponent,
+  removeComponent,
+  getComponentValue,
+  hasComponent,
+  withValue,
+  componentValueEquals,
+  getEntitiesWithValue,
+  overridableComponent,
+} from "../src/Component";
+import { createIndexer } from "../src/Indexer";
+import { Type } from "../src/constants";
+import { createEntity } from "../src/Entity";
+import { AnyComponent, EntityID, EntityIndex, World } from "../src/types";
+import { createWorld } from "../src/World";
+
+describe("Indexer", () => {
+  let world: World;
+
+  beforeEach(() => {
+    world = createWorld();
+  });
+
+  it("emit changes to its stream", () => {
+    const entity = createEntity(world);
+    const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+
+    const mock = jest.fn();
+    component.update$.subscribe((update) => {
+      mock(update);
+    });
+
+    setComponent(component, entity, { x: 1, y: 2 });
+    setComponent(component, entity, { x: 7, y: 2 });
+    setComponent(component, entity, { x: 7, y: 2 });
+    removeComponent(component, entity);
+
+    expect(mock).toHaveBeenNthCalledWith(1, { entity, value: [{ x: 1, y: 2 }, undefined], component });
+    expect(mock).toHaveBeenNthCalledWith(2, {
+      entity,
+      component,
+      value: [
+        { x: 7, y: 2 },
+        { x: 1, y: 2 },
+      ],
+    });
+    expect(mock).toHaveBeenNthCalledWith(3, {
+      entity,
+      component,
+      value: [
+        { x: 7, y: 2 },
+        { x: 7, y: 2 },
+      ],
+    });
+    expect(mock).toHaveBeenNthCalledWith(4, { entity, component, value: [undefined, { x: 7, y: 2 }] });
+  });
+
+  describe("setComponent", () => {
+    let component: AnyComponent;
+    let entity: EntityIndex;
+    let value: number;
+
+    beforeEach(() => {
+      component = createIndexer(world, defineComponent(world, { value: Type.Number }));
+      entity = createEntity(world);
+      value = 1;
+      setComponent(component, entity, { value });
+    });
+
+    it("should store the component value", () => {
+      expect(component.values.value.get(entity)).toBe(value);
+    });
+
+    it("should store the entity", () => {
+      expect(hasComponent(component, entity)).toBe(true);
+    });
+
+    it.todo("should store the value array");
+  });
+
+  describe("removeComponent", () => {
+    let component: AnyComponent;
+    let entity: EntityIndex;
+    let value: number;
+
+    beforeEach(() => {
+      component = createIndexer(world, defineComponent(world, { value: Type.Number }));
+      entity = createEntity(world);
+      value = 1;
+      setComponent(component, entity, { value });
+      removeComponent(component, entity);
+    });
+
+    it("should remove the component value", () => {
+      expect(component.values.value.get(entity)).toBe(undefined);
+    });
+
+    it("should remove the entity", () => {
+      expect(hasComponent(component, entity)).toBe(false);
+    });
+
+    // it("shouldremove the component from the entity's component set", () => {
+    //   expect(world.entities.get(entity)?.has(component)).toBe(false);
+    // });
+  });
+
+  describe("hasComponent", () => {
+    it("should return true if the entity has the component", () => {
+      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity = createEntity(world);
+      const value = { x: 1, y: 2 };
+      setComponent(component, entity, value);
+
+      expect(hasComponent(component, entity)).toEqual(true);
+    });
+  });
+
+  describe("getComponentValue", () => {
+    it("should return the correct component value", () => {
+      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity = createEntity(world);
+      const value = { x: 1, y: 2 };
+      setComponent(component, entity, value);
+
+      const receivedValue = getComponentValue(component, entity);
+      expect(receivedValue).toEqual(value);
+    });
+  });
+
+  describe("getComponentValueStrict", () => {
+    it.todo("should return the correct component value");
+    it.todo("should error if the component value does not exist");
+  });
+
+  describe("componentValueEquals", () => {
+    it("values should equal equal values", () => {
+      const value1 = { x: 1, y: 2, z: "x" };
+      const value2 = { x: 1, y: 2, z: "x" };
+      const value3 = { x: "1", y: 2, z: "x" };
+
+      expect(componentValueEquals(value1, value2)).toBe(true);
+      expect(componentValueEquals(value2, value3)).toBe(false);
+    });
+  });
+
+  describe("withValue", () => {
+    it("should return a ComponentWithValue", () => {
+      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const value = { x: 1, y: 2 };
+      const componentWithValue = withValue(component, value);
+      expect(componentWithValue).toEqual([component, value]);
+    });
+  });
+
+  describe("getEntitiesWithValue", () => {
+    it("Should return all and only entities with this value", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity1 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
+      createEntity(world, [withValue(Position, { x: 2, y: 1 })]);
+      createEntity(world);
+      const entity4 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
+
+      expect(getEntitiesWithValue(Position, { x: 1, y: 2 })).toEqual(new Set([entity1, entity4]));
+    });
+
+    it("Should keep the entities with value up to date", () => {
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number });
+      const entity1 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
+      const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 1 })]);
+      createEntity(world);
+      const PositionIndexer = createIndexer(world, Position);
+      expect(getEntitiesWithValue(PositionIndexer, { x: 1, y: 2 })).toEqual(new Set([entity1]));
+
+      const entity3 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
+      expect(getEntitiesWithValue(PositionIndexer, { x: 1, y: 2 })).toEqual(new Set([entity1, entity3]));
+
+      setComponent(Position, entity2, { x: 1, y: 2 });
+      expect(getEntitiesWithValue(PositionIndexer, { x: 1, y: 2 })).toEqual(new Set([entity1, entity2, entity3]));
+
+      setComponent(PositionIndexer, entity1, { x: 2, y: 2 });
+      expect(getEntitiesWithValue(PositionIndexer, { x: 1, y: 2 })).toEqual(new Set([entity2, entity3]));
+    });
+  });
+
+  describe("overridableComponent", () => {
+    it("should return a overridable component", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const OverridablePosition = overridableComponent(Position);
+      expect("addOverride" in OverridablePosition).toBe(true);
+      expect("addOverride" in OverridablePosition).toBe(true);
+    });
+
+    it("should mirror all values of the source component", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity1 = createEntity(world);
+      setComponent(Position, entity1, { x: 1, y: 2 });
+
+      const OverridablePosition = overridableComponent(Position);
+      expect(getComponentValue(OverridablePosition, entity1)).toEqual({ x: 1, y: 2 });
+    });
+
+    it("the overridable component should be updated if the original component is updated", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity1 = createEntity(world);
+      setComponent(Position, entity1, { x: 1, y: 2 });
+
+      const OverridableComponent = overridableComponent(Position);
+
+      setComponent(Position, entity1, { x: 2, y: 2 });
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 2, y: 2 });
+
+      const entity2 = createEntity(world, [withValue(Position, { x: 3, y: 3 })]);
+      expect(getComponentValue(OverridableComponent, entity2)).toEqual({ x: 3, y: 3 });
+    });
+
+    it("should return the updated component value if there is a relevant update for the given entity", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity1 = createEntity(world);
+      const entity2 = createEntity(world);
+      setComponent(Position, entity1, { x: 1, y: 2 });
+      setComponent(Position, entity2, { x: 5, y: 6 });
+
+      const OverridableComponent = overridableComponent(Position);
+      OverridableComponent.addOverride("firstOverride" as EntityID, { entity: entity1, value: { x: 2, y: 3 } });
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 2, y: 3 });
+      expect(getComponentValue(OverridableComponent, entity2)).toEqual({ x: 5, y: 6 });
+
+      OverridableComponent.addOverride("secondOverride" as EntityID, { entity: entity1, value: { x: 3, y: 3 } });
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 3, y: 3 });
+
+      OverridableComponent.removeOverride("secondOverride" as EntityID);
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 2, y: 3 });
+
+      setComponent(Position, entity1, { x: 10, y: 20 });
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 2, y: 3 });
+
+      OverridableComponent.removeOverride("firstOverride" as EntityID);
+      expect(getComponentValue(OverridableComponent, entity1)).toEqual({ x: 10, y: 20 });
+    });
+
+    it("adding an override should trigger reactions depending on the getComponentValue of the overriden component", () => {
+      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const entity1 = createEntity(world);
+      setComponent(Position, entity1, { x: 1, y: 2 });
+
+      const OverridablePosition = overridableComponent(Position);
+
+      const spy = jest.fn();
+      OverridablePosition.update$.subscribe(spy);
+
+      expect(spy).toHaveBeenCalledTimes(0);
+
+      OverridablePosition.addOverride("firstOverride" as EntityID, { entity: entity1, value: { x: 3, y: 3 } });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenLastCalledWith({
+        entity: entity1,
+        component: OverridablePosition,
+        value: [
+          { x: 3, y: 3 },
+          { x: 1, y: 2 },
+        ],
+      });
+
+      OverridablePosition.removeOverride("firstOverride" as EntityID);
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenLastCalledWith({
+        entity: entity1,
+        component: OverridablePosition,
+        value: [
+          { x: 1, y: 2 },
+          { x: 3, y: 3 },
+        ],
+      });
+
+      OverridablePosition.addOverride("secondOverride" as EntityID, {
+        entity: 42 as EntityIndex,
+        value: { x: 2, y: 3 },
+      });
+      expect(spy).toHaveBeenLastCalledWith({
+        entity: 42,
+        component: OverridablePosition,
+        value: [{ x: 2, y: 3 }, undefined],
+      });
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
* Add `createIndexer`: wrapping a component this returns an indexed component, that can be used like a regular component, but there will be a little memory and runtime overhead when setting a component value in exchange for much better performance when asking for all entities with a specific value (which is used internally in queries with the `HasValue` query fragment)