### PR TITLE
feat(std-contracts): add FunctionComponent

### DIFF
--- a/packages/network/src/createDecoder.ts
+++ b/packages/network/src/createDecoder.ts
@@ -48,6 +48,8 @@ export function flattenValue<V extends ContractSchemaValue>(
       ContractSchemaValue.UINT128,
       ContractSchemaValue.UINT256,
       ContractSchemaValue.BYTES,
+      ContractSchemaValue.ADDRESS,
+      ContractSchemaValue.BYTES4,
     ].includes(valueType)
   ) {
     return value.toHexString() as ContractSchemaValueTypes[V];

--- a/packages/network/src/createSyncWorker.ts
+++ b/packages/network/src/createSyncWorker.ts
@@ -15,12 +15,12 @@ import { Output } from "./workers/SyncWorker";
  * }
  */
 export function createSyncWorker<Cm extends Components>() {
-  const config$ = new Subject<SyncWorkerConfig<Cm>>();
+  const config$ = new Subject<SyncWorkerConfig>();
   const worker = new Worker(new URL("./workers/Sync.worker.ts", import.meta.url), { type: "module" });
   const ecsEvent$ = new Subject<NetworkComponentUpdate<Cm>>();
 
   // Pass in a "config stream", receive a stream of ECS events
-  const subscription = fromWorker<SyncWorkerConfig<Cm>, Output<Cm>>(worker, config$).subscribe(ecsEvent$);
+  const subscription = fromWorker<SyncWorkerConfig, Output<Cm>>(worker, config$).subscribe(ecsEvent$);
   const dispose = () => {
     worker.terminate();
     subscription?.unsubscribe();

--- a/packages/network/src/types.ts
+++ b/packages/network/src/types.ts
@@ -79,7 +79,7 @@ export type NetworkComponentUpdate<C extends Components = Components> = {
   blockNumber: number;
 };
 
-export type SyncWorkerConfig<Cm extends Components = Components> = {
+export type SyncWorkerConfig = {
   provider: ProviderConfig;
   initialBlockNumber: number;
   worldContract: ContractConfig;
@@ -106,6 +106,8 @@ export enum ContractSchemaValue {
   UINT256,
   BYTES,
   STRING,
+  ADDRESS,
+  BYTES4,
   BOOL_ARRAY,
   INT8_ARRAY,
   INT16_ARRAY,
@@ -141,6 +143,8 @@ export const ContractSchemaValueId: { [key in ContractSchemaValue]: string } = {
   [ContractSchemaValue.UINT256]: "uint256",
   [ContractSchemaValue.BYTES]: "bytes",
   [ContractSchemaValue.STRING]: "string",
+  [ContractSchemaValue.ADDRESS]: "address",
+  [ContractSchemaValue.BYTES4]: "bytes4",
   [ContractSchemaValue.BOOL_ARRAY]: "bool[]",
   [ContractSchemaValue.INT8_ARRAY]: "int8[]",
   [ContractSchemaValue.INT16_ARRAY]: "int16[]",
@@ -195,6 +199,8 @@ export type ContractSchemaValueTypes = {
   [ContractSchemaValue.UINT256]: string;
   [ContractSchemaValue.BYTES]: string;
   [ContractSchemaValue.STRING]: string;
+  [ContractSchemaValue.ADDRESS]: string;
+  [ContractSchemaValue.BYTES4]: string;
   [ContractSchemaValue.BOOL_ARRAY]: boolean[];
   [ContractSchemaValue.INT8_ARRAY]: number[];
   [ContractSchemaValue.INT16_ARRAY]: number[];

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -29,8 +29,8 @@ import { createBlockNumberStream } from "../createBlockNumberStream";
 import { GodID, SyncState } from "./constants";
 export type Output<Cm extends Components> = NetworkComponentUpdate<Cm>;
 
-export class SyncWorker<Cm extends Components> implements DoWork<SyncWorkerConfig<Cm>, Output<Cm>> {
-  private input$ = new Subject<SyncWorkerConfig<Cm>>();
+export class SyncWorker<Cm extends Components> implements DoWork<SyncWorkerConfig, Output<Cm>> {
+  private input$ = new Subject<SyncWorkerConfig>();
   private output$ = new Subject<Output<Cm>>();
 
   constructor() {
@@ -188,7 +188,7 @@ export class SyncWorker<Cm extends Components> implements DoWork<SyncWorkerConfi
     passLiveEventsToOutput = true;
   }
 
-  public work(input$: Observable<SyncWorkerConfig<Cm>>): Observable<Output<Cm>> {
+  public work(input$: Observable<SyncWorkerConfig>): Observable<Output<Cm>> {
     input$.subscribe(this.input$);
     return this.output$.asObservable();
   }

--- a/packages/solecs/src/LibTypes.sol
+++ b/packages/solecs/src/LibTypes.sol
@@ -22,6 +22,8 @@ library LibTypes {
     UINT256,
     BYTES,
     STRING,
+    ADDRESS,
+    BYTES4,
     BOOL_ARRAY,
     INT8_ARRAY,
     INT16_ARRAY,

--- a/packages/std-contracts/src/components/FunctionComponent.sol
+++ b/packages/std-contracts/src/components/FunctionComponent.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+import "solecs/Component.sol";
+
+struct FunctionSelector {
+  address contr;
+  bytes4 func;
+}
+
+contract FunctionComponent is Component {
+  constructor(address world, uint256 id) Component(world, id) {}
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](2);
+    values = new LibTypes.SchemaValue[](2);
+
+    keys[0] = "contr";
+    values[0] = LibTypes.SchemaValue.ADDRESS;
+
+    keys[1] = "func";
+    values[1] = LibTypes.SchemaValue.BYTES4;
+  }
+
+  function set(uint256 entity, FunctionSelector memory value) public {
+    set(entity, abi.encode(value));
+  }
+
+  function getValue(uint256 entity) public view returns (FunctionSelector memory) {
+    return abi.decode(getRawValue(entity), (FunctionSelector));
+  }
+
+  function getEntitiesWithValue(FunctionSelector memory value) public view returns (uint256[] memory) {
+    return getEntitiesWithValue(abi.encode(value));
+  }
+}
+
+function staticcallFunctionSelector(FunctionSelector memory functionSelector, bytes memory args)
+  view
+  returns (bool, bytes memory)
+{
+  return functionSelector.contr.staticcall(bytes.concat(functionSelector.func, args));
+}


### PR DESCRIPTION
- add `ADDRESS` and `BYTES4` schema types
- add `FunctionComponent` to store a contract address and function selector
- add `staticcallFunctionSelector` util to simplify calling function stored in `FunctionComponent`
- remove unused generic type from `SyncWorkerConfig`