### PR TITLE
feat(solecs): add util to split up bitpacked data

### DIFF
--- a/packages/solecs/src/test/utils.t.sol
+++ b/packages/solecs/src/test/utils.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+
+import { split } from "../utils.sol";
+
+contract UtilsTest is DSTestPlus {
+  function testSplit() public {
+    uint32 first = 1;
+    uint64 second = 2;
+
+    // Pack data
+    bytes memory packed = bytes.concat(bytes4(first), bytes8(second));
+
+    // Unpack data
+    uint8[] memory lengths = new uint8[](2);
+    lengths[0] = 4;
+    lengths[1] = 8;
+    bytes[] memory unpacked = split(packed, lengths);
+
+    assertEq(uint32(bytes4(unpacked[0])), first);
+    assertEq(uint64(bytes8(unpacked[1])), second);
+  }
+}

--- a/packages/solecs/src/test/utils.t.sol
+++ b/packages/solecs/src/test/utils.t.sol
@@ -2,9 +2,6 @@
 pragma solidity >=0.8.0;
 
 import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
-import { Vm } from "forge-std/Vm.sol";
-import { console } from "forge-std/console.sol";
-
 import { split } from "../utils.sol";
 
 contract UtilsTest is DSTestPlus {

--- a/packages/solecs/src/utils.sol
+++ b/packages/solecs/src/utils.sol
@@ -55,12 +55,18 @@ function getSystemById(IUint256Component components, uint256 id) view returns (I
 function split(bytes memory data, uint8[] memory lengths) pure returns (bytes[] memory) {
   bytes[] memory unpacked = new bytes[](lengths.length);
   uint256 sum = 0;
-  for (uint256 i = 0; i < lengths.length; i++) {
+  for (uint256 i = 0; i < lengths.length; ) {
     unpacked[i] = new bytes(lengths[i]);
-    for (uint256 j = 0; j < lengths[i]; j++) {
-      unpacked[i][j] = data[sum + j];
+    for (uint256 j = 0; j < lengths[i]; ) {
+      unchecked {
+        unpacked[i][j] = data[sum + j];
+        j += 1;
+      }
     }
-    sum += lengths[i];
+    unchecked {
+      sum += lengths[i];
+      i += 1;
+    }
   }
   return unpacked;
 }

--- a/packages/solecs/src/utils.sol
+++ b/packages/solecs/src/utils.sol
@@ -50,3 +50,17 @@ function getSystemAddressById(IUint256Component components, uint256 id) view ret
 function getSystemById(IUint256Component components, uint256 id) view returns (ISystem) {
   return ISystem(getSystemAddressById(components, id));
 }
+
+/** Split a single bytes blob into an array of bytes of the given length */
+function split(bytes memory data, uint8[] memory lengths) pure returns (bytes[] memory) {
+  bytes[] memory unpacked = new bytes[](lengths.length);
+  uint256 sum = 0;
+  for (uint256 i = 0; i < lengths.length; i++) {
+    unpacked[i] = new bytes(lengths[i]);
+    for (uint256 j = 0; j < lengths[i]; j++) {
+      unpacked[i][j] = data[sum + j];
+    }
+    sum += lengths[i];
+  }
+  return unpacked;
+}


### PR DESCRIPTION
- Add a util to make splitting up bitpacked data easier
- Context: we currently use abi.encode in default components to encode/decode structs to store them in components, but abi.encode pads every struct entry to 32 bytes, wasting a lot of gas on storage, so we should change it to tighter bitpacking