### PR TITLE
fix(std-client): allow default components to be passed in to setupMUDNetwork

### DIFF
--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -176,7 +176,17 @@ function findOrDefineComponent<Cs extends ContractComponents, C extends Contract
   components: Cs,
   component: C
 ): C {
-  return (
-    (Object.values(components).find((c) => c.metadata.contractId === component.metadata.contractId) as C) ?? component
-  );
+  const existingComponent = Object.values(components).find(
+    (c) => c.metadata.contractId === component.metadata.contractId
+  ) as C;
+
+  if (existingComponent) {
+    console.warn(
+      "Component with contract id",
+      component.metadata.contractId,
+      "is defined by default in setupMUDNetwork"
+    );
+  }
+
+  return existingComponent || component;
 }

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -32,28 +32,37 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
   SystemAbis: { [key in keyof SystemTypes]: ContractInterface },
   options?: { initialGasPrice?: number; fetchSystemCalls?: boolean }
 ) {
-  const SystemsRegistry = defineStringComponent(world, {
-    id: "SystemsRegistry",
-    metadata: { contractId: "world.component.systems" },
-  });
+  const SystemsRegistry = findOrDefineComponent(
+    contractComponents,
+    defineStringComponent(world, {
+      id: "SystemsRegistry",
+      metadata: { contractId: "world.component.systems" },
+    })
+  );
 
-  const ComponentsRegistry = defineStringComponent(world, {
-    id: "ComponentsRegistry",
-    metadata: { contractId: "world.component.components" },
-  });
+  const ComponentsRegistry = findOrDefineComponent(
+    contractComponents,
+    defineStringComponent(world, {
+      id: "ComponentsRegistry",
+      metadata: { contractId: "world.component.components" },
+    })
+  );
 
   // used by SyncWorker to notify client of sync progress
-  const LoadingState = defineComponent(
-    world,
-    {
-      state: Type.Number,
-      msg: Type.String,
-      percentage: Type.Number,
-    },
-    {
-      id: "LoadingState",
-      metadata: { contractId: "component.LoadingState" },
-    }
+  const LoadingState = findOrDefineComponent(
+    contractComponents,
+    defineComponent(
+      world,
+      {
+        state: Type.Number,
+        msg: Type.String,
+        percentage: Type.Number,
+      },
+      {
+        id: "LoadingState",
+        metadata: { contractId: "component.LoadingState" },
+      }
+    )
   );
 
   const components: NetworkComponents<C> = {
@@ -155,4 +164,19 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
     registerSystem,
     components,
   };
+}
+
+/**
+ * Find a component in the components object by contract id, or return the component if it doesn't exist
+ * @param components object of components
+ * @param component component to find
+ * @returns component if it exists in components object, otherwise the component passed in
+ */
+function findOrDefineComponent<Cs extends ContractComponents, C extends ContractComponent>(
+  components: Cs,
+  component: C
+): C {
+  return (
+    (Object.values(components).find((c) => c.metadata.contractId === component.metadata.contractId) as C) ?? component
+  );
 }


### PR DESCRIPTION
* before #288 users had to manually define the `LoadingState` component. Since #288 `LoadingState` is created by default in `setupMUDNetwork`, overriding any user-defined `LoadingState` component
* this caused previous clients who had a custom `LoadingState` component and used it for a loading screen to get stuck in that loading screen because their component wasn't updated anymore
* With this PRs components passed in by users get priority over default components (eg if a component with contract id `component.LoadingState` is passed in, it will be used as `LoadingState` component instead of creating a new one)