### PR TITLE
fix(relay): proper interval rate limiting and flag to control account balance check

### DIFF
--- a/packages/services/cmd/ecs-relay/main.go
+++ b/packages/services/cmd/ecs-relay/main.go
@@ -16,7 +16,8 @@ var (
 	idleDisconnectIterval  = flag.Int("idle-disconnect-interval", 60, "Time in seconds for how oftern to disconnect idle clients. Defaults to 60s")
 	messsageDriftTime      = flag.Int("message-drift-time", 5, "Time in seconds that is acceptable as drift before message is not relayed. Defaults to 5s")
 	verifyMessageSignature = flag.Bool("verify-msg-sig", false, "Whether to service-side verify the signature on each relayed message. Defaults to false.")
-	messageRateLimit       = flag.Float64("msg-rate-limit", 10, "Rate limit for messages per second that a single client can push to be relayed. Defaults to 10")
+	verifyAccountBalance   = flag.Bool("verify-account-balance", false, "Whether to service-side verify that the account has balance when relaying message. Defaults to false.")
+	messageRateLimit       = flag.Int("msg-rate-limit", 10, "Rate limit for messages per second that a single client can push to be relayed. Defaults to 10")
 )
 
 func main() {
@@ -34,6 +35,7 @@ func main() {
 		IdleDisconnectIterval:  *idleDisconnectIterval,
 		MessageDriftTime:       *messsageDriftTime,
 		VerifyMessageSignature: *verifyMessageSignature,
+		VerifyAccountBalance:   *verifyAccountBalance,
 		MessageRateLimit:       *messageRateLimit,
 	}
 

--- a/packages/services/pkg/grpc/relay.go
+++ b/packages/services/pkg/grpc/relay.go
@@ -283,6 +283,11 @@ func (server *ecsRelayServer) VerifyMessage(message *pb.Message, identity *pb.Id
 }
 
 func (server *ecsRelayServer) VerifySufficientBalance(client *relay.Client, address string) error {
+	// If the flag to verify account balance is turned off, do nothing.
+	if !server.config.VerifyAccountBalance {
+		return nil
+	}
+
 	if client.ShouldCheckBalance() {
 		balance, err := eth.GetCurrentBalance(server.ethClient, address)
 		if err != nil {
@@ -333,7 +338,7 @@ func (server *ecsRelayServer) HandlePushRequest(request *pb.PushRequest) error {
 
 	// Rate limit the client, if necessary.
 	if !client.GetLimiter().Allow() {
-		return fmt.Errorf("client rate limited, max %.2f msg push / second allowed", server.config.MessageRateLimit)
+		return fmt.Errorf("client rate limited, max %d msg push / second allowed", server.config.MessageRateLimit)
 	}
 
 	// Get the message.

--- a/packages/services/pkg/relay/core.go
+++ b/packages/services/pkg/relay/core.go
@@ -17,7 +17,8 @@ type RelayServerConfig struct {
 	MessageDriftTime      int
 
 	VerifyMessageSignature bool
-	MessageRateLimit       float64
+	VerifyAccountBalance   bool
+	MessageRateLimit       int
 }
 
 type Client struct {
@@ -176,7 +177,7 @@ func (registry *ClientRegistry) Register(identity *pb.Identity, config *RelaySer
 	newClient.identity = identity
 	newClient.channel = make(chan *pb.Message)
 	newClient.connected = false
-	newClient.messageRateLimiter = rate.NewLimiter(rate.Limit(config.MessageRateLimit), 1)
+	newClient.messageRateLimiter = rate.NewLimiter(rate.Every(1*time.Second/time.Duration(config.MessageRateLimit)), config.MessageRateLimit)
 
 	// At most allow a check for balance every 60s if client has funds and every 10s if not.
 	newClient.balancePresentLimiter = rate.NewLimiter(rate.Limit(float64(1)/float64(60)), 1)


### PR DESCRIPTION
- Rate limiting for message pushes / second was calculated incorrectly
- Add flag that by default makes it easier to run the relayer without balance verification for message pushes