### PR TITLE
fix(cli): do not copy System test ABIs during build 🧱

### DIFF
--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -38,7 +38,10 @@ export function filterAbi(abiIn = "./out", abiOut = "./abi", exclude: string[] =
   console.log("Selected ABIs: ", contracts);
 
   // Move selected ABIs to ./abi
-  for (const contract of contracts) copyAbi(abiIn, abiOut, contract);
+  for (const contract of contracts) {
+    if (contract.includes(".t")) continue;
+    copyAbi(abiIn, abiOut, contract);
+  }
 
   console.log("Successfully moved selected ABIs to ./abi");
 }


### PR DESCRIPTION
i thought this was fixed at some point, but it's still happening for me. lmk if there is a better way to fix this.