### PR TITLE
feat: bump devnode gas limit to 100m

### DIFF
--- a/packages/cli/src/commands/devnode.ts
+++ b/packages/cli/src/commands/devnode.ts
@@ -21,7 +21,14 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   console.log("Clearing devnode history");
   const userHomeDir = homedir();
   rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
-  const { child } = await execLog("anvil", ["-b", String(blocktime), "--block-base-fee-per-gas", "0"]);
+  const { child } = await execLog("anvil", [
+    "-b",
+    String(blocktime),
+    "--block-base-fee-per-gas",
+    "0",
+    "--gas-limit",
+    "100000000",
+  ]);
 
   process.on("SIGINT", () => {
     console.log("\ngracefully shutting down from SIGINT (Crtl-C)");


### PR DESCRIPTION
Lattice/MUD testnet runs with 100m gas limit, so this bumps the local devnode testnet to match so we can do a little more work when e.g. initializing a world

We should also make this configurable via CLI!

Open question around what we want our default to be, or put another way, what chains we want MUD dev to be compatible with and their respective gas limits. Since we haven't done a ton of gas golfing, I assume we prob won't be doing much with MUD on mainnet for now?