### PR TITLE
feat(network): send ack between main thread and sync worker

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -69,5 +69,6 @@
     "rxjs": "^7.5.5",
     "threads": "^1.7.0"
   },
-  "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343"
+  "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343",
+  "dependencies": {}
 }

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -5,7 +5,6 @@ import {
   concat,
   concatMap,
   filter,
-  first,
   ignoreElements,
   map,
   Observable,
@@ -34,7 +33,6 @@ import {
 } from "./CacheStore";
 import { createReconnectingProvider } from "../createProvider";
 import { computed } from "mobx";
-import { DelayQueue } from "rx-queue";
 import {
   createSnapshotClient,
   createDecode,

--- a/packages/std-client/package.json
+++ b/packages/std-client/package.json
@@ -67,7 +67,5 @@
     "rxjs": "^7.5.5"
   },
   "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343",
-  "dependencies": {
-    "rx-queue": "^1.0.5"
-  }
+  "dependencies": {}
 }

--- a/packages/std-client/package.json
+++ b/packages/std-client/package.json
@@ -66,5 +66,8 @@
     "react-syntax-highlighter": "^15.5.0",
     "rxjs": "^7.5.5"
   },
-  "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343"
+  "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343",
+  "dependencies": {
+    "rx-queue": "^1.0.5"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,6 +4767,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.8.0.tgz#b8ee8d83a99470c0661bd899417fcd77060682fe"
   integrity sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==
 
+"@types/node@^13.7.4":
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
+
 "@types/node@^16.7.13":
   version "16.11.51"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.51.tgz#bb2114485e6fc1460f630702fb992007d120e928"
@@ -10609,6 +10614,14 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+ix@^4.5.2:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/ix/-/ix-4.6.1.tgz#e9aedaba2019f8ca8df4dae2b21ee5993fd84391"
+  integrity sha512-W4aSy2cJxEgPgtr7aNOPNp/gobmWxoNUrMqH4Wowc80FFX71kqtnGMsJnIPiVN9c5tlVbOUNzjhhKcuYxsL1qQ==
+  dependencies:
+    "@types/node" "^13.7.4"
+    tslib "^2.3.0"
+
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -15342,6 +15355,14 @@ rustbn.js@~0.2.0:
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
+rx-queue@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/rx-queue/-/rx-queue-1.0.5.tgz#17711076923ec8d84f5bb76bc5e5d030ce797c0a"
+  integrity sha512-upDUgE3pk1+JnyV9MBkVSSlpSIg33ygqXvczsQIMVyjubLWCX/QzoFNfQavEHxYxKw+9JNMqDTPnxZ3dnR+61g==
+  dependencies:
+    ix "^4.5.2"
+    rxjs "^7.5.5"
+
 rxjs@^5.5.2:
   version "5.5.12"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
@@ -16866,7 +16887,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,11 +4767,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.8.0.tgz#b8ee8d83a99470c0661bd899417fcd77060682fe"
   integrity sha512-u+h43R6U8xXDt2vzUaVP3VwjjLyOJk6uEciZS8OSyziUQGOwmk+l+4drxcsDboHXwyTaqS1INebghmWMRxq3LA==
 
-"@types/node@^13.7.4":
-  version "13.13.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
-  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
-
 "@types/node@^16.7.13":
   version "16.11.51"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.51.tgz#bb2114485e6fc1460f630702fb992007d120e928"
@@ -10614,14 +10609,6 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-ix@^4.5.2:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/ix/-/ix-4.6.1.tgz#e9aedaba2019f8ca8df4dae2b21ee5993fd84391"
-  integrity sha512-W4aSy2cJxEgPgtr7aNOPNp/gobmWxoNUrMqH4Wowc80FFX71kqtnGMsJnIPiVN9c5tlVbOUNzjhhKcuYxsL1qQ==
-  dependencies:
-    "@types/node" "^13.7.4"
-    tslib "^2.3.0"
-
 jake@^10.8.5:
   version "10.8.5"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
@@ -15355,14 +15342,6 @@ rustbn.js@~0.2.0:
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
-rx-queue@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/rx-queue/-/rx-queue-1.0.5.tgz#17711076923ec8d84f5bb76bc5e5d030ce797c0a"
-  integrity sha512-upDUgE3pk1+JnyV9MBkVSSlpSIg33ygqXvczsQIMVyjubLWCX/QzoFNfQavEHxYxKw+9JNMqDTPnxZ3dnR+61g==
-  dependencies:
-    ix "^4.5.2"
-    rxjs "^7.5.5"
-
 rxjs@^5.5.2:
   version "5.5.12"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
@@ -16887,7 +16866,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
On very high load we were "losing state entries/events" somewhere on the way from the sync worker to the main thread. This PR adds an "ack" event sent from the main thread to the sync worker when the main thread is done processing state updates from the sync worker to avoid blocking the main thread with too many state updates at once. This has the positive side effect that we don't have to throttle event processing on the main thread with a fixed number anymore, but events are always processed at the maximum speed the main thread is capable of.