### PR TITLE
fix(recs): clone set with indexed entities with values before returning

### DIFF
--- a/packages/recs/src/Component.ts
+++ b/packages/recs/src/Component.ts
@@ -2,6 +2,7 @@ import { uuid } from "@latticexyz/utils";
 import { mapObject } from "@latticexyz/utils";
 import { filter, Subject } from "rxjs";
 import { OptionalTypes } from "./constants";
+import { createIndexer } from "./Indexer";
 import {
   Component,
   ComponentValue,
@@ -18,7 +19,7 @@ import { isFullComponentValue, isIndexer } from "./utils";
 export function defineComponent<S extends Schema, M extends Metadata>(
   world: World,
   schema: S,
-  options?: { id?: string; metadata?: M }
+  options?: { id?: string; metadata?: M; indexed?: boolean }
 ) {
   if (Object.keys(schema).length === 0) throw new Error("Component schema must have at least one key");
   const id = options?.id ?? uuid();
@@ -26,7 +27,8 @@ export function defineComponent<S extends Schema, M extends Metadata>(
   const update$ = new Subject();
   const metadata = options?.metadata;
   const entities = () => (Object.values(values)[0] as Map<EntityIndex, unknown>).keys();
-  const component = { values, schema, id, update$, metadata, entities, world } as Component<S, M>;
+  let component = { values, schema, id, update$, metadata, entities, world } as Component<S, M>;
+  if (options?.indexed) component = createIndexer(component);
   world.registerComponent(component);
   return component;
 }

--- a/packages/recs/src/types.ts
+++ b/packages/recs/src/types.ts
@@ -53,7 +53,7 @@ export interface Component<S extends Schema = Schema, M extends Metadata = Metad
   update$: Subject<ComponentUpdate<S>> & { observers: any };
 }
 
-export type Indexer<S extends Schema> = Component<S> & {
+export type Indexer<S extends Schema, M extends Metadata = Metadata> = Component<S, M> & {
   getEntitiesWithValue: (value: ComponentValue<S>) => Set<EntityIndex>;
 };
 

--- a/packages/recs/tests/Indexer.spec.ts
+++ b/packages/recs/tests/Indexer.spec.ts
@@ -24,7 +24,7 @@ describe("Indexer", () => {
 
   it("emit changes to its stream", () => {
     const entity = createEntity(world);
-    const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+    const component = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
 
     const mock = jest.fn();
     component.update$.subscribe((update) => {
@@ -62,7 +62,7 @@ describe("Indexer", () => {
     let value: number;
 
     beforeEach(() => {
-      component = createIndexer(world, defineComponent(world, { value: Type.Number }));
+      component = defineComponent(world, { value: Type.Number }, { indexed: true });
       entity = createEntity(world);
       value = 1;
       setComponent(component, entity, { value });
@@ -85,7 +85,7 @@ describe("Indexer", () => {
     let value: number;
 
     beforeEach(() => {
-      component = createIndexer(world, defineComponent(world, { value: Type.Number }));
+      component = defineComponent(world, { value: Type.Number }, { indexed: true });
       entity = createEntity(world);
       value = 1;
       setComponent(component, entity, { value });
@@ -107,7 +107,7 @@ describe("Indexer", () => {
 
   describe("hasComponent", () => {
     it("should return true if the entity has the component", () => {
-      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const component = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity = createEntity(world);
       const value = { x: 1, y: 2 };
       setComponent(component, entity, value);
@@ -118,7 +118,7 @@ describe("Indexer", () => {
 
   describe("getComponentValue", () => {
     it("should return the correct component value", () => {
-      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const component = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity = createEntity(world);
       const value = { x: 1, y: 2 };
       setComponent(component, entity, value);
@@ -146,7 +146,7 @@ describe("Indexer", () => {
 
   describe("withValue", () => {
     it("should return a ComponentWithValue", () => {
-      const component = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const component = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const value = { x: 1, y: 2 };
       const componentWithValue = withValue(component, value);
       expect(componentWithValue).toEqual([component, value]);
@@ -155,7 +155,7 @@ describe("Indexer", () => {
 
   describe("getEntitiesWithValue", () => {
     it("Should return all and only entities with this value", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity1 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
       createEntity(world, [withValue(Position, { x: 2, y: 1 })]);
       createEntity(world);
@@ -169,7 +169,7 @@ describe("Indexer", () => {
       const entity1 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
       const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 1 })]);
       createEntity(world);
-      const PositionIndexer = createIndexer(world, Position);
+      const PositionIndexer = createIndexer(Position);
       expect(getEntitiesWithValue(PositionIndexer, { x: 1, y: 2 })).toEqual(new Set([entity1]));
 
       const entity3 = createEntity(world, [withValue(Position, { x: 1, y: 2 })]);
@@ -185,14 +185,14 @@ describe("Indexer", () => {
 
   describe("overridableComponent", () => {
     it("should return a overridable component", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const OverridablePosition = overridableComponent(Position);
       expect("addOverride" in OverridablePosition).toBe(true);
       expect("addOverride" in OverridablePosition).toBe(true);
     });
 
     it("should mirror all values of the source component", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity1 = createEntity(world);
       setComponent(Position, entity1, { x: 1, y: 2 });
 
@@ -201,7 +201,7 @@ describe("Indexer", () => {
     });
 
     it("the overridable component should be updated if the original component is updated", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity1 = createEntity(world);
       setComponent(Position, entity1, { x: 1, y: 2 });
 
@@ -215,7 +215,7 @@ describe("Indexer", () => {
     });
 
     it("should return the updated component value if there is a relevant update for the given entity", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity1 = createEntity(world);
       const entity2 = createEntity(world);
       setComponent(Position, entity1, { x: 1, y: 2 });
@@ -240,7 +240,7 @@ describe("Indexer", () => {
     });
 
     it("adding an override should trigger reactions depending on the getComponentValue of the overriden component", () => {
-      const Position = createIndexer(world, defineComponent(world, { x: Type.Number, y: Type.Number }));
+      const Position = defineComponent(world, { x: Type.Number, y: Type.Number }, { indexed: true });
       const entity1 = createEntity(world);
       setComponent(Position, entity1, { x: 1, y: 2 });
 

--- a/packages/ri/client/src/layers/Local/components/LocalPosition.ts
+++ b/packages/ri/client/src/layers/Local/components/LocalPosition.ts
@@ -2,5 +2,5 @@ import { World } from "@latticexyz/recs";
 import { defineCoordComponent } from "@latticexyz/std-client";
 
 export function defineLocalPositionComponent(world: World) {
-  return defineCoordComponent(world, { id: "LocalPosition" });
+  return defineCoordComponent(world, { id: "LocalPosition", indexed: true });
 }

--- a/packages/ri/client/src/layers/Local/systems/PositionSystem/createPositionSystem.ts
+++ b/packages/ri/client/src/layers/Local/systems/PositionSystem/createPositionSystem.ts
@@ -34,6 +34,9 @@ export function createPositionSystem(layer: LocalLayer) {
 
   defineComponentSystem(world, withOptimisticUpdates(Position), (update) => {
     const { entity, value } = update;
+    // Remove any outstanding Paths before computing the new location
+    removeComponent(Path, entity);
+
     const targetPosition = value[0];
     if (targetPosition == null) {
       removeComponent(LocalPosition, entity);

--- a/packages/ri/client/src/layers/Network/components/Position.ts
+++ b/packages/ri/client/src/layers/Network/components/Position.ts
@@ -1,5 +1,9 @@
 import { defineComponent, Type, World } from "@latticexyz/recs";
 
 export function definePositionComponent(world: World, contractId: string) {
-  return defineComponent(world, { x: Type.Number, y: Type.Number }, { id: "Position", metadata: { contractId } });
+  return defineComponent(
+    world,
+    { x: Type.Number, y: Type.Number },
+    { id: "Position", metadata: { contractId }, indexed: true }
+  );
 }

--- a/packages/std-client/src/components/BoolComponent.ts
+++ b/packages/std-client/src/components/BoolComponent.ts
@@ -1,5 +1,8 @@
 import { defineComponent, Metadata, Type, World } from "@latticexyz/recs";
 
-export function defineBoolComponent<M extends Metadata>(world: World, options?: { id?: string; metadata?: M }) {
+export function defineBoolComponent<M extends Metadata>(
+  world: World,
+  options?: { id?: string; metadata?: M; indexed?: boolean }
+) {
   return defineComponent<{ value: Type.Boolean }, M>(world, { value: Type.Boolean }, options);
 }

--- a/packages/std-client/src/components/CoordComponent.ts
+++ b/packages/std-client/src/components/CoordComponent.ts
@@ -1,5 +1,8 @@
 import { defineComponent, Metadata, Type, World } from "@latticexyz/recs";
 
-export function defineCoordComponent<M extends Metadata>(world: World, options?: { id?: string; metadata?: M }) {
+export function defineCoordComponent<M extends Metadata>(
+  world: World,
+  options?: { id?: string; metadata?: M; indexed?: boolean }
+) {
   return defineComponent<{ x: Type.Number; y: Type.Number }, M>(world, { x: Type.Number, y: Type.Number }, options);
 }

--- a/packages/std-client/src/components/NumberComponent.ts
+++ b/packages/std-client/src/components/NumberComponent.ts
@@ -1,5 +1,8 @@
 import { defineComponent, Metadata, Type, World } from "@latticexyz/recs";
 
-export function defineNumberComponent<M extends Metadata>(world: World, options?: { id?: string; metadata?: M }) {
+export function defineNumberComponent<M extends Metadata>(
+  world: World,
+  options?: { id?: string; metadata?: M; indexed?: boolean }
+) {
   return defineComponent<{ value: Type.Number }, M>(world, { value: Type.Number }, options);
 }

--- a/packages/std-client/src/components/StringComponent.ts
+++ b/packages/std-client/src/components/StringComponent.ts
@@ -1,5 +1,8 @@
 import { defineComponent, Metadata, Type, World } from "@latticexyz/recs";
 
-export function defineStringComponent<M extends Metadata>(world: World, options?: { id?: string; metadata?: M }) {
+export function defineStringComponent<M extends Metadata>(
+  world: World,
+  options?: { id?: string; metadata?: M; indexed?: boolean }
+) {
   return defineComponent<{ value: Type.String }, M>(world, { value: Type.String }, options);
 }


### PR DESCRIPTION
* `getEntitiesWithValue` was returning a set, which can be modified by consumers to fuck up the indexing. To avoid this, clone the set before returning it.