### PR TITLE
feat(std-contracts): add Uint256SetBareComponent

### DIFF
--- a/packages/solecs/README.md
+++ b/packages/solecs/README.md
@@ -77,7 +77,7 @@ Everyone has read access.
 For convenience the component implementation in `solecs` also includes a reverse mapping from `keccak256(value)` to set of entities with this value, but this is not strictly required and might change in a future release.
 
 ```solidity
-interface IComponent is IERC173 {
+interface IComponent is IOwnableWritable {
   /** Return the keys and value types of the schema of this component. */
   function getSchema() external pure returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
 
@@ -94,10 +94,6 @@ interface IComponent is IERC173 {
   function getEntitiesWithValue(bytes memory value) external view returns (uint256[] memory);
 
   function registerIndexer(address indexer) external;
-
-  function authorizeWriter(address writer) external;
-
-  function unauthorizeWriter(address writer) external;
 }
 
 ```

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rari-capital/solmate": "https://github.com/Rari-Capital/solmate.git#b6ae78e6ff490f8fec7695c7b65d06e5614f1b65",
-    "@solidstate/contracts": "^0.0.48",
+    "@solidstate/contracts": "^0.0.52",
     "@typechain/ethers-v5": "^9.0.0",
     "@types/mocha": "^9.1.1",
     "ds-test": "https://github.com/dapphub/ds-test.git#c7a36fb236f298e04edf28e2fee385b80f53945f",

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@rari-capital/solmate": "https://github.com/Rari-Capital/solmate.git#b6ae78e6ff490f8fec7695c7b65d06e5614f1b65",
+    "@solidstate/contracts": "^0.0.48",
     "@typechain/ethers-v5": "^9.0.0",
     "@types/mocha": "^9.1.1",
     "ds-test": "https://github.com/dapphub/ds-test.git#c7a36fb236f298e04edf28e2fee385b80f53945f",

--- a/packages/solecs/remappings.txt
+++ b/packages/solecs/remappings.txt
@@ -2,3 +2,4 @@ memmove/=../../node_modules/memmove/src/
 ds-test/=../../node_modules/ds-test/src/
 forge-std/=../../node_modules/forge-std/src/
 solmate/=../../node_modules/@rari-capital/solmate/src
+@solidstate/=../../node_modules/@solidstate/

--- a/packages/solecs/src/AbstractComponent.sol
+++ b/packages/solecs/src/AbstractComponent.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "./interfaces/IWorld.sol";
+import { IComponent } from "./interfaces/IComponent.sol";
+
+import { OwnableWritable } from "./OwnableWritable.sol";
+
+/**
+ * Components are a key-value store from entity id to component value.
+ * They are registered in the World and register updates to their state in the World.
+ * They have an owner, who can grant write access to more addresses.
+ * (Systems that want to write to a component need to be given write access first.)
+ * Everyone has read access.
+ */
+abstract contract AbstractComponent is IComponent, OwnableWritable {
+  /** Reference to the World contract this component is registered in */
+  address public world;
+
+  /** Public identifier of this component */
+  uint256 public id;
+
+  error AbstractComponent__NotImplemented();
+
+  constructor(address _world, uint256 _id) {
+    id = _id;
+    if (_world != address(0)) registerWorld(_world);
+  }
+
+  /**
+   * Register this component in the given world.
+   * @param _world Address of the World contract.
+   */
+  function registerWorld(address _world) public onlyOwner {
+    world = _world;
+    IWorld(world).registerComponent(address(this), id);
+  }
+
+  /**
+   * Set the given component value for the given entity.
+   * Registers the update in the World contract.
+   * Can only be called by addresses with write access to this component.
+   * @param entity Entity to set the value for.
+   * @param value Value to set for the given entity.
+   */
+  function set(uint256 entity, bytes memory value) public override onlyWriter {
+    _set(entity, value);
+  }
+
+  /**
+   * Remove the given entity from this component.
+   * Registers the update in the World contract.
+   * Can only be called by addresses with write access to this component.
+   * @param entity Entity to remove from this component.
+   */
+  function remove(uint256 entity) public override onlyWriter {
+    _remove(entity);
+  }
+
+  /**
+   * Set the given component value for the given entity.
+   * Registers the update in the World contract.
+   * Can only be called internally (by the component or contracts deriving from it),
+   * without requiring explicit write access.
+   * @param entity Entity to set the value for.
+   * @param value Value to set for the given entity.
+   */
+  function _set(uint256 entity, bytes memory value) internal virtual;
+
+  /**
+   * Remove the given entity from this component.
+   * Registers the update in the World contract.
+   * Can only be called internally (by the component or contracts deriving from it),
+   * without requiring explicit write access.
+   * @param entity Entity to remove from this component.
+   */
+  function _remove(uint256 entity) internal virtual;
+
+  /** Not implemented in AbstractComponent */
+  function getEntities() public view virtual override returns (uint256[] memory) {
+    revert AbstractComponent__NotImplemented();
+  }
+
+  /** Not implemented in AbstractComponent */
+  function getEntitiesWithValue(bytes memory) public view virtual override returns (uint256[] memory) {
+    revert AbstractComponent__NotImplemented();
+  }
+
+  /** Not implemented in AbstractComponent */
+  function registerIndexer(address) external virtual override {
+    revert AbstractComponent__NotImplemented();
+  }
+}

