### PR TITLE
feat: add ApprovalSystem

### DIFF
--- a/packages/solecs/src/ExternalSystem.sol
+++ b/packages/solecs/src/ExternalSystem.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "./interfaces/IWorld.sol";
+
+import { System } from "./System.sol";
+
+/**
+ * @title System with preconfigured external endpoints.
+ */
+abstract contract ExternalSystem is System {
+  constructor(IWorld _world, address _components) System(_world, _components) {}
+
+  /**
+   * @dev Execute as `msg.sender`
+   */
+  function execute(bytes memory args) public returns (bytes memory) {
+    // TODO remove return
+    return _execute(msg.sender, args);
+  }
+
+  /**
+   * @dev Check if `msg.sender` has approval from `from`, then execute as `from`
+   */
+  function executeFrom(address from, bytes memory args) public {
+    requireApproved(from, args);
+    _execute(from, args);
+  }
+
+  /**
+   * @dev Check if `msg.sender` has approval from `this` (the system itself), then execute as `from`.
+   */
+  function executeInternal(address from, bytes memory args) public {
+    requireApproved(address(this), args);
+    _execute(from, args);
+  }
+
+  function _execute(address from, bytes memory args) internal virtual returns (bytes memory);
+}

--- a/packages/solecs/src/Subsystem.sol
+++ b/packages/solecs/src/Subsystem.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "./interfaces/IWorld.sol";
+
+import { System } from "./System.sol";
+
+/**
+ * @title Internal system template.
+ */
+abstract contract Subsystem is System {
+  constructor(IWorld _world, address _components) System(_world, _components) {}
+
+  function requireApproved() internal {
+    bytes memory emptyArgs;
+    requireApproved(address(this), emptyArgs);
+  }
+}

--- a/packages/solecs/src/System.sol
+++ b/packages/solecs/src/System.sol
@@ -18,4 +18,21 @@ abstract contract System is ISystem, Ownable {
     components = _components == address(0) ? _world.components() : IUint256Component(_components);
     world = _world;
   }
+
+  function requireApproved(address grantor, bytes memory args) internal {
+    address grantee = msg.sender;
+    if (grantor != grantee) {
+      // reverts if not approved
+      world.approval().reduceApproval(grantor, grantee, args);
+    }
+  }
+
+  modifier onlyApproved(address grantor, bytes memory args) {
+    address grantee = msg.sender;
+    if (grantor != grantee) {
+      // reverts if not approved
+      world.approval().reduceApproval(grantor, grantee, args);
+    }
+    _;
+  }
 }

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -4,12 +4,14 @@ pragma solidity >=0.8.0;
 import { Set } from "./Set.sol";
 import { LibQuery } from "./LibQuery.sol";
 import { IWorld, WorldQueryFragment } from "./interfaces/IWorld.sol";
+import { IApprovalSystem } from "./interfaces/IApprovalSystem.sol";
 import { QueryFragment } from "./interfaces/Query.sol";
 import { IUint256Component } from "./interfaces/IUint256Component.sol";
 import { Uint256Component } from "./components/Uint256Component.sol";
 import { addressToEntity, entityToAddress, getIdByAddress, getAddressById, getComponentById } from "./utils.sol";
 import { componentsComponentId, systemsComponentId } from "./constants.sol";
 import { RegisterSystem, ID as registerSystemId, RegisterType } from "./systems/RegisterSystem.sol";
