### PR TITLE
feat(std-contracts): add SystemCallbackComponent

### DIFF
--- a/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
+++ b/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// imports for the component
+import { LibTypes } from "solecs/LibTypes.sol";
+import { BareComponent } from "solecs/BareComponent.sol";
+
+// imports for `executeSystemCallback` helper
+import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { ISystem } from "solecs/interfaces/ISystem.sol";
+import { getAddressById } from "solecs/utils.sol";
+
+struct SystemCallback {
+  uint256 systemId;
+  bytes args;
+}
+
+contract SystemCallbackBareComponent is BareComponent {
+  constructor(address world, uint256 id) BareComponent(world, id) {}
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](2);
+    values = new LibTypes.SchemaValue[](2);
+
+    keys[0] = "systemId";
+    values[0] = LibTypes.SchemaValue.UINT256;
+
+    keys[1] = "args";
+    values[1] = LibTypes.SchemaValue.BYTES;
+  }
+
+  function set(uint256 entity, SystemCallback memory value) public virtual {
+    set(entity, abi.encode(value));
+  }
+
+  function getValue(uint256 entity) public view virtual returns (SystemCallback memory) {
+    return abi.decode(getRawValue(entity), (SystemCallback));
+  }
+}
+
+/**
+ * @dev Queries `world.systems()` for `cb.systemId`,
+ * then executes the system with `cb.args`.
+ */
+function executeSystemCallback(IWorld world, SystemCallback memory cb) returns (bytes memory) {
+  ISystem system = ISystem(getAddressById(world.systems(), cb.systemId));
+  return system.execute(cb.args);
+}

--- a/packages/std-contracts/src/components/SystemCallbackComponent.sol
+++ b/packages/std-contracts/src/components/SystemCallbackComponent.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { LibTypes } from "solecs/LibTypes.sol";
+import { Component } from "solecs/Component.sol";
+
+import { SystemCallback, executeSystemCallback } from "./SystemCallbackBareComponent.sol";
+
+contract SystemCallbackComponent is Component {
+  constructor(address world, uint256 id) Component(world, id) {}
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](2);
+    values = new LibTypes.SchemaValue[](2);
+
+    keys[0] = "systemId";
+    values[0] = LibTypes.SchemaValue.UINT256;
+
+    keys[1] = "args";
+    values[1] = LibTypes.SchemaValue.BYTES;
+  }
+
+  function set(uint256 entity, SystemCallback memory value) public virtual {
+    set(entity, abi.encode(value));
+  }
+
+  function getValue(uint256 entity) public view virtual returns (SystemCallback memory) {
+    return abi.decode(getRawValue(entity), (SystemCallback));
+  }
+
+  function getEntitiesWithValue(SystemCallback memory value) public view virtual returns (uint256[] memory) {
+    return getEntitiesWithValue(abi.encode(value));
+  }
+}

