### PR TITLE
fix: separate component registration from components

### DIFF
--- a/packages/cli/src/contracts/LibDeploy.ejs
+++ b/packages/cli/src/contracts/LibDeploy.ejs
@@ -52,7 +52,8 @@ library LibDeploy {
 <% components.forEach(component => { -%>
 
       console.log("Deploying <%= component %>");
-      comp = new <%= component %>(address(result.world));
+      comp = new <%= component %>(result.world);
+      world.registerComponent(address(comp), <%= component %>ID);
       console.log(address(comp));
 <% });-%>
     } 

--- a/packages/solecs/src/BareComponent.sol
+++ b/packages/solecs/src/BareComponent.sol
@@ -19,7 +19,7 @@ abstract contract BareComponent is IComponent {
   error BareComponent__NotImplemented();
 
   /** Reference to the World contract this component is registered in */
-  address public world;
+  IWorld public world;
 
   /** Owner of the component has write access and can given write access to other addresses */
   address internal _owner;
@@ -30,14 +30,10 @@ abstract contract BareComponent is IComponent {
   /** Mapping from entity id to value in this component */
   mapping(uint256 => bytes) internal entityToValue;
 
-  /** Public identifier of this component */
-  uint256 public id;
-
-  constructor(address _world, uint256 _id) {
+  constructor(IWorld _world) {
     _owner = msg.sender;
     writeAccess[msg.sender] = true;
-    id = _id;
-    if (_world != address(0)) registerWorld(_world);
+    world = _world;
   }
 
   /** Revert if caller is not the owner of this component */
@@ -67,15 +63,6 @@ abstract contract BareComponent is IComponent {
     writeAccess[msg.sender] = false;
     _owner = newOwner;
     writeAccess[newOwner] = true;
-  }
-
-  /**
-   * Register this component in the given world.
-   * @param _world Address of the World contract.
-   */
-  function registerWorld(address _world) public onlyOwner {
-    world = _world;
-    IWorld(world).registerComponent(address(this), id);
   }
 
   /**
@@ -162,7 +149,7 @@ abstract contract BareComponent is IComponent {
     entityToValue[entity] = value;
 
     // Emit global event
-    IWorld(world).registerComponentValueSet(entity, value);
+    world.registerComponentValueSet(entity, value);
   }
 
   /**
@@ -177,6 +164,6 @@ abstract contract BareComponent is IComponent {
     delete entityToValue[entity];
 
     // Emit global event
-    IWorld(world).registerComponentValueRemoved(entity);
+    world.registerComponentValueRemoved(entity);
   }
 }

--- a/packages/solecs/src/Component.sol
+++ b/packages/solecs/src/Component.sol
@@ -26,7 +26,7 @@ abstract contract Component is BareComponent {
   /** List of indexers to be updated when a component value changes */
   IEntityIndexer[] internal indexers;
 
-  constructor(address _world, uint256 _id) BareComponent(_world, _id) {
+  constructor(IWorld _world) BareComponent(_world) {
     entities = new Set();
     valueToEntities = new MapSet();
   }

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -35,8 +35,8 @@ contract World is IWorld {
   event ComponentValueRemoved(uint256 indexed componentId, address indexed component, uint256 indexed entity);
 
   constructor() {
-    _components = new Uint256Component(address(0), componentsComponentId);
-    _systems = new Uint256Component(address(0), systemsComponentId);
+    _components = new Uint256Component(this);
+    _systems = new Uint256Component(this);
     register = new RegisterSystem(this, address(_components));
     _systems.authorizeWriter(address(register));
     _components.authorizeWriter(address(register));
@@ -47,9 +47,9 @@ contract World is IWorld {
    * Separated from the constructor to prevent circular dependencies.
    */
   function init() public {
-    _components.registerWorld(address(this));
-    _systems.registerWorld(address(this));
-    register.execute(abi.encode(msg.sender, RegisterType.System, address(register), registerSystemId));
+    registerComponent(address(_components), componentsComponentId);
+    registerComponent(address(_systems), systemsComponentId);
+    registerSystem(address(register), registerSystemId);
   }
 
   /**

--- a/packages/solecs/src/components/Uint256Component.sol
+++ b/packages/solecs/src/components/Uint256Component.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../interfaces/IWorld.sol";
 import "../Component.sol";
 import "../interfaces/IUint256Component.sol";
 
@@ -7,7 +9,7 @@ import "../interfaces/IUint256Component.sol";
  * Reference implementation of a component storing a uint256 value for each entity.
  */
 contract Uint256Component is Component, IUint256Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/solecs/src/test/Component.t.sol
+++ b/packages/solecs/src/test/Component.t.sol
@@ -4,7 +4,7 @@ import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
 
-import { TestComponent } from "./components/TestComponent.sol";
+import { TestComponent, TestComponentID } from "./components/TestComponent.sol";
 import { World } from "../World.sol";
 
 contract ComponentTest is DSTestPlus {
@@ -17,7 +17,8 @@ contract ComponentTest is DSTestPlus {
   function setUp() public {
     World world = new World();
     world.init();
-    component = new TestComponent(address(world));
+    component = new TestComponent(world);
+    world.registerComponent(address(component), TestComponentID);
   }
 
   function testSetAndGetValue() public {

--- a/packages/solecs/src/test/Indexer.t.sol
+++ b/packages/solecs/src/test/Indexer.t.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.8.0;
 import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
 import { Vm } from "forge-std/Vm.sol";
 
-import { DamageComponent } from "./components/DamageComponent.sol";
-import { PositionComponent, Position } from "./components/PositionComponent.sol";
+import { DamageComponent, ID as DamageComponentID } from "./components/DamageComponent.sol";
+import { PositionComponent, Position, ID as PositionComponentID } from "./components/PositionComponent.sol";
 import { Indexer } from "../Indexer.sol";
 import { World } from "../World.sol";
 import { Component } from "../Component.sol";
@@ -21,8 +21,12 @@ contract IndexerTest is DSTestPlus {
     World world = new World();
     world.init();
 
-    position = new PositionComponent(address(world));
-    damage = new DamageComponent(address(world));
+    position = new PositionComponent(world);
+    world.registerComponent(address(position), PositionComponentID);
+
+    damage = new DamageComponent(world);
+    world.registerComponent(address(damage), DamageComponentID);
+
     Component[] memory components = new Component[](2);
     components[0] = position;
     components[1] = damage;

--- a/packages/solecs/src/test/LibQuery.t.sol
+++ b/packages/solecs/src/test/LibQuery.t.sol
@@ -8,10 +8,10 @@ import { console } from "forge-std/console.sol";
 import { World } from "../World.sol";
 import { LibQuery } from "../LibQuery.sol";
 import { QueryFragment, QueryType } from "../interfaces/Query.sol";
-import { TestComponent1, TestComponent2, TestComponent3 } from "./components/TestComponent.sol";
-import { PrototypeTagComponent } from "./components/PrototypeTagComponent.sol";
-import { FromPrototypeComponent } from "./components/FromPrototypeComponent.sol";
-import { OwnedByEntityComponent } from "./components/OwnedByEntityComponent.sol";
+import { TestComponent1, TestComponent1ID, TestComponent2, TestComponent2ID, TestComponent3, TestComponent3ID } from "./components/TestComponent.sol";
+import { PrototypeTagComponent, ID as PrototypeTagComponentID } from "./components/PrototypeTagComponent.sol";
+import { FromPrototypeComponent, ID as FromPrototypeComponentID } from "./components/FromPrototypeComponent.sol";
+import { OwnedByEntityComponent, ID as OwnedByEntityComponentID } from "./components/OwnedByEntityComponent.sol";
 
 contract LibQueryTest is DSTest {
   Vm internal immutable vm = Vm(HEVM_ADDRESS);
@@ -29,12 +29,20 @@ contract LibQueryTest is DSTest {
   function setUp() public {
     World world = new World();
     world.init();
-    component1 = new TestComponent1(address(world));
-    component2 = new TestComponent2(address(world));
-    component3 = new TestComponent3(address(world));
-    prototypeTag = new PrototypeTagComponent(address(world));
-    fromPrototype = new FromPrototypeComponent(address(world));
-    ownedByEntity = new OwnedByEntityComponent(address(world));
+
+    component1 = new TestComponent1(world);
+    component2 = new TestComponent2(world);
+    component3 = new TestComponent3(world);
+    prototypeTag = new PrototypeTagComponent(world);
+    fromPrototype = new FromPrototypeComponent(world);
+    ownedByEntity = new OwnedByEntityComponent(world);
+
+    world.registerComponent(address(component1), TestComponent1ID);
+    world.registerComponent(address(component2), TestComponent2ID);
+    world.registerComponent(address(component3), TestComponent3ID);
+    world.registerComponent(address(prototypeTag), PrototypeTagComponentID);
+    world.registerComponent(address(fromPrototype), FromPrototypeComponentID);
+    world.registerComponent(address(ownedByEntity), OwnedByEntityComponentID);
   }
 
   function testHasQuery() public {

--- a/packages/solecs/src/test/components/DamageComponent.sol
+++ b/packages/solecs/src/test/components/DamageComponent.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
 uint256 constant ID = uint256(keccak256("mudwar.components.Damage"));
 
 contract DamageComponent is Component {
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;

--- a/packages/solecs/src/test/components/FromPrototypeComponent.sol
+++ b/packages/solecs/src/test/components/FromPrototypeComponent.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
-contract FromPrototypeComponent is Component {
-  uint256 public constant ID = uint256(keccak256("lib.fromPrototype"));
+uint256 constant ID = uint256(keccak256("lib.fromPrototype"));
 
-  constructor(address world) Component(world, ID) {}
+contract FromPrototypeComponent is Component {
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;

--- a/packages/solecs/src/test/components/OwnedByEntityComponent.sol
+++ b/packages/solecs/src/test/components/OwnedByEntityComponent.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
-contract OwnedByEntityComponent is Component {
-  uint256 public constant ID = uint256(keccak256("lib.ownedByEntity"));
+uint256 constant ID = uint256(keccak256("lib.ownedByEntity"));
 
-  constructor(address world) Component(world, ID) {}
+contract OwnedByEntityComponent is Component {
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;

--- a/packages/solecs/src/test/components/PositionComponent.sol
+++ b/packages/solecs/src/test/components/PositionComponent.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
@@ -12,7 +13,7 @@ struct Position {
 uint256 constant ID = uint256(keccak256("mudwar.components.Position"));
 
 contract PositionComponent is Component {
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys[0] = "x";

--- a/packages/solecs/src/test/components/PrototypeTagComponent.sol
+++ b/packages/solecs/src/test/components/PrototypeTagComponent.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
-contract PrototypeTagComponent is Component {
-  uint256 public constant ID = uint256(keccak256("lib.prototypeTag"));
+uint256 constant ID = uint256(keccak256("lib.prototypeTag"));
 
-  constructor(address world) Component(world, ID) {}
+contract PrototypeTagComponent is Component {
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;

--- a/packages/solecs/src/test/components/TestComponent.sol
+++ b/packages/solecs/src/test/components/TestComponent.sol
@@ -1,52 +1,54 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "../../interfaces/IWorld.sol";
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 
-contract TestComponent is Component {
-  uint256 public constant ID = uint256(keccak256("lib.testComponent"));
+uint256 constant TestComponentID = uint256(keccak256("lib.testComponent"));
 
-  constructor(address world) Component(world, ID) {}
+contract TestComponent is Component {
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;
   }
 }
+
+uint256 constant TestComponent1ID = uint256(keccak256("lib.testComponent1"));
 
 contract TestComponent1 is Component {
-  uint256 public constant ID = uint256(keccak256("lib.testComponent1"));
-
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;
   }
 }
+
+uint256 constant TestComponent2ID = uint256(keccak256("lib.testComponent2"));
 
 contract TestComponent2 is Component {
-  uint256 public constant ID = uint256(keccak256("lib.testComponent2"));
-
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;
   }
 }
+
+uint256 constant TestComponent3ID = uint256(keccak256("lib.testComponent3"));
 
 contract TestComponent3 is Component {
-  uint256 public constant ID = uint256(keccak256("lib.testComponent3"));
-
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;
   }
 }
 
-contract TestComponent4 is Component {
-  uint256 public constant ID = uint256(keccak256("lib.testComponent4"));
+uint256 constant TestComponent4ID = uint256(keccak256("lib.testComponent4"));
 
-  constructor(address world) Component(world, ID) {}
+contract TestComponent4 is Component {
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     values[0] = LibTypes.SchemaValue.UINT256;

--- a/packages/std-contracts/src/components/AddressBareComponent.sol
+++ b/packages/std-contracts/src/components/AddressBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract AddressBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/AddressComponent.sol
+++ b/packages/std-contracts/src/components/AddressComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract AddressComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/BoolBareComponent.sol
+++ b/packages/std-contracts/src/components/BoolBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract BoolBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/BoolComponent.sol
+++ b/packages/std-contracts/src/components/BoolComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract BoolComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/CoordBareComponent.sol
+++ b/packages/std-contracts/src/components/CoordBareComponent.sol
@@ -8,7 +8,7 @@ struct Coord {
 }
 
 contract CoordBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](2);

--- a/packages/std-contracts/src/components/CoordComponent.sol
+++ b/packages/std-contracts/src/components/CoordComponent.sol
@@ -8,7 +8,7 @@ struct Coord {
 }
 
 contract CoordComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](2);

--- a/packages/std-contracts/src/components/FunctionBareComponent.sol
+++ b/packages/std-contracts/src/components/FunctionBareComponent.sol
@@ -8,7 +8,7 @@ struct FunctionSelector {
 }
 
 contract FunctionBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](2);

--- a/packages/std-contracts/src/components/FunctionComponent.sol
+++ b/packages/std-contracts/src/components/FunctionComponent.sol
@@ -8,7 +8,7 @@ struct FunctionSelector {
 }
 
 contract FunctionComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](2);

--- a/packages/std-contracts/src/components/Int32BareComponent.sol
+++ b/packages/std-contracts/src/components/Int32BareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract Int32BareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Int32Component.sol
+++ b/packages/std-contracts/src/components/Int32Component.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract Int32Component is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/StringArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract StringArrayBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/StringArrayComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract StringArrayComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/StringBareComponent.sol
+++ b/packages/std-contracts/src/components/StringBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract StringBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/StringComponent.sol
+++ b/packages/std-contracts/src/components/StringComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract StringComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract Uint256ArrayBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint256ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract Uint256ArrayComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint256BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256BareComponent.sol
@@ -6,7 +6,7 @@ import "solecs/BareComponent.sol";
  * Reference implementation of a component storing a uint256 value for each entity.
  */
 contract Uint256BareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract Uint32ArrayBareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint32ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract Uint32ArrayComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint32BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32BareComponent.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/BareComponent.sol";
 
 contract Uint32BareComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/Uint32Component.sol
+++ b/packages/std-contracts/src/components/Uint32Component.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0;
 import "solecs/Component.sol";
 
 contract Uint32Component is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](1);

--- a/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
@@ -9,7 +9,7 @@ struct VoxelCoord {
 }
 
 contract VoxelCoordComponent is BareComponent {
-  constructor(address world, uint256 id) BareComponent(world, id) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](3);

--- a/packages/std-contracts/src/components/VoxelCoordComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordComponent.sol
@@ -9,7 +9,7 @@ struct VoxelCoord {
 }
 
 contract VoxelCoordComponent is Component {
-  constructor(address world, uint256 id) Component(world, id) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](3);

--- a/packages/std-contracts/src/test/GasComponent.t.sol
+++ b/packages/std-contracts/src/test/GasComponent.t.sol
@@ -12,8 +12,8 @@ import { Uint256BareComponent } from "../components/Uint256BareComponent.sol";
 import { CoordComponent, Coord } from "../components/CoordComponent.sol";
 import { CoordBareComponent, Coord as BareCoord } from "../components/CoordBareComponent.sol";
 
-import { TestComponent, TestStruct } from "./TestComponent.sol";
-import { TestBareComponent, TestStructBare } from "./TestBareComponent.sol";
+import { TestComponent, TestStruct, ID as TestComponentID } from "./TestComponent.sol";
+import { TestBareComponent, TestStructBare, ID as TestBareComponentID } from "./TestBareComponent.sol";
 
 contract ComponentTest is DSTestPlus {
   Vm internal immutable vm = Vm(HEVM_ADDRESS);
@@ -44,14 +44,24 @@ contract ComponentTest is DSTestPlus {
   function setUp() public {
     World world = new World();
     world.init();
-    boolComponent = new BoolComponent(address(world), BoolID);
-    boolBareComponent = new BoolBareComponent(address(world), BoolBareID);
-    uint256Component = new Uint256Component(address(world), Uint256ID);
-    uint256BareComponent = new Uint256BareComponent(address(world), Uint256BareID);
-    coordComponent = new CoordComponent(address(world), CoordID);
-    coordBareComponent = new CoordBareComponent(address(world), CoordBareID);
-    testComponent = new TestComponent(address(world));
-    testBareComponent = new TestBareComponent(address(world));
+
+    boolComponent = new BoolComponent(world);
+    boolBareComponent = new BoolBareComponent(world);
+    uint256Component = new Uint256Component(world);
+    uint256BareComponent = new Uint256BareComponent(world);
+    coordComponent = new CoordComponent(world);
+    coordBareComponent = new CoordBareComponent(world);
+    testComponent = new TestComponent(world);
+    testBareComponent = new TestBareComponent(world);
+
+    world.registerComponent(address(boolComponent), BoolID);
+    world.registerComponent(address(boolBareComponent), BoolBareID);
+    world.registerComponent(address(uint256Component), Uint256ID);
+    world.registerComponent(address(uint256BareComponent), Uint256BareID);
+    world.registerComponent(address(coordComponent), CoordID);
+    world.registerComponent(address(coordBareComponent), CoordBareID);
+    world.registerComponent(address(testComponent), TestComponentID);
+    world.registerComponent(address(testBareComponent), TestBareComponentID);
   }
 
   function testBaseComponentGas() public {

--- a/packages/std-contracts/src/test/TestBareComponent.sol
+++ b/packages/std-contracts/src/test/TestBareComponent.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { BareComponent } from "solecs/BareComponent.sol";
 import { LibTypes } from "solecs/LibTypes.sol";
 
@@ -13,7 +15,7 @@ struct TestStructBare {
 }
 
 contract TestBareComponent is BareComponent {
-  constructor(address world) BareComponent(world, ID) {}
+  constructor(IWorld world) BareComponent(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](4);

--- a/packages/std-contracts/src/test/TestComponent.sol
+++ b/packages/std-contracts/src/test/TestComponent.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
+import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { Component } from "solecs/Component.sol";
 import { LibTypes } from "solecs/LibTypes.sol";
 
@@ -13,7 +15,7 @@ struct TestStruct {
 }
 
 contract TestComponent is Component {
-  constructor(address world) Component(world, ID) {}
+  constructor(IWorld world) Component(world) {}
 
   function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
     keys = new string[](4);


### PR DESCRIPTION
@alvrs This is a fix for the component registration issue I mentioned in discord, where you can't deploy a new component with an existing ID (RegisterSystem expects the owner of the old component to be the new component, instead of the deployer).

2 and 3 don't have to be in the same PR as 1, but they're very related breaking changes that would go well together imo.

1. Make world.registerComponent call external, like with systems. Remove registerWorld from components.
2. id in Component constructor only existed to support registerWorld, remove it as well. This simplifies the constructor and the component state. Id can still be obtained via `getIdByAddress` when needed.
3. In Component's constructor change `world` from `address` to `IWorld`. I assume it was `address` because some components (like world's registries) had to have world separately initialized, and the constructor could receive `address(0)`. That is no longer the case, and component constructor now treats world exactly the same as system constructor. This also simplifies Component creation (all the places I've seen had to cast IWorld to address).

World.init, std-contracts, tests, LibDeploy.ejs are changed to support the new constructor and registration.
I don't think this breaks any other packages, but I may have missed something.
This is naturally a breaking change for any project that implements or deploys components