+import { ApprovalSystem, ID as approvalSystemId } from "./systems/ApprovalSystem.sol";
 
 /**
  * The `World` contract is at the core of every on-chain world.
@@ -31,6 +33,7 @@ contract World is IWorld {
   Uint256Component private _components;
   Uint256Component private _systems;
   RegisterSystem public register;
+  ApprovalSystem internal _approval;
 
   event ComponentValueSet(uint256 indexed componentId, address indexed component, uint256 indexed entity, bytes data);
   event ComponentValueRemoved(uint256 indexed componentId, address indexed component, uint256 indexed entity);
@@ -41,6 +44,7 @@ contract World is IWorld {
     register = new RegisterSystem(this, address(_components));
     _systems.authorizeWriter(address(register));
     _components.authorizeWriter(address(register));
+    _approval = new ApprovalSystem(this, address(_components));
   }
 
   /**
@@ -67,6 +71,10 @@ contract World is IWorld {
    */
   function systems() public view returns (IUint256Component) {
     return _systems;
+  }
+
+  function approval() public view returns (IApprovalSystem) {
+    return _approval;
   }
 
   /**

--- a/packages/solecs/src/components/ApprovalComponent.sol
+++ b/packages/solecs/src/components/ApprovalComponent.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "../interfaces/IWorld.sol";
+import { Approval } from "../interfaces/IApprovalSystem.sol";
+import { BareComponent } from "../BareComponent.sol";
+import { LibTypes } from "../LibTypes.sol";
+
+contract ApprovalComponent is BareComponent {
+  constructor(address world, uint256 id) BareComponent(world, id) {}
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](3);
+    values = new LibTypes.SchemaValue[](3);
+
+    keys[0] = "expiryTimestamp";
+    values[0] = LibTypes.SchemaValue.UINT128;
+
+    keys[1] = "numCalls";
+    values[1] = LibTypes.SchemaValue.UINT128;
+
+    keys[2] = "args";
+    values[2] = LibTypes.SchemaValue.BYTES;
+  }
+
+  function set(uint256 entity, Approval memory value) public virtual {
+    set(entity, abi.encode(value));
+  }
+
+  function getValue(uint256 entity) public view virtual returns (Approval memory value) {
+    // ensure getValue always succeeds; the caller is then responsible for checking empty values
+    bytes memory rawValue = getRawValue(entity);
+    if (rawValue.length == 0) {
+      return value;
+    }
+    value = abi.decode(rawValue, (Approval));
+    return value;
+  }
+}

--- a/packages/solecs/src/components/ApprovalEntityReversalComponent.sol
+++ b/packages/solecs/src/components/ApprovalEntityReversalComponent.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "../interfaces/IWorld.sol";
+import { BareComponent } from "../BareComponent.sol";
+import { LibTypes } from "../LibTypes.sol";
+
+struct ApprovalEntityReversal {
+  address grantor;
+  address grantee;
+  uint256 systemId;
+}
+
+/// @title Reverse mapping of approvalEntity to its hashed values.
+/// @dev It's important to know which approvals belong to which grantors, so they can be revoked.
+contract ApprovalEntityReversalComponent is BareComponent {
+  constructor(address world, uint256 id) BareComponent(world, id) {}
+
+  function getSchema() public pure override returns (string[] memory keys, LibTypes.SchemaValue[] memory values) {
+    keys = new string[](3);
+    values = new LibTypes.SchemaValue[](3);
+
+    keys[0] = "grantor";
+    values[0] = LibTypes.SchemaValue.ADDRESS;
+
+    keys[1] = "grantee";
+    values[1] = LibTypes.SchemaValue.ADDRESS;
+
+    keys[2] = "systemId";
+    values[2] = LibTypes.SchemaValue.UINT256;
+  }
+
+  function set(uint256 entity, ApprovalEntityReversal memory value) public virtual {
+    set(entity, abi.encode(value));
+  }
+
+  function getValue(uint256 entity) public view virtual returns (ApprovalEntityReversal memory) {
+    return abi.decode(getRawValue(entity), (ApprovalEntityReversal));
+  }
+}

--- a/packages/solecs/src/constants.sol
+++ b/packages/solecs/src/constants.sol
@@ -3,3 +3,5 @@ pragma solidity >=0.8.0;
 
 uint256 constant componentsComponentId = uint256(keccak256("world.component.components"));
 uint256 constant systemsComponentId = uint256(keccak256("world.component.systems"));
+uint256 constant approvalComponentId = uint256(keccak256("world.component.approval"));
+uint256 constant approvalEntityReversalComponentId = uint256(keccak256("world.component.approvalEntityReversal"));

--- a/packages/solecs/src/interfaces/IApprovalSystem.sol
+++ b/packages/solecs/src/interfaces/IApprovalSystem.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { ISystem } from "./ISystem.sol";
+
+struct Approval {
+  uint128 expiryTimestamp;
+  uint128 numCalls;
+  bytes args;
+}
+
+interface IApprovalSystem is ISystem {
+  function setApproval(
+    address grantee,
+    uint256 systemId,
+    Approval memory approval
+  ) external;
+
+  function setApproval(address grantee, Approval memory approval) external;
+
+  function reduceApproval(
+    address grantor,
+    address grantee,
+    bytes memory args
+  ) external;
+
+  function revokeApproval(address grantee, uint256 systemId) external;
+
+  function revokeApproval(address grantee) external;
+
+  function getApproval(
+    address grantor,
+    address grantee,
+    uint256 systemId
+  ) external view returns (Approval memory);
+
+  function getApproval(address grantor, address grantee) external view returns (Approval memory);
+}

--- a/packages/solecs/src/interfaces/IWorld.sol
+++ b/packages/solecs/src/interfaces/IWorld.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0;
 
 import { QueryType } from "./Query.sol";
 import { IUint256Component } from "./IUint256Component.sol";
+import { IApprovalSystem } from "./IApprovalSystem.sol";
 
 // For ProxyRead and ProxyExpand QueryFragments:
 // - component must be a component whose raw value decodes to a single uint256
@@ -17,6 +18,8 @@ interface IWorld {
   function components() external view returns (IUint256Component);
 
   function systems() external view returns (IUint256Component);
+
+  function approval() external view returns (IApprovalSystem);
 
   function registerComponent(address componentAddr, uint256 id) external;
 

--- a/packages/solecs/src/systems/ApprovalSystem.sol
+++ b/packages/solecs/src/systems/ApprovalSystem.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IWorld } from "../interfaces/IWorld.sol";
+import { IApprovalSystem } from "../interfaces/IApprovalSystem.sol";
+import { ApprovalComponent, Approval } from "../components/ApprovalComponent.sol";
+import { ApprovalEntityReversalComponent, ApprovalEntityReversal } from "../components/ApprovalEntityReversalComponent.sol";
+import { getAddressById, getIdByAddress } from "../utils.sol";
+import { approvalComponentId, approvalEntityReversalComponentId } from "../constants.sol";
+import { System } from "../System.sol";
+
+/// @dev Approval entity = hashed(grantor, grantee, systemId)
+/// @param systemId For generic approval use 0
+function getApprovalEntity(
+  address grantor,
+  address grantee,
+  uint256 systemId
+) pure returns (uint256) {
+  return uint256(keccak256(abi.encode(grantor, grantee, systemId)));
+}
+
+uint256 constant ID = uint256(keccak256("world.system.approval"));
+
+contract ApprovalSystem is System, IApprovalSystem {
+  error ApprovalSystem__OnlyWorld();
+  error ApprovalSystem__TimeExpired();
+  error ApprovalSystem__NumCallsExpired();
+  error ApprovalSystem__ArgsMismatch();
+
+  constructor(IWorld _world, address _components) System(_world, _components) {}
+
+  function execute(bytes memory args) public view returns (bytes memory) {
+    // TODO remove execute
+  }
+
+  /**
+   * @dev Approve `grantee` to call ONLY `systemId` on behalf of `msg.sender`.
+   * (`systemId` == 0 is a special case, see the other `setApproval` for details)
+   *
+   * Approval is valid only while `block.timestamp` > `expiryTimestamp` and `numCalls` > 0.
+   * If `args` isn't empty, then approval is only valid for system calls with exact `args`.
+   */
+  function setApproval(
+    address grantee,
+    uint256 systemId,
+    Approval memory approval
+  ) public override {
+    address grantor = msg.sender;
+    uint256 approvalEntity = getApprovalEntity(grantor, grantee, systemId);
+
+    _approvalComponent().set(approvalEntity, approval);
+
+    _approvalEntityReversalComponent().set(
+      approvalEntity,
+      ApprovalEntityReversal({ grantor: grantor, grantee: grantee, systemId: systemId })
+    );
+  }
+
+  /**
+   * @dev Approve `grantee` to call ANY system on behalf of `msg.sender`.
+   * Only `expiryTimestamp` is used.
+   */
+  function setApproval(address grantee, Approval memory approval) public override {
+    // RegisterSystem disallows id 0, so it's safe to use for generic approval
+    setApproval(grantee, 0, approval);
+  }
+
+  /**
+   * @dev Check approval, reduce `numCalls` for non-generic approval.
+   * Revert if not approved.
+   * Should be used by systems as a permission check.
+   */
+  function reduceApproval(
+    address grantor,
+    address grantee,
+    bytes memory args
+  ) public override {
+    // Generic approval
+    // (approval for all systems, denoted by systemId 0)
+    Approval memory approval = getApproval(grantor, grantee);
+
+    // Return successfully if a generic approval is valid
+    // (generic approval ignores `numCalls` and `args`)
+    if (approval.expiryTimestamp > block.timestamp) return;
+
+    // Specific approval
+    // (the caller is the approved system, to ensure only it can reduce `numCalls`)
+    uint256 systemId = getIdByAddress(world.systems(), msg.sender);
+    approval = getApproval(grantor, grantee, systemId);
+
+    // Revert if approval is absent or expired
+    // (for absent values getApproval returns 0s instead of reverting)
+    if (approval.expiryTimestamp <= block.timestamp) {
+      revert ApprovalSystem__TimeExpired();
+    }
+
+    // Revert if numCalls is 0
+    if (approval.numCalls == 0) {
+      revert ApprovalSystem__NumCallsExpired();
+    }
+
+    // Revert if approval is for specific `args` and they don't match
+    if (approval.args.length > 0 && keccak256(approval.args) != keccak256(args)) {
+      revert ApprovalSystem__ArgsMismatch();
+    }
+
+    // Reduce numCalls; except `type(uint128).max` is permanent approval
+    if (approval.numCalls != type(uint128).max) {
+      approval.numCalls -= 1;
+      uint256 approvalEntity = getApprovalEntity(grantor, grantee, systemId);
+      _approvalComponent().set(approvalEntity, approval);
+    }
+  }
+
+  /**
+   * @dev Revoke `grantee`'s approval to call `systemId` on behalf of `msg.sender`.
+   */
+  function revokeApproval(address grantee, uint256 systemId) public override {
+    _approvalComponent().remove(getApprovalEntity(msg.sender, grantee, systemId));
+  }
+
+  /**
+   * @dev Revoke `grantee`'s approval to call any system on behalf of `msg.sender`.
+   */
+  function revokeApproval(address grantee) public override {
+    // RegisterSystem disallows id 0, so it's safe to use for generic approval
+    _approvalComponent().remove(getApprovalEntity(msg.sender, grantee, 0));
+  }
+
+  function getApproval(
+    address grantor,
+    address grantee,
+    uint256 systemId
+  ) public view override returns (Approval memory) {
+    return _approvalComponent().getValue(getApprovalEntity(grantor, grantee, systemId));
+  }
+
+  function getApproval(address grantor, address grantee) public view override returns (Approval memory) {
+    // RegisterSystem disallows id 0, so it's safe to use for generic approval
+    return getApproval(grantor, grantee, 0);
+  }
+
+  function _approvalComponent() internal view returns (ApprovalComponent) {
+    return ApprovalComponent(getAddressById(components, approvalComponentId));
+  }
+
+  function _approvalEntityReversalComponent() internal view returns (ApprovalEntityReversalComponent) {
+    return ApprovalEntityReversalComponent(getAddressById(components, approvalEntityReversalComponentId));
+  }
+}

