### PR TITLE
feat(solecs): add world to IComponent definition

### DIFF
--- a/packages/solecs/src/interfaces/IComponent.sol
+++ b/packages/solecs/src/interfaces/IComponent.sol
@@ -25,4 +25,6 @@ interface IComponent is IERC173 {
   function authorizeWriter(address writer) external;
 
   function unauthorizeWriter(address writer) external;
+
+  function world() external view returns (address);
 }


### PR DESCRIPTION
this is helpful when writing Libraries that need world access but only receive `IUint256Component components` as an argument