### PR TITLE
Add subsystem

### DIFF
--- a/packages/solecs/README.md
+++ b/packages/solecs/README.md
@@ -77,7 +77,7 @@ Everyone has read access.
 For convenience the component implementation in `solecs` also includes a reverse mapping from `keccak256(value)` to set of entities with this value, but this is not strictly required and might change in a future release.
 
 ```solidity
-interface IComponent is IERC173 {
+interface IComponent is IOwnableWritable {
   /** Return the keys and value types of the schema of this component. */
   function getSchema() external pure returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
 
@@ -94,10 +94,6 @@ interface IComponent is IERC173 {
   function getEntitiesWithValue(bytes memory value) external view returns (uint256[] memory);
 
   function registerIndexer(address indexer) external;
-
-  function authorizeWriter(address writer) external;
-
-  function unauthorizeWriter(address writer) external;
 }
 
 ```

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@rari-capital/solmate": "https://github.com/Rari-Capital/solmate.git#b6ae78e6ff490f8fec7695c7b65d06e5614f1b65",
+    "@solidstate/contracts": "^0.0.48",
     "@typechain/ethers-v5": "^9.0.0",
     "@types/mocha": "^9.1.1",
     "ds-test": "https://github.com/dapphub/ds-test.git#c7a36fb236f298e04edf28e2fee385b80f53945f",

--- a/packages/solecs/remappings.txt
+++ b/packages/solecs/remappings.txt
@@ -2,3 +2,4 @@ memmove/=../../node_modules/memmove/src/
 ds-test/=../../node_modules/ds-test/src/
 forge-std/=../../node_modules/forge-std/src/
 solmate/=../../node_modules/@rari-capital/solmate/src
+@solidstate/=../../node_modules/@solidstate/

--- a/packages/solecs/src/BareComponent.sol
+++ b/packages/solecs/src/BareComponent.sol
@@ -8,6 +8,8 @@ import { Set } from "./Set.sol";
 import { MapSet } from "./MapSet.sol";
 import { LibTypes } from "./LibTypes.sol";
 
+import { OwnableWritable } from "./OwnableWritable.sol";
+
 /**
  * Components are a key-value store from entity id to component value.
  * They are registered in the World and register updates to their state in the World.
@@ -15,17 +17,11 @@ import { LibTypes } from "./LibTypes.sol";
  * (Systems that want to write to a component need to be given write access first.)
  * Everyone has read access.
  */