--- a/packages/std-contracts/src/test/SystemCallbackComponent.t.sol
+++ b/packages/std-contracts/src/test/SystemCallbackComponent.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { DSTest } from "ds-test/test.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+
+import { World } from "solecs/World.sol";
+import { Uint256BareComponent } from "../components/Uint256BareComponent.sol";
+import { TestSystem } from "./TestSystem.sol";
+import { SystemCallbackComponent } from "../components/SystemCallbackComponent.sol";
+import { SystemCallbackBareComponent, SystemCallback, executeSystemCallback } from "../components/SystemCallbackBareComponent.sol";
+
+contract SystemCallbackComponentTest is DSTest {
+  Vm internal immutable vm = Vm(HEVM_ADDRESS);
+
+  World internal world;
+
+  Uint256BareComponent internal uint256BareComponent;
+  uint256 Uint256BareID = uint256(keccak256("component.Uint256Bare"));
+
+  SystemCallbackBareComponent internal systemCallbackBareComponent;
+  SystemCallbackComponent internal systemCallbackComponent;
+
+  TestSystem internal system;
+  uint256 TestSystemID = uint256(keccak256("system.TestSystem"));
+
+  uint256 internal entity = uint256(keccak256("test entity"));
+  uint256[] internal entities;
+  bytes[] internal values;
+
+  function setUp() public {
+    world = new World();
+    world.init();
+    address worldAddress = address(world);
+
+    uint256BareComponent = new Uint256BareComponent(worldAddress, Uint256BareID);
+    systemCallbackBareComponent = new SystemCallbackBareComponent(
+      worldAddress,
+      uint256(keccak256("component.SystemCallbackBare"))
+    );
+    systemCallbackComponent = new SystemCallbackComponent(worldAddress, uint256(keccak256("component.SystemCallback")));
+
+    system = new TestSystem(world, address(world.components()));
+    world.registerSystem(address(system), TestSystemID);
+    uint256BareComponent.authorizeWriter(address(system));
+
+    // initialize sample values for TestSystem,
+    // which will be called by `executeSystemCallback` to set these values
+    entities = new uint256[](10);
+    values = new bytes[](10);
+    for (uint256 i; i < entities.length; i++) {
+      entities[i] = i;
+      values[i] = abi.encode(i + 10);
+    }
+  }
+
+  function testGetAndExecuteSystemCallbackBare() public {
+    SystemCallback memory cb = SystemCallback({
+      systemId: TestSystemID,
+      args: abi.encode(Uint256BareID, entities, values)
+    });
+    systemCallbackBareComponent.set(entity, cb);
+
+    executeSystemCallback(world, systemCallbackBareComponent.getValue(entity));
+
+    for (uint256 i; i < entities.length; i++) {
+      assertEq(uint256BareComponent.getValue(i), i + 10);
+    }
+  }
+
+  function testGetAndExecuteSystemCallback() public {
+    SystemCallback memory cb = SystemCallback({
+      systemId: TestSystemID,
+      args: abi.encode(Uint256BareID, entities, values)
+    });
+    systemCallbackComponent.set(entity, cb);
+
+    executeSystemCallback(world, systemCallbackComponent.getValue(entity));
+
+    for (uint256 i; i < entities.length; i++) {
+      assertEq(uint256BareComponent.getValue(i), i + 10);
+    }
+  }
+
+  function _cbForGas() internal returns (SystemCallback memory) {
+    // minimize the args so they don't affect gas too much
+    entities = new uint256[](1);
+    values = new bytes[](1);
+    return SystemCallback({ systemId: TestSystemID, args: abi.encode(Uint256BareID, entities, values) });
+  }
+
+  function testSystemCallbackGas() public {
+    uint256 gas;
+    SystemCallback memory cb = _cbForGas();
+
+    // Set
+    gas = gasleft();
+    systemCallbackComponent.set(entity, cb);
+    console.log("Setting a SystemCallback component used %s gas", gas - gasleft());
+    // Get
+    gas = gasleft();
+    cb = systemCallbackComponent.getValue(entity);
+    console.log("Getting a SystemCallback component used %s gas", gas - gasleft());
+    // Update
+    gas = gasleft();
+    systemCallbackComponent.set(entity, cb);
+    console.log("Updating a SystemCallback component used %s gas", gas - gasleft());
+    // Remove
+    gas = gasleft();
+    systemCallbackComponent.remove(entity);
+    console.log("Removing a SystemCallback component used %s gas", gas - gasleft());
+    // Call
+    gas = gasleft();
+    executeSystemCallback(world, cb);
+    console.log("Executing a SystemCallback used %s gas", gas - gasleft());
+  }
+
+  function testSystemCallbackBareGas() public {
+    uint256 gas;
+    SystemCallback memory cb = _cbForGas();
+
+    // Set
+    gas = gasleft();
+    systemCallbackBareComponent.set(entity, cb);
+    console.log("Setting a Bare SystemCallback component used %s gas", gas - gasleft());
+    // Get
+    gas = gasleft();
+    cb = systemCallbackBareComponent.getValue(entity);
+    console.log("Getting a Bare SystemCallback component used %s gas", gas - gasleft());
+    // Update
+    gas = gasleft();
+    systemCallbackBareComponent.set(entity, cb);
+    console.log("Updating a Bare SystemCallback component used %s gas", gas - gasleft());
+    // Remove
+    gas = gasleft();
+    systemCallbackBareComponent.remove(entity);
+    console.log("Removing a Bare SystemCallback component used %s gas", gas - gasleft());
+    // Call
+    gas = gasleft();
+    executeSystemCallback(world, cb);
+    console.log("Executing a SystemCallback used %s gas", gas - gasleft());
+  }
+}

--- a/packages/std-contracts/src/test/TestSystem.sol
+++ b/packages/std-contracts/src/test/TestSystem.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { IComponent } from "solecs/interfaces/IComponent.sol";
+import { System } from "solecs/System.sol";
+import { getAddressById } from "solecs/utils.sol";
+
+uint256 constant ID = uint256(keccak256("lib.testSystem"));
+
+/// @dev Sets values of `entities` to `newValues` for the component with `componentId`
+contract TestSystem is System {
+  constructor(IWorld _world, address _components) System(_world, _components) {}
+
+  function execute(bytes memory args) public returns (bytes memory) {
+    (uint256 componentId, uint256[] memory entities, bytes[] memory newValues) = abi.decode(
+      args,
+      (uint256, uint256[], bytes[])
+    );
+
+    IComponent comp = IComponent(getAddressById(components, componentId));
+
+    for (uint256 i; i < entities.length; i++) {
+      uint256 entity = entities[i];
+      bytes memory newValue = newValues[i];
+      comp.set(entity, newValue);
+    }
+    return "";
+  }
+
+  function executeTyped(
+    uint256 componentId,
+    uint256[] memory entities,
+    bytes[] memory newValues
+  ) public {
+    execute(abi.encode(componentId, entities, newValues));
+  }
+}


### PR DESCRIPTION
FunctionComponent:
- Stores an arbitrary contract's address and a selector to one of its functions.
- You use `staticcallFunctionSelector` with your own arguments to that function.
- If the contract address is a system, an outdated version of it could get called, which could make maintaining a FunctionComponent troublesome.

SystemCallbackComponent:
- Stores a system ID and the arguments for that specific system's execute (note how no address is stored).
- You use `executeSystemCallback` with your own `IWorld` address. You do NOT use your own arguments (although technically you could, but that seems like an antipattern).
- Maintaining a SystemCallbackComponent gets troublesome only if the system's arguments change. Otherwise the system's logic can change seamlessly.
- You do not need to know which system the callback calls, or what the arguments are (however you can inspect them if you want to).

This is designed primarily with Subsystems in mind, however it technically works with any systems and doesn't depend on #268