### PR TITLE
chore(solecs): remove console import from MapSet

### DIFF
--- a/packages/solecs/src/MapSet.sol
+++ b/packages/solecs/src/MapSet.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.0;
-import { console } from "forge-std/console.sol";
 
 /**
  * Key value store with uint256 key and uint256 Set value


### PR DESCRIPTION
Remove forge console import from solecs MapSet contract.

The console is not used and there is no reason to keep debugging import in this file.