### PR TITLE
feat(solecs): storage access utility

### DIFF
--- a/packages/solecs/src/LibStorage.sol
+++ b/packages/solecs/src/LibStorage.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IUint256Component } from "./interfaces/IUint256Component.sol";
+import { IWorld } from "./interfaces/IWorld.sol";
+import { getSystemAddressById, getAddressById } from "./utils.sol";
+
+/**
+  This library provides a utility to access the addresses of the components registry
+  and the world directly. 
+
+  It relies on the invariant that the base System class declares components as the first state variable
+  and the world as the second one.
+
+  This enables a direct storage read based on the layout of storage in Solidity
+  https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html#layout-of-state-variables-in-storage
+
+  DO NOT change the order of the base System variables.
+  DO NOT add a variable before the components and world in the base System.
+ */
+
+library LibStorage {
+  function c() internal view returns (IUint256Component components) {
+    assembly {
+      components := sload(0)
+    }
+  }
+
+  function w() internal view returns (IWorld world) {
+    assembly {
+      world := sload(1)
+    }
+  }
+
+  function sys(uint256 systemID) internal view returns (address) {
+    return getSystemAddressById(c(), systemID);
+  }
+
+  function comp(uint256 componentID) internal view returns (address) {
+    return getAddressById(c(), componentID);
+  }
+}


### PR DESCRIPTION
Based on the assumption that `System` contracts in MUD have `IUint256Component components` and `IWorld world` as the first two state variables, we can fetch their addresses directly from storage using assembly `sload`.

As long as this variable invariant holds, as documented [here](https://github.com/latticexyz/mud/blob/927dbc584254031ea563b2c7c9d5441e78468c15/packages/solecs/src/LibStorage.sol#L18), a nice pattern is now possible:

Previously in MUD, any `Library` that wants to read or write from a component needs to be passed the address of the components registry:
```solidity
  function isAdmin(IUint256Component components, address sender) internal view returns (bool) {
    AdminComponent adminComponent = AdminComponent(getAddressById(components, AdminComponentID));
    ...
  }
```

Furthermore, it is tedious from a developer experience to have to call `getAddressById(components, ...)` every time a component needs to be loaded.

Using LibStorage, MUD Libraries and Systems can now do the following:
```solidity
import {LibStorage} from "solecs/LibStorage.sol";
import { AdminComponent , ID as AdminComponentID } from "../components/AdminComponent.sol";

library  LibAdmin {
  function isAdmin(address sender) internal view returns (bool) {
    AdminComponent adminComponent = AdminComponent(LibStorage.comp(AdminComponentID));
    ...
  }
}

```

This is possible because _the library knows the location of the components' address by doing a direct storage read instead of getting passed that address_.

You can reduce boilerplate code even further with two tricks:

1. Alias `LibStorage` to something shorter:
```solidity
import {LibStorage as s} from "solecs/LibStorage.sol";

library  LibAdmin {
  function isAdmin(address sender) internal view returns (bool) {
    AdminComponent adminComponent = AdminComponent(s.comp(AdminComponentID));
    ...
  }
}
```
2. Use a more succinct naming scheme for components:
```solidity
import {LibStorage as s} from "solecs/LibStorage.sol";
import { AdminComponent as Admin , ID as AdminID } from "../components/AdminComponent.sol";

library  LibAdmin {
  function isAdmin(address sender) internal view returns (bool) {
    Admin admin = Admin(s.comp(AdminID));
    ...
  }
}
```

**Using these tricks, we get a `~54` char reduction in code everywhere we want to access a component.**

You can also store the component registry address at the start of a function and use the traditional method to access:

```solidity
import {LibStorage as s} from "solecs/LibStorage.sol";
import { AdminComponent as Admin , ID as AdminID } from "../components/AdminComponent.sol";

library  LibAdmin {
  function isAdmin(address sender) internal view returns (bool) {
    UInt256Components c = s.c();
    Admin admin = Admin(getAddressByID(c, AdminID));
    ...
  }
}
```