-abstract contract BareComponent is IComponent {
+abstract contract BareComponent is IComponent, OwnableWritable {
   error BareComponent__NotImplemented();
 
   /** Reference to the World contract this component is registered in */
   address public world;
-
-  /** Owner of the component has write access and can given write access to other addresses */
-  address internal _owner;
-
-  /** Addresses with write access to this component */
-  mapping(address => bool) public writeAccess;
 
   /** Mapping from entity id to value in this component */
   mapping(uint256 => bytes) internal entityToValue;
@@ -34,39 +30,8 @@ abstract contract BareComponent is IComponent {
   uint256 public id;
 
   constructor(address _world, uint256 _id) {
-    _owner = msg.sender;
-    writeAccess[msg.sender] = true;
     id = _id;
     if (_world != address(0)) registerWorld(_world);
-  }
-
-  /** Revert if caller is not the owner of this component */
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
-
-  /** Revert if caller does not have write access to this component */
-  modifier onlyWriter() {
-    require(writeAccess[msg.sender], "ONLY_WRITER");
-    _;
-  }
-
-  /** Get the owner of this component */
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  /**
-   * Transfer ownership of this component to a new owner.
-   * Can only be called by the current owner.
-   * @param newOwner Address of the new owner.
-   */
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    writeAccess[msg.sender] = false;
-    _owner = newOwner;
-    writeAccess[newOwner] = true;
   }
 
   /**
@@ -129,24 +94,6 @@ abstract contract BareComponent is IComponent {
   /** Not implemented in BareComponent */
   function registerIndexer(address) external virtual override {
     revert BareComponent__NotImplemented();
-  }
-
-  /**
-   * Grant write access to this component to the given address.
-   * Can only be called by the owner of this component.
-   * @param writer Address to grant write access to.
-   */
-  function authorizeWriter(address writer) public override onlyOwner {
-    writeAccess[writer] = true;
-  }
-
-  /**
-   * Revoke write access to this component to the given address.
-   * Can only be called by the owner of this component.
-   * @param writer Address to revoke write access .
-   */
-  function unauthorizeWriter(address writer) public override onlyOwner {
-    delete writeAccess[writer];
   }
 
   /**

--- a/packages/solecs/src/LibQuery.sol
+++ b/packages/solecs/src/LibQuery.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
+
 import { IComponent } from "./interfaces/IComponent.sol";
 import { QueryFragment, QueryType } from "./interfaces/Query.sol";
-import "memmove/LinkedList.sol";
+import { LinkedList, LinkedListLib } from "memmove/LinkedList.sol";
 
 struct Uint256Node {
   uint256 value;

--- a/packages/solecs/src/MapSet.sol
+++ b/packages/solecs/src/MapSet.sol
@@ -1,22 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * Key value store with uint256 key and uint256 Set value
  */
-contract MapSet {
-  address private owner;
+contract MapSet is Ownable {
   mapping(uint256 => uint256[]) internal items;
   mapping(uint256 => mapping(uint256 => uint256)) internal itemToIndex;
-
-  constructor() {
-    owner = msg.sender;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "ONLY_OWNER");
-    _;
-  }
 
   function add(uint256 setKey, uint256 item) public onlyOwner {
     if (has(setKey, item)) return;

--- a/packages/solecs/src/Ownable.sol
+++ b/packages/solecs/src/Ownable.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { Ownable as SolidStateOwnable } from "@solidstate/contracts/access/ownable/Ownable.sol";
+import { OwnableStorage } from "@solidstate/contracts/access/ownable/OwnableStorage.sol";
+
+/**
+ * IERC173 implementation
+ */
+contract Ownable is SolidStateOwnable {
+  using OwnableStorage for OwnableStorage.Layout;
+
+  constructor() {
+    // Initialize owner (SolidState has no constructors)
+    OwnableStorage.layout().setOwner(msg.sender);
+  }
+}

--- a/packages/solecs/src/OwnableWritable.sol
+++ b/packages/solecs/src/OwnableWritable.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IOwnableWritable } from "./interfaces/IOwnableWritable.sol";
+
+import { Ownable } from "./Ownable.sol";
+import { OwnableWritableStorage } from "./OwnableWritableStorage.sol";
+
+/**
+ * Ownable with authorized writers
+ */
+abstract contract OwnableWritable is IOwnableWritable, Ownable {
+  error OwnableWritable__NotWriter();
+
+  /** Whether given operator has write access */
+  function writeAccess(address operator) public view returns (bool) {
+    return OwnableWritableStorage.layout().writeAccess[operator] || operator == owner();
+  }
+
+  /** Revert if caller does not have write access to this component */
+  modifier onlyWriter() {
+    if (!writeAccess(msg.sender)) {
+      revert OwnableWritable__NotWriter();
+    }
+    _;
+  }
+
+  /**
+   * Grant write access to the given address.
+   * Can only be called by the owner.
+   * @param writer Address to grant write access to.
+   */
+  function authorizeWriter(address writer) public onlyOwner {
+    OwnableWritableStorage.layout().writeAccess[writer] = true;
+  }
+
+  /**
+   * Revoke write access from the given address.
+   * Can only be called by the owner.
+   * @param writer Address to revoke write access.
+   */
+  function unauthorizeWriter(address writer) public onlyOwner {
+    delete OwnableWritableStorage.layout().writeAccess[writer];
+  }
+}

--- a/packages/solecs/src/OwnableWritableStorage.sol
+++ b/packages/solecs/src/OwnableWritableStorage.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+library OwnableWritableStorage {
+  struct Layout {
+    /** Addresses with write access */
+    mapping(address => bool) writeAccess;
+  }
+
+  bytes32 internal constant STORAGE_SLOT = keccak256("solecs.contracts.storage.OwnableWritable");
+
+  function layout() internal pure returns (Layout storage l) {
+    bytes32 slot = STORAGE_SLOT;
+    assembly {
+      l.slot := slot
+    }
+  }
+}

--- a/packages/solecs/src/PayableSystem.sol
+++ b/packages/solecs/src/PayableSystem.sol
@@ -5,31 +5,17 @@ import { IPayableSystem } from "./interfaces/IPayableSystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { IWorld } from "./interfaces/IWorld.sol";
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * System base contract
  */
-abstract contract PayableSystem is IPayableSystem {
+abstract contract PayableSystem is IPayableSystem, Ownable {
   IUint256Component components;
   IWorld world;
-  address _owner;
-
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
 
   constructor(IWorld _world, address _components) {
-    _owner = msg.sender;
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
-  }
-
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    _owner = newOwner;
   }
 }

--- a/packages/solecs/src/Set.sol
+++ b/packages/solecs/src/Set.sol
@@ -1,22 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * Set of unique uint256
  */
-contract Set {
-  address private owner;
+contract Set is Ownable {
   uint256[] internal items;
   mapping(uint256 => uint256) internal itemToIndex;
-
-  constructor() {
-    owner = msg.sender;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "ONLY_OWNER");
-    _;
-  }
 
   function add(uint256 item) public onlyOwner {
     if (has(item)) return;

--- a/packages/solecs/src/Subsystem.sol
+++ b/packages/solecs/src/Subsystem.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IWorld } from "./interfaces/IWorld.sol";
+import { System } from "./System.sol";
+
+import { OwnableWritable } from "./OwnableWritable.sol";
+
+/**
+ * Subsystem base contract
+ */
+abstract contract Subsystem is System, OwnableWritable {
+  constructor(IWorld _world, address _components) System(_world, _components) {}
+
+  /** Subsystems have predefined access control for execute */
+  function execute(bytes memory args) public override onlyWriter returns (bytes memory) {
+    return _execute(args);
+  }
+
+  /** Override _execute rather than execute */
+  function _execute(bytes memory args) internal virtual returns (bytes memory);
+}

--- a/packages/solecs/src/System.sol
+++ b/packages/solecs/src/System.sol
@@ -5,31 +5,17 @@ import { ISystem } from "./interfaces/ISystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { IWorld } from "./interfaces/IWorld.sol";
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * System base contract
  */
-abstract contract System is ISystem {
+abstract contract System is ISystem, Ownable {
   IUint256Component components;
   IWorld world;
-  address _owner;
-
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
 
   constructor(IWorld _world, address _components) {
-    _owner = msg.sender;
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
-  }
-
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    _owner = newOwner;
   }
 }

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Set } from "./Set.sol";
 import { LibQuery } from "./LibQuery.sol";
 import { IWorld, WorldQueryFragment } from "./interfaces/IWorld.sol";

--- a/packages/solecs/src/components/Uint256Component.sol
+++ b/packages/solecs/src/components/Uint256Component.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
-import "../Component.sol";
-import "../interfaces/IUint256Component.sol";
+
+import { Component } from "../Component.sol";
+import { LibTypes } from "../LibTypes.sol";
+import { IUint256Component } from "../interfaces/IUint256Component.sol";
 
 /**
  * Reference implementation of a component storing a uint256 value for each entity.

--- a/packages/solecs/src/interfaces/IComponent.sol
+++ b/packages/solecs/src/interfaces/IComponent.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { IERC173 } from "./IERC173.sol";
+import { IOwnableWritable } from "./IOwnableWritable.sol";
 import { LibTypes } from "../LibTypes.sol";
 
-interface IComponent is IERC173 {
+interface IComponent is IOwnableWritable {
   /** Return the keys and value types of the schema of this component. */
   function getSchema() external pure returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
 
@@ -21,10 +21,6 @@ interface IComponent is IERC173 {
   function getEntitiesWithValue(bytes memory value) external view returns (uint256[] memory);
 
   function registerIndexer(address indexer) external;
-
-  function authorizeWriter(address writer) external;
-
-  function unauthorizeWriter(address writer) external;
 
   function world() external view returns (address);
 }

--- a/packages/solecs/src/interfaces/IERC165.sol
+++ b/packages/solecs/src/interfaces/IERC165.sol
@@ -1,12 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IERC165 {
-  /// @notice Query if a contract implements an interface
-  /// @param interfaceId The interface identifier, as specified in ERC-165
-  /// @dev Interface identification is specified in ERC-165. This function
-  ///  uses less than 30,000 gas.
-  /// @return `true` if the contract implements `interfaceID` and
-  ///  `interfaceID` is not 0xffffffff, `false` otherwise
-  function supportsInterface(bytes4 interfaceId) external view returns (bool);
-}
+import { IERC165 } from "@solidstate/contracts/interfaces/IERC165.sol";

--- a/packages/solecs/src/interfaces/IERC173.sol
+++ b/packages/solecs/src/interfaces/IERC173.sol
@@ -1,24 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-/**
- * @title ERC-173 Contract ownership standard
- * @dev see https://eips.ethereum.org/EIPS/eip-173
- */
-interface IERC173 {
-  /** @dev This emits when ownership of a contract changes. */
-  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
-  /**
-   * @notice Get the address of the owner
-   * @return The address of the owner.
-   */
-  function owner() external view returns (address);
-
-  /**
-   * @notice Set the address of the new owner of the contract
-   * @dev Set _newOwner to address(0) to renounce any ownership.
-   * @param _newOwner The address of the new owner of the contract
-   */
-  function transferOwnership(address _newOwner) external;
-}
+import { IERC173 } from "@solidstate/contracts/interfaces/IERC173.sol";

--- a/packages/solecs/src/interfaces/IOwnableWritable.sol
+++ b/packages/solecs/src/interfaces/IOwnableWritable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IERC173 } from "./IERC173.sol";
+
+interface IOwnableWritable is IERC173 {
+  function authorizeWriter(address writer) external;
+
+  function unauthorizeWriter(address writer) external;
+}

--- a/packages/solecs/src/interfaces/IPayableSystem.sol
+++ b/packages/solecs/src/interfaces/IPayableSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "./IERC173.sol";
+import { IERC173 } from "./IERC173.sol";
 
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.

--- a/packages/solecs/src/interfaces/ISystem.sol
+++ b/packages/solecs/src/interfaces/ISystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "./IERC173.sol";
+import { IERC173 } from "./IERC173.sol";
 
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.

--- a/packages/solecs/src/interfaces/IWorld.sol
+++ b/packages/solecs/src/interfaces/IWorld.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { QueryType } from "./Query.sol";
 import { IUint256Component } from "./IUint256Component.sol";
 

--- a/packages/solecs/src/interfaces/Query.sol
+++ b/packages/solecs/src/interfaces/Query.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
+
 import { IComponent } from "./IComponent.sol";
 import { LinkedList } from "memmove/LinkedList.sol";
 

--- a/packages/solecs/src/systems/RegisterSystem.sol
+++ b/packages/solecs/src/systems/RegisterSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { ISystem } from "../interfaces/ISystem.sol";
 import { IWorld } from "../interfaces/IWorld.sol";
 import { IERC173 } from "../interfaces/IERC173.sol";

--- a/packages/solecs/src/test/OwnableWritable.t.sol
+++ b/packages/solecs/src/test/OwnableWritable.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+
+import { IOwnableInternal } from "@solidstate/contracts/access/ownable/IOwnableInternal.sol";
+import { OwnableWritable } from "../OwnableWritable.sol";
+
+import { TestComponent } from "./components/TestComponent.sol";
+import { TestSubsystem } from "./systems/TestSubsystem.sol";
+import { World } from "../World.sol";
+
+contract OwnableWritableTest is DSTestPlus {
+  Vm internal immutable vm = Vm(HEVM_ADDRESS);
+
+  address payable[] internal users;
+
+  address writer = address(bytes20(keccak256("writer")));
+  address notWriter = address(bytes20(keccak256("notWriter")));
+
+  TestComponent internal component;
+  TestSubsystem internal subsystem;
+
+  function setUp() public {
+    World world = new World();
+    world.init();
+
+    component = new TestComponent(address(world));
+    subsystem = new TestSubsystem(world, address(world.components()));
+
+    component.authorizeWriter(writer);
+    subsystem.authorizeWriter(writer);
+  }
+
+  function testWriteAccess() public {
+    assertTrue(component.writeAccess(writer));
+    assertTrue(subsystem.writeAccess(writer));
+    // owner also counts as a writer
+    assertTrue(component.writeAccess(address(this)));
+    assertTrue(subsystem.writeAccess(address(this)));
+  }
+
+  function testNoWriteAccess() public {
+    assertFalse(component.writeAccess(notWriter));
+    assertFalse(subsystem.writeAccess(notWriter));
+  }
+
+  function testWriterCanWrite() public {
+    vm.startPrank(writer);
+
+    component.set(1, abi.encode(1));
+    assertTrue(component.has(1));
+
+    assertEq(abi.decode(subsystem.execute(abi.encode(1)), (uint256)), 1);
+  }
+
+  function testNotWriterCanNotWrite() public {
+    vm.startPrank(notWriter);
+
+    vm.expectRevert(OwnableWritable.OwnableWritable__NotWriter.selector);
+    component.set(1, abi.encode(1));
+
+    vm.expectRevert(OwnableWritable.OwnableWritable__NotWriter.selector);
+    subsystem.execute(abi.encode(1));
+  }
+
+  function testWriterCanNotAuthorize() public {
+    vm.startPrank(writer);
+
+    vm.expectRevert(IOwnableInternal.Ownable__NotOwner.selector);
+    component.authorizeWriter(notWriter);
+
+    vm.expectRevert(IOwnableInternal.Ownable__NotOwner.selector);
+    component.unauthorizeWriter(writer);
+  }
+
+  function testUnauthorizeWriter() public {
+    component.unauthorizeWriter(writer);
+    subsystem.unauthorizeWriter(writer);
+
+    vm.startPrank(writer);
+
+    assertFalse(component.writeAccess(writer));
+    assertFalse(subsystem.writeAccess(writer));
+
+    vm.expectRevert(OwnableWritable.OwnableWritable__NotWriter.selector);
+    component.set(1, abi.encode(1));
+
+    vm.expectRevert(OwnableWritable.OwnableWritable__NotWriter.selector);
+    subsystem.execute(abi.encode(1));
+  }
+}

--- a/packages/solecs/src/test/systems/TestSubsystem.sol
+++ b/packages/solecs/src/test/systems/TestSubsystem.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
+import { Subsystem } from "../../Subsystem.sol";
+
+contract TestSubsystem is Subsystem {
+  uint256 public constant ID = uint256(keccak256("lib.testSubsystem"));
+
+  constructor(IWorld _world, address _components) Subsystem(_world, _components) {}
+
+  function _execute(bytes memory args) internal pure override returns (bytes memory) {
+    return args;
+  }
+}

--- a/packages/std-contracts/remappings.txt
+++ b/packages/std-contracts/remappings.txt
@@ -3,3 +3,4 @@ ds-test/=../../node_modules/ds-test/src/
 forge-std/=../../node_modules/forge-std/src/
 solmate/=../../node_modules/@rari-capital/solmate/src
 solecs/=../../node_modules/@latticexyz/solecs/src/
+@solidstate/=../../node_modules/@solidstate/

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,6 +3274,11 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@solidstate/contracts@^0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@solidstate/contracts/-/contracts-0.0.48.tgz#c97eb44cec623a388c67e2b36b404df3d46cf6ed"
+  integrity sha512-egof846MhC1lo+C8MJPmvte2xOjGEIbHcEB4G2H1ysC51F3xd81WZOTB/w+irylBSBK+HQE2uxhVW8QlUTBcEQ==
+
 "@swc/helpers@^0.4.2":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.11.tgz#db23a376761b3d31c26502122f349a21b592c8de"


### PR DESCRIPTION
Depends on #265

> 1. What's the benefit of Subsystems over Libraries?

- Given contract size issues, internal libraries can't always be used. Public libraries can be troublesome during deployment. Whereas Subsystems share OwnableWritable with components, which allows them to have similar authorization logic in deployment.
- Dependency bloat. E.g. SkillSubsystem can have all the mana, effect etc components authorized for it. Then Systems which use SkillSubsystem need to authorize only SkillSubsystem, not all of its components.
- Clarity of responsibility. It can be rather unclear which components a library modifies. This kinda reiterates the 2nd point though.

Naturally subsystems are only needed for projects with many components and systems, and they don't negate the need for libraries either.
The way I see it is rather than ECS this is ECCM - entity component controller model, also with non-component-aware-models, and no actual systems. And in MUD a controller is called system, and model - subsystem. And libraries and non-component-aware-models are both called libraries.
(By non-component-aware I mean libraries that use components, but don't deal with authorization. It could just as well be diamond storage)