### PR TITLE
fix(cli): mud trace bug for non-local networks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ jobs:
         run: yarn docs
 
       - name: Publish to Cloudflare Pages
+        if: github.event.pull_request.head.repo.full_name == github.repository
         id: cloudflare_publish
         uses: cloudflare/pages-action@13c6a2f35417aaf1906cdbb1f6faf6c72c697b08
         with:

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -31,7 +31,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const deployData = config && JSON.parse(readFileSync(config, { encoding: "utf8" }));
   const labels = [];
 
-  const provider = new JsonRpcProvider(rpc || "http://localhost:8545");
+  const rpcUrl = rpc || "http://localhost:8545";
+  const provider = new JsonRpcProvider(rpcUrl);
   const World = new Contract(world, WorldAbi, provider);
 
   if (deployData) {
@@ -57,11 +58,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     labels.push(...components, ...systems);
   }
-
   await execLog("cast", [
     "run",
     ...labels.map((label) => ["--label", `${label[1]}:${label[0]}`]).flat(),
     ...(debug ? ["--debug"] : []),
+    `--rpc-url`,
+    `${rpcUrl}`,
     `${tx}`,
   ]);
 


### PR DESCRIPTION
The `cast run` call in `mud trace` was not using the `rpc` argument. It was defaulting to localhost:8545, which breaks for production chains.

This pr fixes that problem.