### PR TITLE
refactor: move worker logs to debug

### DIFF
--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -24,6 +24,25 @@
     "build": "rimraf dist && rimraf ./.parcel-cache && yarn prepack && parcel build && tsc --emitDeclarationOnly; yarn postpack",
     "release": "npm publish || echo 'version already published'"
   },
+  "dependencies": {
+    "debug": "^4.3.4"
+  },
+  "peerDependencies": {
+    "@ethersproject/providers": "^5.6.1",
+    "@improbable-eng/grpc-web": "^0.15.0",
+    "@latticexyz/recs": "^1.28.1",
+    "@latticexyz/services": "^1.28.1",
+    "@latticexyz/solecs": "^1.28.1",
+    "@latticexyz/utils": "^1.28.1",
+    "@protobuf-ts/grpcweb-transport": "^2.7.0",
+    "async-mutex": "^0.3.2",
+    "ethers": "^5.7.1",
+    "mobx": "^6.5.0",
+    "nice-grpc-web": "^2.0.0",
+    "observable-webworker": "^4.0.1",
+    "rxjs": "^7.5.5",
+    "threads": "^1.7.0"
+  },
   "devDependencies": {
     "@ethersproject/abi": "^5.6.0",
     "@ethersproject/providers": "^5.6.1",
@@ -33,6 +52,7 @@
     "@latticexyz/solecs": "^1.30.1",
     "@latticexyz/utils": "^1.30.1",
     "@protobuf-ts/grpcweb-transport": "^2.7.0",
+    "@types/debug": "^4.1.7",
     "@types/google-protobuf": "^3.15.6",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",
@@ -53,22 +73,6 @@
     "typedoc": "0.23.21",
     "typedoc-plugin-markdown": "^3.13.6",
     "typescript": "^4.6.2"
-  },
-  "peerDependencies": {
-    "@ethersproject/providers": "^5.6.1",
-    "@improbable-eng/grpc-web": "^0.15.0",
-    "@latticexyz/recs": "^1.28.1",
-    "@latticexyz/services": "^1.28.1",
-    "@latticexyz/solecs": "^1.28.1",
-    "@latticexyz/utils": "^1.28.1",
-    "@protobuf-ts/grpcweb-transport": "^2.7.0",
-    "async-mutex": "^0.3.2",
-    "ethers": "^5.7.1",
-    "mobx": "^6.5.0",
-    "nice-grpc-web": "^2.0.0",
-    "observable-webworker": "^4.0.1",
-    "rxjs": "^7.5.5",
-    "threads": "^1.7.0"
   },
   "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343"
 }

--- a/packages/network/src/debug.ts
+++ b/packages/network/src/debug.ts
@@ -1,0 +1,3 @@
+import createDebug from "debug";
+
+export const debug = createDebug("mud:network");

--- a/packages/network/src/workers/CacheStore.ts
+++ b/packages/network/src/workers/CacheStore.ts
@@ -4,6 +4,9 @@ import { initCache } from "../initCache";
 import { ECSStateReply } from "@latticexyz/services/protobuf/ts/ecs-snapshot/ecs-snapshot";
 import { NetworkComponentUpdate, NetworkEvents } from "../types";
 import { formatEntityID } from "../utils";
+import { debug as parentDebug } from "./debug";
+
+const debug = parentDebug.extend("CacheStore");
 
 export type State = Map<number, ComponentValue>;
 export type CacheStore = ReturnType<typeof createCacheStore>;
@@ -115,7 +118,7 @@ export function mergeCacheStores(stores: CacheStore[]): CacheStore {
 }
 
 export async function saveCacheStoreToIndexDb(cache: ECSCache, store: CacheStore) {
-  console.log("[Cache] store cache with size", store.state.size, "at block", store.blockNumber);
+  debug("store cache with size", store.state.size, "at block", store.blockNumber);
   await cache.set("ComponentValues", "current", store.state);
   await cache.set("Mappings", "components", store.components);
   await cache.set("Mappings", "entities", store.entities);

--- a/packages/network/src/workers/Sync.worker.ts
+++ b/packages/network/src/workers/Sync.worker.ts
@@ -1,5 +1,4 @@
 import { runWorker } from "@latticexyz/utils";
 import { SyncWorker } from "./SyncWorker";
 
-console.log("[SyncWorker] Starting Sync Worker");
 runWorker(new SyncWorker());

--- a/packages/network/src/workers/debug.ts
+++ b/packages/network/src/workers/debug.ts
@@ -1,0 +1,3 @@
+import { debug as parentDebug } from "../debug";
+
+export const debug = parentDebug.extend("workers");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,6 +3403,13 @@
   resolved "https://registry.yarnpkg.com/@types/clear/-/clear-0.1.2.tgz#131050f8a7b429ae0e4ca390339ea9977ca977bd"
   integrity sha512-h3GHp9BuPgY3X+WKWwJgTIl/h38KkcdU6JG28i1xdrlS8YXVi3V1YrhaZkjuvur97qZo8TMQjVXJorTf87LvfA==
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/ejs@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.1.tgz#29c539826376a65e7f7d672d51301f37ed718f6d"
@@ -3540,6 +3547,11 @@
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node-fetch@^2.6.2":
   version "2.6.2"


### PR DESCRIPTION
Worker logs are really noisy and get in the way of my own app's logs, so this PR moves them into the `debug` library, which namespaces them and makes them opt-in (with the "Verbose" log level and namespace logging toggled with e.g. `localStorage.debug = mud.*`)

<img width="432" alt="image" src="https://user-images.githubusercontent.com/508855/207168778-812e7292-11ff-4512-8958-c6820714916f.png">

I'll plan to move more things to this in the future.