### PR TITLE
fix(cli): reset LibDeploy.sol using original/cached contents

### DIFF
--- a/packages/cli/src/commands/codegen-libdeploy.ts
+++ b/packages/cli/src/commands/codegen-libdeploy.ts
@@ -1,6 +1,4 @@
 import type { Arguments, CommandBuilder } from "yargs";
-import ejs from "ejs";
-import { readFileSync, writeFileSync } from "fs";
 import { generateLibDeploy } from "../utils";
 
 type Options = {

--- a/packages/cli/src/utils/codegen.ts
+++ b/packages/cli/src/utils/codegen.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 const contractsDir = path.join(__dirname, "../../src/contracts");
 
-const originalLibDeploy = readFile(path.join(contractsDir, "LibDeploy.sol"));
+const stubLibDeploy = readFile(path.join(contractsDir, "LibDeploy.sol"));
 
 export async function generateLibDeploy(configPath: string, out: string, systems?: string | string[]) {
   // Parse config
@@ -28,5 +28,5 @@ export async function generateLibDeploy(configPath: string, out: string, systems
 }
 
 export async function resetLibDeploy(out: string) {
-  await writeFile(path.join(out, "LibDeploy.sol"), await originalLibDeploy);
+  await writeFile(path.join(out, "LibDeploy.sol"), await stubLibDeploy);
 }

--- a/packages/cli/src/utils/codegen.ts
+++ b/packages/cli/src/utils/codegen.ts
@@ -1,12 +1,14 @@
-import { readFileSync, writeFileSync } from "fs";
+import { readFile, writeFile } from "fs/promises";
 import ejs from "ejs";
 import path from "path";
 
 const contractsDir = path.join(__dirname, "../../src/contracts");
 
+const originalLibDeploy = readFile(path.join(contractsDir, "LibDeploy.sol"));
+
 export async function generateLibDeploy(configPath: string, out: string, systems?: string | string[]) {
   // Parse config
-  const config = JSON.parse(readFileSync(configPath, { encoding: "utf8" }));
+  const config = JSON.parse(await readFile(configPath, { encoding: "utf8" }));
 
   // Filter systems
   if (systems) {
@@ -20,11 +22,11 @@ export async function generateLibDeploy(configPath: string, out: string, systems
   console.log("Generating deployment script");
   const LibDeploy = await ejs.renderFile(path.join(contractsDir, "LibDeploy.ejs"), config, { async: true });
   const libDeployPath = path.join(out, "LibDeploy.sol");
-  writeFileSync(libDeployPath, LibDeploy);
+  await writeFile(libDeployPath, LibDeploy);
 
   return libDeployPath;
 }
 
 export async function resetLibDeploy(out: string) {
-  writeFileSync(path.join(out, "LibDeploy.sol"), readFileSync(path.join(contractsDir, "LibDeploy.sol")));
+  await writeFile(path.join(out, "LibDeploy.sol"), await originalLibDeploy);
 }

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -1,6 +1,5 @@
 import { constants, Wallet } from "ethers";
-import { rmSync } from "fs";
-import { generateLibDeploy } from "./codegen";
+import { generateLibDeploy, resetLibDeploy } from "./codegen";
 import { findLog } from "./findLog";
 import { generateTypes } from "./types";
 import { execa } from "execa";
@@ -77,7 +76,7 @@ export async function generateAndDeploy(args: DeployOptions) {
   } finally {
     // Remove generated LibDeploy
     console.log("Cleaning up deployment script");
-    if (libDeployPath) rmSync(libDeployPath);
+    if (libDeployPath) resetLibDeploy(contractsDir);
   }
 
   return { deployedWorldAddress, initialBlockNumber };


### PR DESCRIPTION
Running the dev scripts would delete/overwrite the `LibDeploy.sol` file, which kept later parts of the hot reloading from continuing (e.g. couldn't find deleted file). This may only be visible with linked MUD deps, didn't test with a regular npm install.