### PR TITLE
feat(network): add support for external wallets (eg MetaMask)

### DIFF
--- a/packages/network/src/createNetwork.ts
+++ b/packages/network/src/createNetwork.ts
@@ -38,10 +38,10 @@ export async function createNetwork(initialConfig: NetworkConfig) {
   // Get address
   const initialConnectedAddress = config.provider.externalProvider ? await signer.get()?.getAddress() : undefined;
   const connectedAddress = computed(() =>
-    config.privateKey ? new Wallet(config.privateKey).address.toLowerCase() : initialConnectedAddress
+    config.privateKey ? new Wallet(config.privateKey).address.toLowerCase() : initialConnectedAddress?.toLowerCase()
   );
   const connectedAddressChecksummed = computed(() =>
-    config.privateKey ? new Wallet(config.privateKey).address : undefined
+    config.privateKey ? new Wallet(config.privateKey).address : initialConnectedAddress
   );
 
   // Listen to new block numbers

--- a/packages/network/src/createNetwork.ts
+++ b/packages/network/src/createNetwork.ts
@@ -29,14 +29,16 @@ export async function createNetwork(initialConfig: NetworkConfig) {
 
   // Create signer
   const signer = computed<Signer | undefined>(() => {
-    const privateKey = config.privateKey;
     const currentProviders = providers.get();
+    if (config.provider.externalProvider) return currentProviders.json.getSigner();
+    const privateKey = config.privateKey;
     if (privateKey && currentProviders) return createSigner(privateKey, currentProviders);
   });
 
   // Get address
+  const initialConnectedAddress = config.provider.externalProvider ? await signer.get()?.getAddress() : undefined;
   const connectedAddress = computed(() =>
-    config.privateKey ? new Wallet(config.privateKey).address.toLowerCase() : undefined
+    config.privateKey ? new Wallet(config.privateKey).address.toLowerCase() : initialConnectedAddress
   );
   const connectedAddressChecksummed = computed(() =>
     config.privateKey ? new Wallet(config.privateKey).address : undefined

--- a/packages/network/src/createProvider.ts
+++ b/packages/network/src/createProvider.ts
@@ -1,4 +1,4 @@
-import { Networkish, WebSocketProvider } from "@ethersproject/providers";
+import { Networkish, Web3Provider, WebSocketProvider } from "@ethersproject/providers";
 import { callWithRetry, observableToComputed, timeoutAfter } from "@latticexyz/utils";
 import { IComputedValue, IObservableValue, observable, reaction, runInAction } from "mobx";
 import { ensureNetworkIsUp } from "./networkUtils";
@@ -16,17 +16,19 @@ export type Providers = ReturnType<typeof createProvider>;
  *   ws: WebSocketProvider
  * }
  */
-export function createProvider({ chainId, jsonRpcUrl, wsRpcUrl, options }: ProviderConfig) {
+export function createProvider({ chainId, jsonRpcUrl, wsRpcUrl, externalProvider, options }: ProviderConfig) {
   const network: Networkish = {
     chainId,
     name: "mudChain",
   };
-  const providers = {
-    json: options?.batch
-      ? new MUDJsonRpcBatchProvider(jsonRpcUrl, network)
-      : new MUDJsonRpcProvider(jsonRpcUrl, network),
-    ws: wsRpcUrl ? new WebSocketProvider(wsRpcUrl, network) : undefined,
-  };
+  const providers = externalProvider
+    ? { json: new Web3Provider(externalProvider, network), ws: undefined }
+    : {
+        json: options?.batch
+          ? new MUDJsonRpcBatchProvider(jsonRpcUrl, network)
+          : new MUDJsonRpcProvider(jsonRpcUrl, network),
+        ws: wsRpcUrl ? new WebSocketProvider(wsRpcUrl, network) : undefined,
+      };
 
   if (options?.pollingInterval) {
     providers.json.pollingInterval = options.pollingInterval;

--- a/packages/network/src/types.ts
+++ b/packages/network/src/types.ts
@@ -1,4 +1,5 @@
 import { Result } from "@ethersproject/abi";
+import { ExternalProvider } from "@ethersproject/providers";
 import { Components, ComponentValue, EntityID, SchemaOf } from "@latticexyz/recs";
 import { TxMetadata } from "@latticexyz/services/protobuf/ts/ecs-stream/ecs-stream";
 import { Cached } from "@latticexyz/utils";
@@ -39,6 +40,7 @@ export interface ProviderConfig {
   chainId: number;
   jsonRpcUrl: string;
   wsRpcUrl?: string;
+  externalProvider?: ExternalProvider;
   options?: { batch?: boolean; pollingInterval?: number; skipNetworkCheck?: boolean };
 }
 

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -101,13 +101,19 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
 
   // Create sync worker
   const ack$ = new Subject<Ack>();
+  // Avoid passing externalProvider to sync worker (too complex to copy)
+  const {
+    provider: { externalProvider: _, ...providerConfig },
+    ...syncWorkerConfig
+  } = networkConfig;
   const { ecsEvents$, input$, dispose } = createSyncWorker<C>(ack$);
   world.registerDisposer(dispose);
   function startSync() {
     input$.next({
       type: InputType.Config,
       data: {
-        ...networkConfig,
+        ...syncWorkerConfig,
+        provider: providerConfig,
         worldContract: contractsConfig.World,
         initialBlockNumber: networkConfig.initialBlockNumber ?? 0,
         disableCache: networkConfig.devMode, // Disable cache on local networks (hardhat / anvil)


### PR DESCRIPTION
Support for external wallets to mud. 
Allows users to pass in `externalProvider` (which is an ethers.js `ExternalProvider`) to the network config and then use the associated signer for txs.
