### PR TITLE
fix: new entities should be included in overrides

### DIFF
--- a/packages/recs/src/Component.ts
+++ b/packages/recs/src/Component.ts
@@ -374,7 +374,7 @@ export function overridableComponent<S extends Schema, M extends Metadata, T = u
       if (prop === "removeOverride") return removeOverride;
       if (prop === "values") return valuesProxy;
       if (prop === "update$") return update$;
-      if (prop === "entities") return () => [...overriddenEntityValues.keys(), ...target.entities()];
+      if (prop === "entities") return () => new Set([...overriddenEntityValues.keys(), ...target.entities()]).values();
 
       return Reflect.get(target, prop);
     },

--- a/packages/recs/src/Component.ts
+++ b/packages/recs/src/Component.ts
@@ -374,6 +374,7 @@ export function overridableComponent<S extends Schema, M extends Metadata, T = u
       if (prop === "removeOverride") return removeOverride;
       if (prop === "values") return valuesProxy;
       if (prop === "update$") return update$;
+      if (prop === "entities") return () => [...overriddenEntityValues.keys(), ...target.entities()];
 
       return Reflect.get(target, prop);
     },


### PR DESCRIPTION
Before this change, creating new entities with overrides on the client (for optimistic rendering) resulted in ~no visible changes.