### PR TITLE
style(solecs): rename arguments to args

### DIFF
--- a/packages/solecs/src/interfaces/IPayableSystem.sol
+++ b/packages/solecs/src/interfaces/IPayableSystem.sol
@@ -6,5 +6,5 @@ import "./IOwned.sol";
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.
 interface IPayableSystem is IOwned {
-  function execute(bytes memory arguments) external payable returns (bytes memory);
+  function execute(bytes memory args) external payable returns (bytes memory);
 }

--- a/packages/solecs/src/interfaces/ISystem.sol
+++ b/packages/solecs/src/interfaces/ISystem.sol
@@ -6,5 +6,5 @@ import "./IOwned.sol";
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.
 interface ISystem is IOwned {
-  function execute(bytes memory arguments) external returns (bytes memory);
+  function execute(bytes memory args) external returns (bytes memory);
 }

--- a/packages/solecs/src/systems/RegisterSystem.sol
+++ b/packages/solecs/src/systems/RegisterSystem.sol
@@ -18,7 +18,7 @@ uint256 constant ID = uint256(keccak256("world.system.register"));
 contract RegisterSystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
-  function requirement(bytes memory arguments) public view returns (bytes memory) {
+  function requirement(bytes memory args) public view returns (bytes memory) {
     // TODO: Refactor to remove requirement/execute split
   }
 
@@ -31,9 +31,9 @@ contract RegisterSystem is System {
     return execute(abi.encode(msgSender, registerType, addr, id));
   }
 
-  function execute(bytes memory arguments) public returns (bytes memory) {
+  function execute(bytes memory args) public returns (bytes memory) {
     (address msgSender, RegisterType registerType, address addr, uint256 id) = abi.decode(
-      arguments,
+      args,
       (address, RegisterType, address, uint256)
     );
     require(msg.sender == address(world), "system can only be called via World");

--- a/packages/std-contracts/src/systems/BulkSetStateSystem.sol
+++ b/packages/std-contracts/src/systems/BulkSetStateSystem.sol
@@ -23,9 +23,9 @@ contract BulkSetStateSystem is System {
     // NOTE: Make sure to not include this system in a production deployment, as anyone can change all component values
   }
 
-  function execute(bytes memory arguments) public returns (bytes memory) {
+  function execute(bytes memory args) public returns (bytes memory) {
     (uint256[] memory componentIds, uint256[] memory entities, ECSEvent[] memory state) = abi.decode(
-      arguments,
+      args,
       (uint256[], uint256[], ECSEvent[])
     );
 

--- a/packages/std-contracts/src/systems/ComponentDevSystem.sol
+++ b/packages/std-contracts/src/systems/ComponentDevSystem.sol
@@ -15,8 +15,8 @@ contract ComponentDevSystem is System {
     // NOTE: Make sure to not include this system in a production deployment, as anyone can change all component values
   }
 
-  function execute(bytes memory arguments) public returns (bytes memory) {
-    (uint256 componentId, uint256 entity, bytes memory value) = abi.decode(arguments, (uint256, uint256, bytes));
+  function execute(bytes memory args) public returns (bytes memory) {
+    (uint256 componentId, uint256 entity, bytes memory value) = abi.decode(args, (uint256, uint256, bytes));
     IComponent c = IComponent(getAddressById(components, componentId));
     if (value.length == 0) {
       c.remove(entity);


### PR DESCRIPTION
This is changed as Typechain-exported Contracts do not like the variable name arguments as its a
reserved keyword in strict-mode Classes
