### PR TITLE
fix: add LoadingState component from SyncWorker

### DIFF
--- a/packages/std-client/src/setup/types.ts
+++ b/packages/std-client/src/setup/types.ts
@@ -31,4 +31,9 @@ export type ContractComponents = {
 export type NetworkComponents<C extends ContractComponents> = C & {
   SystemsRegistry: Component<{ value: Type.String }>;
   ComponentsRegistry: Component<{ value: Type.String }>;
+  LoadingState: Component<{
+    state: Type.Number;
+    msg: Type.String;
+    percentage: Type.Number;
+  }>;
 };


### PR DESCRIPTION
Without this, your console will see a bunch of logs like this:

<img width="448" alt="image" src="https://user-images.githubusercontent.com/508855/207158831-df8d79ea-aac8-4955-8bf6-54ca619aa3ee.png">
