### PR TITLE
docs: fix typo

### DIFF
--- a/packages/solecs/src/Indexer.sol
+++ b/packages/solecs/src/Indexer.sol
@@ -95,7 +95,7 @@ contract Indexer is IEntityIndexer, IERC165 {
 
     require(foundSenderComponent, "Message Sender is not indexed!");
 
-    // if there is no entity with this value, return
+    // If there is no entity with this value, return
     if (!has(entity)) return;
 
     // Remove the entity from the reverse mapping


### PR DESCRIPTION
comments are uniformly capitalized in code base; this comment is not capitalized