### PR TITLE
feat(network): add loading state component update stream to SyncWorker

### DIFF
--- a/packages/network/src/workers/SyncWorker.spec.ts
+++ b/packages/network/src/workers/SyncWorker.spec.ts
@@ -1,13 +1,14 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { sleep } from "@latticexyz/utils";
+import { keccak256, sleep } from "@latticexyz/utils";
 import { computed } from "mobx";
-import { SyncWorker } from "./SyncWorker";
-import { Subject } from "rxjs";
+import { Output, SyncWorker } from "./SyncWorker";
+import { Subject, Subscription } from "rxjs";
 import { NetworkComponentUpdate, SyncWorkerConfig } from "../types";
-import { EntityID } from "@latticexyz/recs";
+import { Components, EntityID } from "@latticexyz/recs";
 import { createCacheStore, storeEvent } from "./CacheStore";
 import * as syncUtils from "./syncUtils";
 import "fake-indexeddb/auto";
+import { GodID, SyncState } from "./constants";
 
 // Test constants
 const cacheBlockNumber = 99;
@@ -98,13 +99,56 @@ jest.mock("./syncUtils", () => ({
 describe("Sync.worker", () => {
   let input$: Subject<SyncWorkerConfig>;
   let output: jest.Mock;
+  let subscription: Subscription;
+  let worker: SyncWorker<Components>;
 
   beforeEach(async () => {
     input$ = new Subject<SyncWorkerConfig>();
-    const worker = new SyncWorker();
+    worker = new SyncWorker();
 
     output = jest.fn();
-    worker.work(input$).subscribe(output);
+    subscription = worker.work(input$).subscribe((e) => {
+      if (e.component !== keccak256("component.LoadingState")) {
+        console.log("Called with", e);
+        output(e);
+      }
+    });
+  });
+
+  afterEach(() => {
+    subscription?.unsubscribe();
+  });
+
+  it("should report the current loading state via the `component.LoadingState` component", async () => {
+    const freshOutput = jest.fn();
+    const freshWorker = new SyncWorker();
+    const freshInput$ = new Subject<SyncWorkerConfig>();
+
+    const sub = (subscription = freshWorker.work(freshInput$).subscribe(freshOutput));
+
+    freshInput$.next({
+      checkpointServiceUrl: "",
+      chainId: 4242,
+      worldContract: { address: "0x00", abi: [] },
+      provider: { jsonRpcUrl: "", options: { batch: false, pollingInterval: 1000, skipNetworkCheck: true } },
+      initialBlockNumber: 0,
+    });
+
+    const finalUpdate: Output<Components> = {
+      component: keccak256("component.LoadingState"),
+      value: { state: SyncState.LIVE, msg: "Streaming live events", percentage: 100 },
+      entity: GodID,
+      txHash: "worker",
+      lastEventInTx: false,
+      blockNumber: 99,
+    };
+
+    await sleep(0);
+    blockNumber$.next(101);
+    await sleep(0);
+    expect(freshOutput).toHaveBeenCalledWith(finalUpdate);
+
+    sub?.unsubscribe();
   });
 
   it("should pass live events to the output", async () => {

--- a/packages/network/src/workers/constants.ts
+++ b/packages/network/src/workers/constants.ts
@@ -1,0 +1,9 @@
+import { EntityID } from "@latticexyz/recs";
+
+export enum SyncState {
+  CONNECTING,
+  INITIAL,
+  LIVE,
+}
+
+export const GodID = "0x060D" as EntityID;

--- a/packages/network/src/workers/index.ts
+++ b/packages/network/src/workers/index.ts
@@ -1,3 +1,4 @@
 export * from "./SyncWorker";
 export * from "./syncUtils";
 export * from "./CacheStore";
+export * from "./constants";

--- a/packages/std-client/src/utils.ts
+++ b/packages/std-client/src/utils.ts
@@ -17,11 +17,9 @@ import {
 } from "@latticexyz/recs";
 import { Coord, keccak256 } from "@latticexyz/utils";
 import { BigNumber } from "ethers";
-import { Clock } from "@latticexyz/network";
+import { Clock, GodID } from "@latticexyz/network";
 import { deferred } from "@latticexyz/utils";
 import { filter } from "rxjs";
-
-export const GodID = keccak256("mudwar.god") as EntityID;
 
 export function getCurrentTurn(
   world: World,


### PR DESCRIPTION
Add a loading state component with id keccak("component.LoadingState") to the sync worker that is
used to broadcast the current loading state to the main thread. This can be used to build a loading
screen in the client by adding a new network layer component with "contractId"
kecccak("component.LoadingState").

BREAKING CHANGE: The loading state component is attached to the entity with id 0x060D (GodID). The
std-client package previously exported a different mudwar specific GodID, which has been replaced
with the 0x060D GodID exported by the network package.