### PR TITLE
Revert "feat: bump devnode gas limit to 100m (#289)"

### DIFF
--- a/packages/cli/src/commands/devnode.ts
+++ b/packages/cli/src/commands/devnode.ts
@@ -21,14 +21,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   console.log("Clearing devnode history");
   const userHomeDir = homedir();
   rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
-  const { child } = await execLog("anvil", [
-    "-b",
-    String(blocktime),
-    "--block-base-fee-per-gas",
-    "0",
-    "--gas-limit",
-    "100000000",
-  ]);
+  const { child } = await execLog("anvil", ["-b", String(blocktime), "--block-base-fee-per-gas", "0"]);
 
   process.on("SIGINT", () => {
     console.log("\ngracefully shutting down from SIGINT (Crtl-C)");


### PR DESCRIPTION
This reverts commit a02e44bb9e3c2ee6b8aaea7b080cd35820bf1de1.

I've grown a little afraid of this 100m limit as a default. Someone might build on it assuming they can deploy to a testnet or mainnet, but find that they have to do a bunch of refactoring to stay under the (30m standard) gas limit.

The original motivation for bumping this was the tutorial, but I found a way to simplify the initializing code so it didn't need so much gas.

I'll prob revisit this in the future to make it configurable so folks can break out of the default limit.