### PR TITLE
feat(std-contracts): built-in hasValue() for string components

### DIFF
--- a/packages/std-contracts/src/components/StringBareComponent.sol
+++ b/packages/std-contracts/src/components/StringBareComponent.sol
@@ -21,4 +21,8 @@ contract StringBareComponent is BareComponent {
     string memory value = abi.decode(getRawValue(entity), (string));
     return value;
   }
+
+  function hasValue(uint256 id, string memory value) public view returns (bool) {
+    return keccak256(getRawValue(id)) == keccak256(abi.encode(value));
+  }
 }

--- a/packages/std-contracts/src/components/StringComponent.sol
+++ b/packages/std-contracts/src/components/StringComponent.sol
@@ -25,4 +25,8 @@ contract StringComponent is Component {
   function getEntitiesWithValue(string memory value) public view virtual returns (uint256[] memory) {
     return getEntitiesWithValue(abi.encode(value));
   }
+
+  function hasValue(uint256 id, string memory value) public view returns (bool) {
+    return keccak256(getRawValue(id)) == keccak256(abi.encode(value));
+  }
 }


### PR DESCRIPTION
Just a bit of a verbose check that seems to be getting used somewhat
frequently on our end. Feel free to ignore and close if there was a good
reason not to include this.
