### PR TITLE
feat(network): expose method to register new system contracts on the client

### DIFF
--- a/packages/network/src/createSystemExecutor.ts
+++ b/packages/network/src/createSystemExecutor.ts
@@ -6,7 +6,6 @@ import { observable, runInAction } from "mobx";
 import { createTxQueue } from "./createTxQueue";
 import { Network } from "./createNetwork";
 import { BehaviorSubject } from "rxjs";
-import { TxQueue } from "./types";
 
 /**
  * Create a system executor object.
@@ -38,8 +37,7 @@ export function createSystemExecutor<T extends { [key: string]: Contract }>(
   for (const systemEntity of getComponentEntities(systems)) {
     const system = createSystemContract(systemEntity, network.signer.get());
     if (!system) continue;
-    if (system.id) initialContracts[system.id as keyof T] = system.contract as T[keyof T];
-    initialContracts[system.hashedId as keyof T] = system.contract as T[keyof T];
+    initialContracts[system.id as keyof T] = system.contract as T[keyof T];
   }
   runInAction(() => systemContracts.set(initialContracts));
 
@@ -48,27 +46,27 @@ export function createSystemExecutor<T extends { [key: string]: Contract }>(
     if (!update.value[0]) return;
     const system = createSystemContract(update.entity, network.signer.get());
     if (!system) return;
-    runInAction(() => {
-      if (system.id) systemContracts.set({ ...systemContracts.get(), [system.id]: system.contract });
-      systemContracts.set({ ...systemContracts.get(), [system.hashedId]: system.contract });
-    });
+    runInAction(() => systemContracts.set({ ...systemContracts.get(), [system.id]: system.contract }));
   });
 
   const { txQueue, dispose } = createTxQueue<T>(systemContracts, network, gasPrice$, options);
   world.registerDisposer(dispose);
 
-  return { systems: txQueue, untypedSystems: txQueue as TxQueue<{ [key: string]: Contract }> };
+  return txQueue;
 
   function createSystemContract<C extends Contract>(
     entity: EntityIndex,
     signerOrProvider?: Signer | Provider
-  ): { id: string | undefined; hashedId: string; contract: C } | undefined {
-    const { value: hashedId } = getComponentValue(systems, entity) || {};
-    if (!hashedId) throw new Error("System entity not found");
-    const id = systemIdPreimages[hashedId];
+  ): { id: string; contract: C } | undefined {
+    const { value: hashedSystemId } = getComponentValue(systems, entity) || {};
+    if (!hashedSystemId) throw new Error("System entity not found");
+    const id = systemIdPreimages[hashedSystemId];
+    if (!id) {
+      console.warn("Unknown system:", hashedSystemId);
+      return;
+    }
     return {
       id,
-      hashedId,
       contract: new Contract(toEthAddress(world.entities[entity]), interfaces[id], signerOrProvider) as C,
     };
   }

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -108,16 +108,9 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
   });
   world.registerDisposer(disposeTxQueue);
 
-  const { systems, untypedSystems } = createSystemExecutor<SystemTypes>(
-    world,
-    network,
-    SystemsRegistry,
-    SystemAbis,
-    gasPriceInput$,
-    {
-      devMode: networkConfig.devMode,
-    }
-  );
+  const systems = createSystemExecutor<SystemTypes>(world, network, SystemsRegistry, SystemAbis, gasPriceInput$, {
+    devMode: networkConfig.devMode,
+  });
 
   // Create sync worker
   const ack$ = new Subject<Ack>();
@@ -148,7 +141,6 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
     network,
     startSync,
     systems,
-    untypedSystems,
     gasPriceInput$,
     ecsEvent$: ecsEvents$.pipe(concatMap((updates) => from(updates))),
     mappings,

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -108,9 +108,16 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
   });
   world.registerDisposer(disposeTxQueue);
 
-  const systems = createSystemExecutor<SystemTypes>(world, network, SystemsRegistry, SystemAbis, gasPriceInput$, {
-    devMode: networkConfig.devMode,
-  });
+  const { systems, registerSystem } = createSystemExecutor<SystemTypes>(
+    world,
+    network,
+    SystemsRegistry,
+    SystemAbis,
+    gasPriceInput$,
+    {
+      devMode: networkConfig.devMode,
+    }
+  );
 
   // Create sync worker
   const ack$ = new Subject<Ack>();
@@ -145,6 +152,7 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
     ecsEvent$: ecsEvents$.pipe(concatMap((updates) => from(updates))),
     mappings,
     registerComponent,
+    registerSystem,
   };
 }
 


### PR DESCRIPTION
- expose `registerSystem` function to register new system contracts in the client after the client has been deployed (ie in plugins)