### PR TITLE
fix(network): initial sync

### DIFF
--- a/packages/network/src/workers/CacheStore.ts
+++ b/packages/network/src/workers/CacheStore.ts
@@ -58,6 +58,15 @@ export function storeEvent<Cm extends Components>(
   cacheStore.blockNumber = blockNumber - 1;
 }
 
+export function storeEvents<Cm extends Components>(
+  cacheStore: CacheStore,
+  events: Omit<NetworkComponentUpdate<Cm>, "lastEventInTx" | "txHash">[]
+) {
+  for (const event of events) {
+    storeEvent(cacheStore, event);
+  }
+}
+
 export function getCacheStoreEntries<Cm extends Components>({
   blockNumber,
   state,

--- a/packages/network/src/workers/SyncWorker.spec.ts
+++ b/packages/network/src/workers/SyncWorker.spec.ts
@@ -70,6 +70,7 @@ jest.mock("./CacheStore", () => ({
 
     return cache;
   },
+  saveCacheStoreToIndexDb: jest.fn(),
 }));
 
 jest.mock("../createBlockNumberStream", () => ({
@@ -94,6 +95,12 @@ jest.mock("./syncUtils", () => ({
       for (const event of gapStateEvents) storeEvent(store, event);
     }
     return store;
+  }),
+  fetchEventsInBlockRangeChunked: jest.fn((fetchWorldEvents: any, from: number, to: number) => {
+    if (to > 1000) {
+      return gapStateEvents;
+    }
+    return [];
   }),
 }));
 
@@ -276,7 +283,7 @@ describe("Sync.worker", () => {
     await sleep(0);
 
     // Expect state between cache block number and current block number to have been fetched
-    expect(syncUtils.fetchStateInBlockRange).toHaveBeenLastCalledWith(
+    expect(syncUtils.fetchEventsInBlockRangeChunked).toHaveBeenLastCalledWith(
       expect.anything(),
       cacheBlockNumber,
       currentBlockNumber,
@@ -356,7 +363,7 @@ describe("Sync.worker", () => {
     });
 
     // Expect state between cache block number and current block number to have been fetched
-    expect(syncUtils.fetchStateInBlockRange).toHaveBeenLastCalledWith(
+    expect(syncUtils.fetchEventsInBlockRangeChunked).toHaveBeenLastCalledWith(
       expect.anything(),
       cacheBlockNumber,
       firstLiveBlockNumber,

--- a/packages/network/src/workers/syncUtils.ts
+++ b/packages/network/src/workers/syncUtils.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { EntityID, ComponentValue } from "@latticexyz/recs";
-import { to256BitString, awaitPromise, range, sleep } from "@latticexyz/utils";
+import { EntityID, ComponentValue, Components } from "@latticexyz/recs";
+import { to256BitString, awaitPromise, range } from "@latticexyz/utils";
 import { GrpcWebFetchTransport } from "@protobuf-ts/grpcweb-transport";
 import { BytesLike, Contract, BigNumber } from "ethers";
 import { Observable, map, concatMap, of, from } from "rxjs";
@@ -11,7 +11,7 @@ import { ECSStateReply } from "@latticexyz/services/protobuf/ts/ecs-snapshot/ecs
 import { ECSStateSnapshotServiceClient } from "@latticexyz/services/protobuf/ts/ecs-snapshot/ecs-snapshot.client";
 import { ECSStreamServiceClient } from "@latticexyz/services/protobuf/ts/ecs-stream/ecs-stream.client";
 import { NetworkComponentUpdate, ContractConfig } from "../types";
-import { CacheStore, createCacheStore, storeEvent } from "./CacheStore";
+import { CacheStore, createCacheStore, storeEvent, storeEvents } from "./CacheStore";
 import { abi as ComponentAbi } from "@latticexyz/solecs/abi/Component.json";
 import { abi as WorldAbi } from "@latticexyz/solecs/abi/World.json";
 import { Component, World } from "@latticexyz/solecs/types/ethers-contracts";
@@ -204,6 +204,48 @@ export function createLatestEventStreamRPC(
 }
 
 /**
+ * Fetch ECS events from contracts in the given block range.
+ *
+ * @param fetchWorldEvents Function to fetch World events in a block range ({@link createFetchWorldEventsInBlockRange}).
+ * @param fromBlockNumber Start of block range (inclusive).
+ * @param toBlockNumber End of block range (inclusive).
+ * @param interval Chunk fetching the blocks in intervals to avoid overwhelming the client.
+ * @returns Promise resolving with array containing the contract ECS events in the given block range.
+ */
+export async function fetchEventsInBlockRangeChunked(
+  fetchWorldEvents: ReturnType<typeof createFetchWorldEventsInBlockRange>,
+  fromBlockNumber: number,
+  toBlockNumber: number,
+  interval = 50,
+  setLoadingState?: (state: SyncState, msg: string, percentage: number) => void
+): Promise<NetworkComponentUpdate<Components>[]> {
+  const events: NetworkComponentUpdate<Components>[] = [];
+  const delta = toBlockNumber - fromBlockNumber;
+  const numSteps = Math.ceil(delta / interval);
+  const steps = [...range(numSteps, interval, fromBlockNumber)];
+
+  for (let i = 0; i < steps.length; i++) {
+    const from = steps[i];
+    const to = i === steps.length - 1 ? toBlockNumber : steps[i + 1] - 1;
+    const chunkEvents = await fetchWorldEvents(from, to);
+
+    if (setLoadingState) {
+      setLoadingState(
+        SyncState.INITIAL,
+        `Fetching state from block ${fromBlockNumber} to ${toBlockNumber} (${i * interval}/${delta})`,
+        80
+      );
+    }
+
+    console.log(`[SyncWorker] initial sync fetched ${events.length} events from block range ${from} -> ${to}`);
+
+    events.push(...chunkEvents);
+  }
+
+  return events;
+}
+
+/**
  * Fetch ECS state from contracts in the given block range.
  *
  * @param fetchWorldEvents Function to fetch World events in a block range ({@link createFetchWorldEventsInBlockRange}).
@@ -220,29 +262,16 @@ export async function fetchStateInBlockRange(
   setLoadingState?: (state: SyncState, msg: string, percentage: number) => void
 ): Promise<CacheStore> {
   const cacheStore = createCacheStore();
-  const delta = toBlockNumber - fromBlockNumber;
-  const numSteps = Math.ceil(delta / interval);
-  const steps = [...range(numSteps, interval, fromBlockNumber)];
 
-  for (let i = 0; i < steps.length; i++) {
-    const from = steps[i];
-    const to = i === steps.length - 1 ? toBlockNumber : steps[i + 1] - 1;
-    const events = await fetchWorldEvents(from, to);
+  const events = await fetchEventsInBlockRangeChunked(
+    fetchWorldEvents,
+    fromBlockNumber,
+    toBlockNumber,
+    interval,
+    setLoadingState
+  );
 
-    if (setLoadingState) {
-      setLoadingState(
-        SyncState.INITIAL,
-        `Fetching state from block ${fromBlockNumber} to ${toBlockNumber} (${i * interval}/${delta})`,
-        80
-      );
-    }
-
-    console.log(`[SyncWorker] initial sync fetched ${events.length} events from block range ${from} -> ${to}`);
-
-    for (const event of events) {
-      storeEvent(cacheStore, event);
-    }
-  }
+  storeEvents(cacheStore, events);
 
   return cacheStore;
 }


### PR DESCRIPTION
- fix a bug during initial sync: previously we were loading three states during the initial sync (cache state, gap state, live state) and then merged them to get the full initial state. This approach led to an issue when one of the states included a **ComponentValueRemoved** event targeting a value in another state (eg cache state has a component value, gap state applies an event to remove this value, but because the gap state doesn't have the value, the removal event is not actually applied when merging the states). To prevent this issue, this PR changes the initial sync logic to load **events** of the "gap state" and "live state" and apply them to the cache state, such that removal events are considered.

- store cache to indexdb on every block instead of every time interval to avoid storing it before all events of the block have been applied to the local state

