### PR TITLE
refactor(ecs-browser): removing phaserx deps from ecs-browser

### DIFF
--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -50,7 +50,6 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@latticexyz/phaserx": "^1",
     "@latticexyz/recs": "^1",
     "@latticexyz/std-client": "^1",
     "@latticexyz/utils": "^1",

--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -20,7 +20,6 @@
     "release": "npm publish || echo 'version already published'"
   },
   "devDependencies": {
-    "@latticexyz/phaserx": "^1.24.1",
     "@latticexyz/recs": "^1.24.1",
     "@latticexyz/std-client": "^1.24.1",
     "@latticexyz/utils": "^1.24.1",

--- a/packages/ecs-browser/src/Browser.tsx
+++ b/packages/ecs-browser/src/Browser.tsx
@@ -7,7 +7,7 @@ import { QueryBuilder } from "./QueryBuilder";
 import { useClearDevHighlights } from "./hooks";
 import { observer } from "mobx-react-lite";
 import { PrototypeCreator } from "./PrototypeCreator";
-import { Coord } from "@latticexyz/phaserx";
+import { Coord } from "./shared";
 
 /**
  * An Entity Browser for viewing/editiing Component values.

--- a/packages/ecs-browser/src/PrototypeCreator/PrototypeCreator.tsx
+++ b/packages/ecs-browser/src/PrototypeCreator/PrototypeCreator.tsx
@@ -1,7 +1,7 @@
 import { Component, EntityID, getComponentValue, Has, Layers, Type } from "@latticexyz/recs";
 import React, { useEffect, useState } from "react";
 import { ComponentBrowserButton, ComponentBrowserSelect } from "../StyledComponents";
-import { Coord } from "@latticexyz/phaserx";
+import { Coord } from "../shared";
 import { useComponentValueStream, useQuery } from "@latticexyz/std-client";
 
 export const PrototypeCreator: React.FC<{

--- a/packages/ecs-browser/src/QueryBuilder/PositionFilterButton.tsx
+++ b/packages/ecs-browser/src/QueryBuilder/PositionFilterButton.tsx
@@ -1,7 +1,7 @@
 import { Component, Type } from "@latticexyz/recs";
 import React, { useEffect, useState } from "react";
 import { ComponentBrowserButton } from "../StyledComponents";
-import { pixelCoordToTileCoord } from "@latticexyz/phaserx";
+import { pixelCoordToTileCoord } from "../shared";
 
 export const PositionFilterButton: React.FC<{
   editQuery: (queryText: string) => void;

--- a/packages/ecs-browser/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/ecs-browser/src/QueryBuilder/QueryBuilder.tsx
@@ -204,10 +204,12 @@ export const QueryBuilder = ({
           queryInputRef={queryInputRef}
           input={(layers.phaser as any)?.scenes.Main.phaserScene.input}
         />
-        <ComponentBrowserButton onClick={() => {
-          queryInputRef.current?.focus();
-          editQuery('[Has(Selected)]');
-        }}>
+        <ComponentBrowserButton
+          onClick={() => {
+            queryInputRef.current?.focus();
+            editQuery("[Has(Selected)]");
+          }}
+        >
           View Selected Entity
         </ComponentBrowserButton>
         <h3>Filter by Component</h3>

--- a/packages/ecs-browser/src/shared.ts
+++ b/packages/ecs-browser/src/shared.ts
@@ -1,0 +1,22 @@
+/**
+ * @see phaserx src/types
+ */
+
+export type Coord = {
+  x: number;
+  y: number;
+};
+
+type PixelCoord = Coord;
+type WorldCoord = Coord;
+
+/**
+ * @see phaserx src/coords
+ */
+
+export function pixelCoordToTileCoord(pixelCoord: PixelCoord, tileWidth: number, tileHeight: number): WorldCoord {
+  return {
+    x: Math.floor(pixelCoord.x / tileWidth),
+    y: Math.floor(pixelCoord.y / tileHeight),
+  };
+}


### PR DESCRIPTION
Removing the shared files from phaserx with locally shared functions inside of the ecs-browser
package inside of shared.ts

fix #231
