### PR TITLE
fix(cli): extract encoded arguments from signature

### DIFF
--- a/packages/network/src/createTxQueue.ts
+++ b/packages/network/src/createTxQueue.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BaseContract, BigNumberish, CallOverrides, Overrides } from "ethers";
 import { autorun, computed, IComputedValue, IObservableValue, observable, runInAction } from "mobx";
-import { mapObject, deferred, uuid, awaitValue, cacheUntilReady } from "@latticexyz/utils";
+import { mapObject, deferred, uuid, awaitValue, cacheUntilReady, extractEncodedArguments } from "@latticexyz/utils";
 import { Mutex } from "async-mutex";
 import { TransactionResponse } from "@ethersproject/providers";
 import { Contracts, TxQueue } from "./types";
@@ -236,9 +236,9 @@ export function createTxQueue<C extends Contracts>(
         const worldAddress = params.get("worldAddress");
         // Log useful commands that can be used to replay this tx
         const trace = `mud trace --config deploy.json --world ${worldAddress} --tx ${txResult.hash}`;
-        const call = `mud call-system --world ${worldAddress} --caller ${network.connectedAddress.get()} --calldata ${
+        const call = `mud call-system --world ${worldAddress} --caller ${network.connectedAddress.get()} --calldata ${extractEncodedArguments(
           txResult.data
-        } --systemId <SYSTEM_ID>`;
+        )} --systemId <SYSTEM_ID>`;
 
         console.log("---------- DEBUG COMMANDS (RUN IN TERMINAL) -------------");
         console.log("Trace:");

--- a/packages/network/src/networkUtils.ts
+++ b/packages/network/src/networkUtils.ts
@@ -7,7 +7,7 @@ import {
   BaseProvider,
   TransactionRequest,
 } from "@ethersproject/providers";
-import { callWithRetry, range, sleep } from "@latticexyz/utils";
+import { callWithRetry, extractEncodedArguments, range, sleep } from "@latticexyz/utils";
 import { BigNumber, Contract } from "ethers";
 import { resolveProperties, defaultAbiCoder as abi } from "ethers/lib/utils";
 import { Contracts, ContractTopics, ContractEvent, ContractsConfig } from "./types";
@@ -185,6 +185,6 @@ export async function getRevertReason(txHash: string, provider: BaseProvider): P
   const tx = await provider.getTransaction(txHash);
   tx.gasPrice = undefined; // tx object contains both gasPrice and maxFeePerGas
   const encodedRevertReason = await provider.call(tx as TransactionRequest);
-  const decodedRevertReason = abi.decode(["string"], "0x" + encodedRevertReason.substring(10));
+  const decodedRevertReason = abi.decode(["string"], extractEncodedArguments(encodedRevertReason));
   return decodedRevertReason[0];
 }

--- a/packages/utils/src/eth.ts
+++ b/packages/utils/src/eth.ts
@@ -12,3 +12,9 @@ export function toEthAddress(input: string) {
   // Prefix with 0x
   return `0x${input}`;
 }
+
+export function extractEncodedArguments(input: string) {
+  // Cutting off the first 4 bytes, which represent the function selector
+  if (input[0] !== "0" && input[1] !== "x") throw new Error("Invalid hex string");
+  return "0x" + input.substring(10);
+}


### PR DESCRIPTION
- #115 added logging prefilled commands to the js console to debug a failed transaction, but the prefilled data was invalid (included the function selector). This PR fixes that by extracting only the encoded arguments from the call.