### PR TITLE
fix: use interfaces in LibDeploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-36276aac0408fde8b00c19e2cfc3b7bec3fc429d
+          version: nightly-5206d4e9c8bbabe7b004a6ddc44e35b2f1bc72ee
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: a09511b
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Generate docs
     steps:
       - name: Setup Go
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5206d4e9c8bbabe7b004a6ddc44e35b2f1bc72ee
+          version: nightly
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: a09511b
+          version: nightly-36276aac0408fde8b00c19e2cfc3b7bec3fc429d
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Run tests
     steps:
       - uses: actions/setup-node@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-5206d4e9c8bbabe7b004a6ddc44e35b2f1bc72ee
+          version: nightly
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: a09511b
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-36276aac0408fde8b00c19e2cfc3b7bec3fc429d
+          version: nightly-5206d4e9c8bbabe7b004a6ddc44e35b2f1bc72ee
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: a09511b
+          version: nightly-36276aac0408fde8b00c19e2cfc3b7bec3fc429d
 
       - name: Install dependencies
         run: yarn install --network-concurrency 1

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   },
   "scripts": {
-    "prepare": "husky install && (forge --version || yarn foundryup) && yarn workspaces run prepare",
+    "prepare": "husky install && yarn workspaces run prepare",
     "commit": "cz",
     "prettier:check": "prettier --check 'packages/**/*.ts'",
     "prettier": "prettier --write 'packages/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   },
   "scripts": {
-    "prepare": "husky install && yarn workspaces run prepare",
+    "prepare": "husky install && (forge --version || yarn foundryup) && yarn workspaces run prepare",
     "commit": "cz",
     "prettier:check": "prettier --check 'packages/**/*.ts'",
     "prettier": "prettier --write 'packages/**/*.ts'",

--- a/packages/cli/src/contracts/LibDeploy.ejs
+++ b/packages/cli/src/contracts/LibDeploy.ejs
@@ -8,8 +8,9 @@ import { DSTest } from "ds-test/test.sol";
 import { console } from "forge-std/console.sol";
 
 // Solecs 
+import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { World } from "solecs/World.sol";
-import { Component } from "solecs/Component.sol";
+import { IComponent } from "solecs/interfaces/IComponent.sol";
 import { getAddressById } from "solecs/utils.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";
 import { ISystem } from "solecs/interfaces/ISystem.sol";
@@ -25,7 +26,7 @@ import { <%= system.name %>, ID as <%= system.name %>ID } from "systems/<%- syst
 <% }); -%>
 
 struct DeployResult {
-  World world;
+  IWorld world;
   address deployer;
 }
 
@@ -42,12 +43,12 @@ library LibDeploy {
     // ------------------------
 
     // Deploy world
-    result.world = _world == address(0) ? new World() : World(_world);
+    result.world = _world == address(0) ? new World() : IWorld(_world);
     if (_world == address(0)) result.world.init(); // Init if it's a fresh world
 
     // Deploy components
     if (!_reuseComponents) {
-      Component comp;
+      IComponent comp;
 <% components.forEach(component => { -%>
 
       console.log("Deploying <%= component %>");
@@ -65,7 +66,7 @@ library LibDeploy {
     uint256 componentId,
     address writer
   ) internal {
-    Component(getAddressById(components, componentId)).authorizeWriter(writer);
+    IComponent(getAddressById(components, componentId)).authorizeWriter(writer);
   }
   
   /**
@@ -76,7 +77,7 @@ library LibDeploy {
     address _world,
     bool init
   ) internal {
-    World world = World(_world);
+    IWorld world = IWorld(_world);
     // Deploy systems
     ISystem system; 
     IUint256Component components = world.components();

--- a/packages/cli/src/contracts/LibDeploy.sol
+++ b/packages/cli/src/contracts/LibDeploy.sol
@@ -7,10 +7,10 @@ pragma solidity >=0.8.0;
 //        To manually generate the real LibDeploy.sol use
 //        `mud codegen-libdeploy`.
 
-import {World} from "solecs/World.sol";
+import {IWorld} from "solecs/interfaces/IWorld.sol";
 
 struct DeployResult {
-  World world;
+  IWorld world;
   address deployer;
 }
 

--- a/packages/solecs/src/interfaces/IWorld.sol
+++ b/packages/solecs/src/interfaces/IWorld.sol
@@ -44,4 +44,6 @@ interface IWorld {
   function getUniqueEntityId() external view returns (uint256);
 
   function query(WorldQueryFragment[] calldata worldQueryFragments) external view returns (uint256[] memory);
+
+  function init() external;
 }

--- a/packages/std-contracts/src/test/MudTest.t.sol
+++ b/packages/std-contracts/src/test/MudTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { DSTest } from "ds-test/test.sol";
-import { World } from "solecs/World.sol";
+import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { getAddressById } from "solecs/utils.sol";
@@ -10,7 +10,7 @@ import { console } from "forge-std/console.sol";
 import { Utilities } from "./Utilities.sol";
 
 interface IDeploy {
-  function deploy(address deployer) external returns (World world);
+  function deploy(address deployer) external returns (IWorld world);
 }
 
 contract MudTest is DSTest {
@@ -22,7 +22,7 @@ contract MudTest is DSTest {
   address payable internal eve;
   address internal deployer;
 
-  World internal world;
+  IWorld internal world;
   IUint256Component components;
   IUint256Component systems;
 


### PR DESCRIPTION
* This PR replaces `World` and `Component` in deploy/test files with `IWorld` and `IComponent` to allow alternative World/Component implementations