### PR TITLE
docs: enforce custom retype styling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,38 +1,38 @@
 <style>
   .dark .dark\:text-blue-400, .dark, .dark .docs-markdown a:not(.no-link), .dark .dark\:hover\:text-blue-400:hover  {
-    color: #eb4926;
+    color: #eb4926!important;
   }
 
   .dark .dark\:hover\:text-blue-200:hover {
-    color: #f9ccc2;
+    color: #f9ccc2!important;
   }
 
   .dark .dark\:bg-blue-400 {
-    background-color: #eb4926;
+    background-color: #eb4926!important;
   }
 
   .dark .dark\:bg-dark-550 {
-    background-color: rgb(255 255 255 / 10%);
+    background-color: rgb(255 255 255 / 10%)!important;
   }
 
   .dark .dark\:border-dark-600 {
-    border-color: rgb(255 255 255 / 5%);  
+    border-color: rgb(255 255 255 / 5%)!important;  
   }
 
   .dark .dark\:bg-dark-650 {
-    background-color: #270e09;
+    background-color: #270e09!important;
   }
 
   .dark .dark\:bg-dark-850 {
-    background-color: #000000;
+    background-color: #000000!important;
   }
 
   .dark .dark\:bg-dark-800 {
-    background-color: #000000; 
+    background-color: #000000!important; 
   }
 
   .rounded, .rounded-r-lg, .rounded-l {
-    border-radius: 0;
+    border-radius: 0!important;
   }
 </style>
 <script>


### PR DESCRIPTION
Retype overrode custom styling when navigating to a new page; this PR adds `!important` flags to custom css to make sure it has higher precedence than default retype styling.