### PR TITLE
feat(network): fall back to rpc if stream service errors

### DIFF
--- a/packages/network/src/workers/SyncWorker.spec.ts
+++ b/packages/network/src/workers/SyncWorker.spec.ts
@@ -236,7 +236,6 @@ describe("Sync.worker", () => {
       initialBlockNumber: 0,
     });
     await sleep(0);
-    expect(createLatestEventStreamRPC).not.toHaveBeenCalled();
     expect(createLatestEventStreamService).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
- catch errors in event stream from stream service and fall back to rpc in case of an error