--- a/packages/solecs/src/BareComponent.sol
+++ b/packages/solecs/src/BareComponent.sol
@@ -8,6 +8,8 @@ import { Set } from "./Set.sol";
 import { MapSet } from "./MapSet.sol";
 import { LibTypes } from "./LibTypes.sol";
 
+import { OwnableWritable } from "./OwnableWritable.sol";
+
 /**
  * Components are a key-value store from entity id to component value.
  * They are registered in the World and register updates to their state in the World.
@@ -15,17 +17,11 @@ import { LibTypes } from "./LibTypes.sol";
  * (Systems that want to write to a component need to be given write access first.)
  * Everyone has read access.
  */
-abstract contract BareComponent is IComponent {
+abstract contract BareComponent is IComponent, OwnableWritable {
   error BareComponent__NotImplemented();
 
   /** Reference to the World contract this component is registered in */
   address public world;
-
-  /** Owner of the component has write access and can given write access to other addresses */
-  address internal _owner;
-
-  /** Addresses with write access to this component */
-  mapping(address => bool) public writeAccess;
 
   /** Mapping from entity id to value in this component */
   mapping(uint256 => bytes) internal entityToValue;
@@ -34,39 +30,8 @@ abstract contract BareComponent is IComponent {
   uint256 public id;
 
   constructor(address _world, uint256 _id) {
-    _owner = msg.sender;
-    writeAccess[msg.sender] = true;
     id = _id;
     if (_world != address(0)) registerWorld(_world);
-  }
-
-  /** Revert if caller is not the owner of this component */
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
-
-  /** Revert if caller does not have write access to this component */
-  modifier onlyWriter() {
-    require(writeAccess[msg.sender], "ONLY_WRITER");
-    _;
-  }
-
-  /** Get the owner of this component */
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  /**
-   * Transfer ownership of this component to a new owner.
-   * Can only be called by the current owner.
-   * @param newOwner Address of the new owner.
-   */
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    writeAccess[msg.sender] = false;
-    _owner = newOwner;
-    writeAccess[newOwner] = true;
   }
 
   /**
@@ -129,24 +94,6 @@ abstract contract BareComponent is IComponent {
   /** Not implemented in BareComponent */
   function registerIndexer(address) external virtual override {
     revert BareComponent__NotImplemented();
-  }
-
-  /**
-   * Grant write access to this component to the given address.
-   * Can only be called by the owner of this component.
-   * @param writer Address to grant write access to.
-   */
-  function authorizeWriter(address writer) public override onlyOwner {
-    writeAccess[writer] = true;
-  }
-
-  /**
-   * Revoke write access to this component to the given address.
-   * Can only be called by the owner of this component.
-   * @param writer Address to revoke write access .
-   */
-  function unauthorizeWriter(address writer) public override onlyOwner {
-    delete writeAccess[writer];
   }
 
   /**

--- a/packages/solecs/src/LibQuery.sol
+++ b/packages/solecs/src/LibQuery.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
+
 import { IComponent } from "./interfaces/IComponent.sol";
 import { QueryFragment, QueryType } from "./interfaces/Query.sol";
-import "memmove/LinkedList.sol";
+import { LinkedList, LinkedListLib } from "memmove/LinkedList.sol";
 
 struct Uint256Node {
   uint256 value;

--- a/packages/solecs/src/MapSet.sol
+++ b/packages/solecs/src/MapSet.sol
@@ -1,22 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * Key value store with uint256 key and uint256 Set value
  */
-contract MapSet {
-  address private owner;
+contract MapSet is Ownable {
   mapping(uint256 => uint256[]) internal items;
   mapping(uint256 => mapping(uint256 => uint256)) internal itemToIndex;
-
-  constructor() {
-    owner = msg.sender;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "ONLY_OWNER");
-    _;
-  }
 
   function add(uint256 setKey, uint256 item) public onlyOwner {
     if (has(setKey, item)) return;

--- a/packages/solecs/src/Ownable.sol
+++ b/packages/solecs/src/Ownable.sol
@@ -8,8 +8,6 @@ import { OwnableStorage } from "@solidstate/contracts/access/ownable/OwnableStor
  * IERC173 implementation
  */
 contract Ownable is SolidStateOwnable {
-  using OwnableStorage for OwnableStorage.Layout;
-
   constructor() {
     // Initialize owner (SolidState has no constructors)
     OwnableStorage.layout().owner = msg.sender;

--- a/packages/solecs/src/Ownable.sol
+++ b/packages/solecs/src/Ownable.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { Ownable as SolidStateOwnable } from "@solidstate/contracts/access/ownable/Ownable.sol";
+import { OwnableStorage } from "@solidstate/contracts/access/ownable/OwnableStorage.sol";
+
+/**
+ * IERC173 implementation
+ */
+contract Ownable is SolidStateOwnable {
+  using OwnableStorage for OwnableStorage.Layout;
+
+  constructor() {
+    // Initialize owner (SolidState has no constructors)
+    OwnableStorage.layout().setOwner(msg.sender);
+  }
+}

--- a/packages/solecs/src/Ownable.sol
+++ b/packages/solecs/src/Ownable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 import { Ownable as SolidStateOwnable } from "@solidstate/contracts/access/ownable/Ownable.sol";

--- a/packages/solecs/src/Ownable.sol
+++ b/packages/solecs/src/Ownable.sol
@@ -12,6 +12,6 @@ contract Ownable is SolidStateOwnable {
 
   constructor() {
     // Initialize owner (SolidState has no constructors)
-    OwnableStorage.layout().setOwner(msg.sender);
+    OwnableStorage.layout().owner = msg.sender;
   }
 }

--- a/packages/solecs/src/OwnableWritable.sol
+++ b/packages/solecs/src/OwnableWritable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 import { IOwnableWritable } from "./interfaces/IOwnableWritable.sol";

--- a/packages/solecs/src/OwnableWritable.sol
+++ b/packages/solecs/src/OwnableWritable.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IOwnableWritable } from "./interfaces/IOwnableWritable.sol";
+
+import { Ownable } from "./Ownable.sol";
+import { OwnableWritableStorage } from "./OwnableWritableStorage.sol";
+
+/**
+ * Ownable with authorized writers
+ */
+abstract contract OwnableWritable is IOwnableWritable, Ownable {
+  error OwnableWritable__NotWriter();
+
+  /** Whether given operator has write access */
+  function writeAccess(address operator) public view returns (bool) {
+    return OwnableWritableStorage.layout().writeAccess[operator] || operator == owner();
+  }
+
+  /** Revert if caller does not have write access to this component */
+  modifier onlyWriter() {
+    if (!writeAccess(msg.sender)) {
+      revert OwnableWritable__NotWriter();
+    }
+    _;
+  }
+
+  /**
+   * Grant write access to the given address.
+   * Can only be called by the owner.
+   * @param writer Address to grant write access to.
+   */
+  function authorizeWriter(address writer) public onlyOwner {
+    OwnableWritableStorage.layout().writeAccess[writer] = true;
+  }
+
+  /**
+   * Revoke write access from the given address.
+   * Can only be called by the owner.
+   * @param writer Address to revoke write access.
+   */
+  function unauthorizeWriter(address writer) public onlyOwner {
+    delete OwnableWritableStorage.layout().writeAccess[writer];
+  }
+}

--- a/packages/solecs/src/OwnableWritableStorage.sol
+++ b/packages/solecs/src/OwnableWritableStorage.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+library OwnableWritableStorage {
+  struct Layout {
+    /** Addresses with write access */
+    mapping(address => bool) writeAccess;
+  }
+
+  bytes32 internal constant STORAGE_SLOT = keccak256("solecs.contracts.storage.OwnableWritable");
+
+  function layout() internal pure returns (Layout storage l) {
+    bytes32 slot = STORAGE_SLOT;
+    assembly {
+      l.slot := slot
+    }
+  }
+}

--- a/packages/solecs/src/OwnableWritableStorage.sol
+++ b/packages/solecs/src/OwnableWritableStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 library OwnableWritableStorage {

--- a/packages/solecs/src/PayableSystem.sol
+++ b/packages/solecs/src/PayableSystem.sol
@@ -5,31 +5,17 @@ import { IPayableSystem } from "./interfaces/IPayableSystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { IWorld } from "./interfaces/IWorld.sol";
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * System base contract
  */
-abstract contract PayableSystem is IPayableSystem {
+abstract contract PayableSystem is IPayableSystem, Ownable {
   IUint256Component components;
   IWorld world;
-  address _owner;
-
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
 
   constructor(IWorld _world, address _components) {
-    _owner = msg.sender;
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
-  }
-
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    _owner = newOwner;
   }
 }

--- a/packages/solecs/src/Set.sol
+++ b/packages/solecs/src/Set.sol
@@ -1,22 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * Set of unique uint256
  */
-contract Set {
-  address private owner;
+contract Set is Ownable {
   uint256[] internal items;
   mapping(uint256 => uint256) internal itemToIndex;
-
-  constructor() {
-    owner = msg.sender;
-  }
-
-  modifier onlyOwner() {
-    require(msg.sender == owner, "ONLY_OWNER");
-    _;
-  }
 
   function add(uint256 item) public onlyOwner {
     if (has(item)) return;

--- a/packages/solecs/src/System.sol
+++ b/packages/solecs/src/System.sol
@@ -5,31 +5,17 @@ import { ISystem } from "./interfaces/ISystem.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { IWorld } from "./interfaces/IWorld.sol";
 
+import { Ownable } from "./Ownable.sol";
+
 /**
  * System base contract
  */
-abstract contract System is ISystem {
+abstract contract System is ISystem, Ownable {
   IUint256Component components;
   IWorld world;
-  address _owner;
-
-  modifier onlyOwner() {
-    require(msg.sender == _owner, "ONLY_OWNER");
-    _;
-  }
 
   constructor(IWorld _world, address _components) {
-    _owner = msg.sender;
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
-  }
-
-  function owner() public view override returns (address) {
-    return _owner;
-  }
-
-  function transferOwnership(address newOwner) public override onlyOwner {
-    emit OwnershipTransferred(_owner, newOwner);
-    _owner = newOwner;
   }
 }

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Set } from "./Set.sol";
 import { LibQuery } from "./LibQuery.sol";
 import { IWorld, WorldQueryFragment } from "./interfaces/IWorld.sol";

--- a/packages/solecs/src/components/Uint256Component.sol
+++ b/packages/solecs/src/components/Uint256Component.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
-import "../Component.sol";
-import "../interfaces/IUint256Component.sol";
+
+import { Component } from "../Component.sol";
+import { LibTypes } from "../LibTypes.sol";
+import { IUint256Component } from "../interfaces/IUint256Component.sol";
 
 /**
  * Reference implementation of a component storing a uint256 value for each entity.

--- a/packages/solecs/src/interfaces/IComponent.sol
+++ b/packages/solecs/src/interfaces/IComponent.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import { IERC173 } from "./IERC173.sol";
+import { IOwnableWritable } from "./IOwnableWritable.sol";
 import { LibTypes } from "../LibTypes.sol";
 
-interface IComponent is IERC173 {
+interface IComponent is IOwnableWritable {
   /** Return the keys and value types of the schema of this component. */
   function getSchema() external pure returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
 
@@ -21,10 +21,6 @@ interface IComponent is IERC173 {
   function getEntitiesWithValue(bytes memory value) external view returns (uint256[] memory);
 
   function registerIndexer(address indexer) external;
-
-  function authorizeWriter(address writer) external;
-
-  function unauthorizeWriter(address writer) external;
 
   function world() external view returns (address);
 }

--- a/packages/solecs/src/interfaces/IERC165.sol
+++ b/packages/solecs/src/interfaces/IERC165.sol
@@ -1,12 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IERC165 {
-  /// @notice Query if a contract implements an interface
-  /// @param interfaceId The interface identifier, as specified in ERC-165
-  /// @dev Interface identification is specified in ERC-165. This function
-  ///  uses less than 30,000 gas.
-  /// @return `true` if the contract implements `interfaceID` and
-  ///  `interfaceID` is not 0xffffffff, `false` otherwise
-  function supportsInterface(bytes4 interfaceId) external view returns (bool);
-}
+import { IERC165 } from "@solidstate/contracts/interfaces/IERC165.sol";

--- a/packages/solecs/src/interfaces/IERC173.sol
+++ b/packages/solecs/src/interfaces/IERC173.sol
@@ -1,24 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-/**
- * @title ERC-173 Contract ownership standard
- * @dev see https://eips.ethereum.org/EIPS/eip-173
- */
-interface IERC173 {
-  /** @dev This emits when ownership of a contract changes. */
-  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
-  /**
-   * @notice Get the address of the owner
-   * @return The address of the owner.
-   */
-  function owner() external view returns (address);
-
-  /**
-   * @notice Set the address of the new owner of the contract
-   * @dev Set _newOwner to address(0) to renounce any ownership.
-   * @param _newOwner The address of the new owner of the contract
-   */
-  function transferOwnership(address _newOwner) external;
-}
+import { IERC173 } from "@solidstate/contracts/interfaces/IERC173.sol";

--- a/packages/solecs/src/interfaces/IOwnableWritable.sol
+++ b/packages/solecs/src/interfaces/IOwnableWritable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.0;
+
+import { IERC173 } from "./IERC173.sol";
+
+interface IOwnableWritable is IERC173 {
+  function authorizeWriter(address writer) external;
+
+  function unauthorizeWriter(address writer) external;
+}

--- a/packages/solecs/src/interfaces/IOwnableWritable.sol
+++ b/packages/solecs/src/interfaces/IOwnableWritable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
 import { IERC173 } from "./IERC173.sol";

--- a/packages/solecs/src/interfaces/IPayableSystem.sol
+++ b/packages/solecs/src/interfaces/IPayableSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "./IERC173.sol";
+import { IERC173 } from "./IERC173.sol";
 
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.

--- a/packages/solecs/src/interfaces/ISystem.sol
+++ b/packages/solecs/src/interfaces/ISystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import "./IERC173.sol";
+import { IERC173 } from "./IERC173.sol";
 
 // The minimum requirement for a system is to have an `execute` function.
 // For convenience having an `executeTyped` function with typed arguments is recommended.

--- a/packages/solecs/src/interfaces/IWorld.sol
+++ b/packages/solecs/src/interfaces/IWorld.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { QueryType } from "./Query.sol";
 import { IUint256Component } from "./IUint256Component.sol";
 

--- a/packages/solecs/src/interfaces/Query.sol
+++ b/packages/solecs/src/interfaces/Query.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.13;
+
 import { IComponent } from "./IComponent.sol";
 import { LinkedList } from "memmove/LinkedList.sol";
 

--- a/packages/solecs/src/systems/RegisterSystem.sol
+++ b/packages/solecs/src/systems/RegisterSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { ISystem } from "../interfaces/ISystem.sol";
 import { IWorld } from "../interfaces/IWorld.sol";
 import { IERC173 } from "../interfaces/IERC173.sol";

--- a/packages/solecs/tasks/compile.ts
+++ b/packages/solecs/tasks/compile.ts
@@ -10,6 +10,7 @@ subtask(TASK_COMPILE_SOLIDITY).setAction(async (_: { force: boolean; quiet: bool
     .readFileSync("remappings.txt")
     .toString()
     .split("\n")
+    .filter((r) => r.length > 0)
     .map((r) => r.split("="));
 
   console.log("remappings", remappings);

--- a/packages/std-contracts/remappings.txt
+++ b/packages/std-contracts/remappings.txt
@@ -3,3 +3,4 @@ ds-test/=../../node_modules/ds-test/src/
 forge-std/=../../node_modules/forge-std/src/
 solmate/=../../node_modules/@rari-capital/solmate/src
 solecs/=../../node_modules/@latticexyz/solecs/src/
+@solidstate/=../../node_modules/@solidstate/

--- a/packages/std-contracts/src/MapSetExtended.sol
+++ b/packages/std-contracts/src/MapSetExtended.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { MapSet } from "solecs/MapSet.sol";
+
+/**
+ * MapSet with batch removal/replacement of values for given key
+ */
+contract MapSetExtended is MapSet {
+  function removeAll(uint256 setKey) public onlyOwner {
+    if (size(setKey) == 0) return;
+
+    uint256 length = items[setKey].length;
+    for (uint256 i; i < length; i++) {
+      // Remove each item's stored index
+      delete itemToIndex[setKey][items[setKey][i]];
+    }
+
+    // Remove the list of items
+    delete items[setKey];
+  }
+
+  function replaceAll(uint256 setKey, uint256[] calldata _items) public onlyOwner {
+    removeAll(setKey);
+
+    items[setKey] = _items;
+
+    for (uint256 i; i < _items.length; i++) {
+      itemToIndex[setKey][_items[i]] = i;
+    }
+  }
+}

--- a/packages/std-contracts/src/components/Uint256SetBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256SetBareComponent.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "solecs/interfaces/IWorld.sol";
+import { LibTypes } from "solecs/LibTypes.sol";
+import { AbstractComponent } from "solecs/AbstractComponent.sol";
+
+import { MapSetExtended } from "../MapSetExtended.sol";
+
+/**
+ * An alternative to Uint256ArrayBareComponent,
+ * hasItem allows checking existence in O(1) instead of reading the whole array.
+ *
+ * There's also addItem and removeItem, which don't write the whole array
+ * (though they still read it all for world value registration).
+ */
+contract Uint256SetBareComponent is AbstractComponent {
+  MapSetExtended internal entityToItemSet;
+
+  constructor(address _world, uint256 _id) AbstractComponent(_world, _id) {
+    entityToItemSet = new MapSetExtended();
+  }
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](1);
+    values = new LibTypes.SchemaValue[](1);
+
+    keys[0] = "value";
+    values[0] = LibTypes.SchemaValue.UINT256_ARRAY;
+  }
+
+  /**
+   * Replace the whole set.
+   * Use addItem to add individual items.
+   */
+  function set(uint256 entity, uint256[] memory value) public onlyWriter {
+    _set(entity, value);
+  }
+
+  /**
+   * Check whether the given entity has a value in this component.
+   * @param entity Entity to check whether it has a value in this component for.
+   */
+  function has(uint256 entity) public view virtual override returns (bool) {
+    return itemSetSize(entity) != 0;
+  }
+
+  /**
+   * Get the size of the given entity's item set.
+   * @dev Set-specific
+   */
+  function itemSetSize(uint256 entity) public view virtual returns (uint256) {
+    return entityToItemSet.size(entity);
+  }
+
+  /**
+   * Get the raw (abi-encoded) value of the given entity in this component.
+   * @param entity Entity to get the raw value in this component for.
+   */
+  function getRawValue(uint256 entity) public view virtual override returns (bytes memory) {
+    return abi.encode(getValue(entity));
+  }
+
+  /**
+   * Get all items in the set as an array.
+   */
+  function getValue(uint256 entity) public view virtual returns (uint256[] memory) {
+    return entityToItemSet.getItems(entity);
+  }
+
+  /**
+   * Check if the set has `item`.
+   * @dev Set-specific
+   */
+  function hasItem(uint256 entity, uint256 item) public view virtual returns (bool) {
+    return entityToItemSet.has(entity, item);
+  }
+
+  /**
+   * Add `item` to the set.
+   * @dev Set-specific
+   */
+  function addItem(uint256 entity, uint256 item) public onlyWriter {
+    _addItem(entity, item);
+  }
+
+  /**
+   * Remove `item` from the set.
+   * @dev Set-specific
+   */
+  function removeItem(uint256 entity, uint256 item) public onlyWriter {
+    _removeItem(entity, item);
+  }
+
+  /**
+   * @inheritdoc AbstractComponent
+   */
+  function _set(uint256 entity, bytes memory value) internal virtual override {
+    _set(entity, abi.decode(value, (uint256[])));
+  }
+
+  function _set(uint256 entity, uint256[] memory items) internal virtual {
+    entityToItemSet.replaceAll(entity, items);
+
+    IWorld(world).registerComponentValueSet(entity, abi.encode(items));
+  }
+
+  function _remove(uint256 entity) internal virtual override {
+    entityToItemSet.removeAll(entity);
+
+    IWorld(world).registerComponentValueRemoved(entity);
+  }
+
+  /**
+   * Add `item` to the set.
+   * @dev Set-specific
+   */
+  function _addItem(uint256 entity, uint256 item) internal virtual {
+    if (hasItem(entity, item)) {
+      // item is already in set
+      return;
+    }
+
+    entityToItemSet.add(entity, item);
+
+    IWorld(world).registerComponentValueSet(entity, abi.encode(entityToItemSet.getItems(entity)));
+  }
+
+  /**
+   * Remove `item` from the set.
+   * @dev Set-specific
+   */
+  function _removeItem(uint256 entity, uint256 item) internal virtual {
+    if (!hasItem(entity, item)) {
+      // item is not in set
+      return;
+    }
+
+    entityToItemSet.remove(entity, item);
+
+    IWorld(world).registerComponentValueSet(entity, abi.encode(entityToItemSet.getItems(entity)));
+  }
+}

--- a/packages/std-contracts/tasks/compile.ts
+++ b/packages/std-contracts/tasks/compile.ts
@@ -10,6 +10,7 @@ subtask(TASK_COMPILE_SOLIDITY).setAction(async (_: { force: boolean; quiet: bool
     .readFileSync("remappings.txt")
     .toString()
     .split("\n")
+    .filter((r) => r.length > 0)
     .map((r) => r.split("="));
 
   console.log("remappings", remappings);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,6 +3248,11 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
+"@solidstate/contracts@^0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@solidstate/contracts/-/contracts-0.0.48.tgz#c97eb44cec623a388c67e2b36b404df3d46cf6ed"
+  integrity sha512-egof846MhC1lo+C8MJPmvte2xOjGEIbHcEB4G2H1ysC51F3xd81WZOTB/w+irylBSBK+HQE2uxhVW8QlUTBcEQ==
+
 "@swc/helpers@^0.4.2":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.11.tgz#db23a376761b3d31c26502122f349a21b592c8de"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,10 +3248,10 @@
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
-"@solidstate/contracts@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.yarnpkg.com/@solidstate/contracts/-/contracts-0.0.48.tgz#c97eb44cec623a388c67e2b36b404df3d46cf6ed"
-  integrity sha512-egof846MhC1lo+C8MJPmvte2xOjGEIbHcEB4G2H1ysC51F3xd81WZOTB/w+irylBSBK+HQE2uxhVW8QlUTBcEQ==
+"@solidstate/contracts@^0.0.52":
+  version "0.0.52"
+  resolved "https://registry.yarnpkg.com/@solidstate/contracts/-/contracts-0.0.52.tgz#cfe7e2ef237421f6e150927d7338c1ef02daa7b8"
+  integrity sha512-xSBn5oLnfYtgNYrsRq/COlWHt0NxK26PFQ3FvI2DDMAFpZKFsffGLzUl8umezj2gVKpN7EZ+EVLdPKjqx6eUOw==
 
 "@swc/helpers@^0.4.2":
   version "0.4.11"


### PR DESCRIPTION
Follow-up to #267

SetComponent is useful for some many-to-many relationships
(they can also be solved via just more components, but that can get very inconvenient and complicated very fast)

Examples of how I use it:
[LearnedSkillsComponent](https://github.com/dk1a/wanderer-cycle/blob/8b4cdc32d17e711a3f60162a59e23057e1a64510/packages/contracts/src/skill/LearnedSkillsComponent.sol)
[GuiseSkillsComponent](https://github.com/dk1a/wanderer-cycle/blob/8b4cdc32d17e711a3f60162a59e23057e1a64510/packages/contracts/src/guise/GuiseSkillsComponent.sol)
[EquipmentSlotAllowedComponent](https://github.com/dk1a/wanderer-cycle/blob/8b4cdc32d17e711a3f60162a59e23057e1a64510/packages/contracts/src/equipment/EquipmentSlotAllowedComponent.sol)
[AffixAvailabilityComponent](https://github.com/dk1a/wanderer-cycle/blob/8b4cdc32d17e711a3f60162a59e23057e1a64510/packages/contracts/src/affix/AffixAvailabilityComponent.sol)

With skills for example, a set component is handy to avoid instantiating unique skill entities for each character