--- a/packages/solecs/src/test/ApprovalSystem.t.sol
+++ b/packages/solecs/src/test/ApprovalSystem.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+
+import { TestComponent } from "./components/TestComponent.sol";
+import { World } from "../World.sol";
+
+contract ApprovalSystemTest is DSTestPlus {
+  Vm internal immutable vm = Vm(HEVM_ADDRESS);
+
+  function setUp() public {
+    World world = new World();
+    world.init();
+  }
+
+  // TODO tests
+}


### PR DESCRIPTION
Draft for #327 

Particular things I'd like feedback on:
1. `ExternalSystem` is meant to be temporary to avoid breaking changes in this PR. In v2 I want to rename `System` to `BareSystem`/`BaseSystem`, and `ExternalSystem` to `System`.
2. `requireApproved` and `onlyApproved` probably shouldn't both exist. I prefer `requireApproved`, since modifiers are in various ways inferior to funcs (no explicit visibility; can't use computed args; only 1 modifier can have a name regardless of args).
3. I want world to be more modular. It just links to `IApprovalSystem`, which then has all the methods. The intent is to have this be the new standard, and later refactor `RegisterSystem` to follow suite.
4. ApprovalComponent's `getValue` never throws. `ApprovalSystem` has no separate error for absent approval, which reuses `ApprovalSystem__TimeExpired`. (to avoid calling `has`, then `getValue`. I think this is shorter, easier to read, and probably saves gas on a method call).
5. `ApprovalEntityReversal` is separate from `Approval`. You'll see in `ApprovalSystem` that reversal is used only once, so in most cases it would needlessly complicate approval if combined together.
6. After making approval-based Subsystem and comparing to #268, I prefer #268, at least in their current forms.
    - Approval has rather complicated logic, designed for mostly non-permanent approval. Whereas using OwnableWritable mirrors components, designed to be permanent, without vestigial data like `expiryTimestamp`.
    - Approval is client-sourced, whereas writeAccess is cli-sourced (as with components).
7. Should this PR have clientside stuff too, or would you rather merge `solecs` changes first?
8. Should generic approvals have their own component without args and numCalls? (that felt like overkill)
9. On the other hand, does IApprovalSystem need separate methods for generic approvals, or should ppl just pass in 0?
10. ApprovalSystem's `execute` is a deprecated noop. This assumes v2 will remove `execute` from `ISystem`.

(no particular order, numbers can make responding easier. Any other feedback is welcome too, this is all subject to change)