### PR TITLE
refactor: remove need for specifying phaserSelector in createCamera

### DIFF
--- a/packages/phaserx/src/createCamera.ts
+++ b/packages/phaserx/src/createCamera.ts
@@ -5,11 +5,8 @@ import { tileCoordToPixelCoord } from "./utils";
 import { Camera, CameraConfig, Coord, GestureState, ObjectPool } from "./types";
 
 export function createCamera(phaserCamera: Phaser.Cameras.Scene2D.Camera, options: CameraConfig): Camera {
-  const phaserGame = document.getElementById(options.phaserSelector);
-  if (!phaserGame) {
-    throw new Error("Could not connect camera input. No element with id " + options.phaserSelector);
-  }
-
+  // Stop default gesture events to not collide with use-gesture
+  // https://github.com/pmndrs/use-gesture/blob/404e2b2ac145a45aff179c1faf5097b97414731c/documentation/pages/docs/gestures.mdx#about-the-pinch-gesture
   document.addEventListener("gesturestart", (e) => e.preventDefault());
   document.addEventListener("gesturechange", (e) => e.preventDefault());
 
@@ -19,7 +16,7 @@ export function createCamera(phaserCamera: Phaser.Cameras.Scene2D.Camera, option
   const pinchStream$ = new Subject<GestureState<"onPinch">>();
 
   const gesture = new Gesture(
-    phaserGame,
+    phaserCamera.scene.game.canvas,
     {
       onPinch: (state: any) => pinchStream$.next(state),
       onWheel: (state: any) => wheelStream$.next(state),

--- a/packages/phaserx/src/types.ts
+++ b/packages/phaserx/src/types.ts
@@ -198,7 +198,6 @@ export type Asset =
     };
 
 export type CameraConfig = {
-  phaserSelector: string;
   pinchSpeed: number;
   wheelSpeed: number;
   minZoom: number;


### PR DESCRIPTION
We don't need to require a `phaserSelector`, since we already have access to the `canvas` element, which is a more accurate representation of game boundaries anyway.

Also adds a comment so we remember why we're disabling default gesture events.