### PR TITLE
feat: flag for sig verification, rate limiting of push, and check for balance when relaying

### DIFF
--- a/packages/services/cmd/ecs-relay/main.go
+++ b/packages/services/cmd/ecs-relay/main.go
@@ -3,16 +3,20 @@ package main
 import (
 	"flag"
 
+	"latticexyz/mud/packages/services/pkg/eth"
 	"latticexyz/mud/packages/services/pkg/grpc"
 	"latticexyz/mud/packages/services/pkg/logger"
 	"latticexyz/mud/packages/services/pkg/relay"
 )
 
 var (
-	port                  = flag.Int("port", 50071, "gRPC Server Port")
-	idleTimeoutTime       = flag.Int("idle-timeout-time", 30, "Time in seconds after which a client connection times out. Defaults to 30s")
-	idleDisconnectIterval = flag.Int("idle-disconnect-interval", 60, "Time in seconds for how oftern to disconnect idle clients. Defaults to 60s")
-	messsageDriftTime     = flag.Int("message-drift-time", 5, "Time in seconds that is acceptable as drift before message is not relayed. Defaults to 5s")
+	wsUrl                  = flag.String("ws-url", "ws://localhost:8545", "Websocket Url")
+	port                   = flag.Int("port", 50071, "gRPC Server Port")
+	idleTimeoutTime        = flag.Int("idle-timeout-time", 30, "Time in seconds after which a client connection times out. Defaults to 30s")
+	idleDisconnectIterval  = flag.Int("idle-disconnect-interval", 60, "Time in seconds for how oftern to disconnect idle clients. Defaults to 60s")
+	messsageDriftTime      = flag.Int("message-drift-time", 5, "Time in seconds that is acceptable as drift before message is not relayed. Defaults to 5s")
+	verifyMessageSignature = flag.Bool("verify-msg-sig", false, "Whether to service-side verify the signature on each relayed message. Defaults to false.")
+	messageRateLimit       = flag.Float64("msg-rate-limit", 10, "Rate limit for messages per second that a single client can push to be relayed. Defaults to 10")
 )
 
 func main() {
@@ -26,11 +30,16 @@ func main() {
 
 	// Build a config.
 	config := &relay.RelayServerConfig{
-		IdleTimeoutTime:       *idleTimeoutTime,
-		IdleDisconnectIterval: *idleDisconnectIterval,
-		MessageDriftTime:      *messsageDriftTime,
+		IdleTimeoutTime:        *idleTimeoutTime,
+		IdleDisconnectIterval:  *idleDisconnectIterval,
+		MessageDriftTime:       *messsageDriftTime,
+		VerifyMessageSignature: *verifyMessageSignature,
+		MessageRateLimit:       *messageRateLimit,
 	}
 
+	// Get an instance of ethereum client.
+	ethClient := eth.GetEthereumClient(*wsUrl, logger)
+
 	// Start gRPC server and the relayer.
-	grpc.StartRelayServer(*port, config, logger)
+	grpc.StartRelayServer(*port, ethClient, config, logger)
 }

--- a/packages/services/go.mod
+++ b/packages/services/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/dghubble/go-twitter v0.0.0-20220816163853-8a0df96f1e6d
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/improbable-eng/grpc-web v0.15.0
+	github.com/keith-turner/ecoji v1.0.0
 	go.uber.org/zap v1.22.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -30,7 +32,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/keith-turner/ecoji v1.0.0 // indirect
 	github.com/klauspost/compress v1.11.7 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/rs/cors v1.7.0 // indirect

--- a/packages/services/go.sum
+++ b/packages/services/go.sum
@@ -516,6 +516,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
+golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/packages/services/pkg/eth/client.go
+++ b/packages/services/pkg/eth/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"go.uber.org/zap"
@@ -51,4 +52,14 @@ func GetCurrentBlockHead(client *ethclient.Client) *big.Int {
 		)
 	}
 	return currentHead.Number
+}
+
+// GetCurrentBalance returns the current balance of account with given address.
+func GetCurrentBalance(client *ethclient.Client, address string) (uint64, error) {
+	balance, err := client.BalanceAt(context.Background(), common.HexToAddress(address), nil)
+	if err != nil {
+		logger.GetLogger().Error("couldn't get current balance for account", zap.String("address", address), zap.Error(err))
+		return 0, err
+	}
+	return balance.Uint64(), nil
 }


### PR DESCRIPTION
- Toggle to switch on / off service-side signature verification before relay
- Rate limiting of `/Push` msg relay endpoint per client
- Only allow authenticated clients with balance > 0 to relay via `/Push`