### PR TITLE
feat(network): allow calling systems by hashed id

### DIFF
--- a/packages/network/src/createSystemExecutor.ts
+++ b/packages/network/src/createSystemExecutor.ts
@@ -6,6 +6,7 @@ import { observable, runInAction } from "mobx";
 import { createTxQueue } from "./createTxQueue";
 import { Network } from "./createNetwork";
 import { BehaviorSubject } from "rxjs";
+import { TxQueue } from "./types";
 
 /**
  * Create a system executor object.
@@ -37,7 +38,8 @@ export function createSystemExecutor<T extends { [key: string]: Contract }>(
   for (const systemEntity of getComponentEntities(systems)) {
     const system = createSystemContract(systemEntity, network.signer.get());
     if (!system) continue;
-    initialContracts[system.id as keyof T] = system.contract as T[keyof T];
+    if (system.id) initialContracts[system.id as keyof T] = system.contract as T[keyof T];
+    initialContracts[system.hashedId as keyof T] = system.contract as T[keyof T];
   }
   runInAction(() => systemContracts.set(initialContracts));
 
@@ -46,27 +48,27 @@ export function createSystemExecutor<T extends { [key: string]: Contract }>(
     if (!update.value[0]) return;
     const system = createSystemContract(update.entity, network.signer.get());
     if (!system) return;
-    runInAction(() => systemContracts.set({ ...systemContracts.get(), [system.id]: system.contract }));
+    runInAction(() => {
+      if (system.id) systemContracts.set({ ...systemContracts.get(), [system.id]: system.contract });
+      systemContracts.set({ ...systemContracts.get(), [system.hashedId]: system.contract });
+    });
   });
 
   const { txQueue, dispose } = createTxQueue<T>(systemContracts, network, gasPrice$, options);
   world.registerDisposer(dispose);
 
-  return txQueue;
+  return { systems: txQueue, untypedSystems: txQueue as TxQueue<{ [key: string]: Contract }> };
 
   function createSystemContract<C extends Contract>(
     entity: EntityIndex,
     signerOrProvider?: Signer | Provider
-  ): { id: string; contract: C } | undefined {
-    const { value: hashedSystemId } = getComponentValue(systems, entity) || {};
-    if (!hashedSystemId) throw new Error("System entity not found");
-    const id = systemIdPreimages[hashedSystemId];
-    if (!id) {
-      console.warn("Unknown system:", hashedSystemId);
-      return;
-    }
+  ): { id: string | undefined; hashedId: string; contract: C } | undefined {
+    const { value: hashedId } = getComponentValue(systems, entity) || {};
+    if (!hashedId) throw new Error("System entity not found");
+    const id = systemIdPreimages[hashedId];
     return {
       id,
+      hashedId,
       contract: new Contract(toEthAddress(world.entities[entity]), interfaces[id], signerOrProvider) as C,
     };
   }

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -108,9 +108,16 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
   });
   world.registerDisposer(disposeTxQueue);
 
-  const systems = createSystemExecutor<SystemTypes>(world, network, SystemsRegistry, SystemAbis, gasPriceInput$, {
-    devMode: networkConfig.devMode,
-  });
+  const { systems, untypedSystems } = createSystemExecutor<SystemTypes>(
+    world,
+    network,
+    SystemsRegistry,
+    SystemAbis,
+    gasPriceInput$,
+    {
+      devMode: networkConfig.devMode,
+    }
+  );
 
   // Create sync worker
   const ack$ = new Subject<Ack>();
@@ -141,6 +148,7 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
     network,
     startSync,
     systems,
+    untypedSystems,
     gasPriceInput$,
     ecsEvent$: ecsEvents$.pipe(concatMap((updates) => from(updates))),
     mappings,


### PR DESCRIPTION
Before systems not included in the complied systems types were ignored by the client. This made it hard to dynamically call systems in the client that were deployed after the main client was deployed.

This PR changes the client logic to create an ethers `Contract` object for every system added to the world systems registry. If no id preimage is available on the client, the contract can be called via it's hashed id.

Example:

If system is known in advance, it's can be called via its id preimage and types:
```
systems["system.Move"].executeTyped(coord);
```

If a system is not known in advance, it can still be called via its hashed id (untyped):

```
untypedSystems[keccak256("system.Move")].executeTyped(coord);
```