### PR TITLE
fix(cli): round gas price to nearest integer (it cannot handle decimals)

### DIFF
--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -51,7 +51,7 @@ export async function deploy(
       reuseComponents ? "true" : "false", // Reuse components?
       "--fork-url",
       rpc,
-      ...(gasPrice != null ? ["--with-gas-price", String(gasPrice)] : []),
+      ...(gasPrice != null ? ["--with-gas-price", String(Math.round(gasPrice))] : []),
     ],
     { stdio: ["inherit", "pipe", "pipe"] }
   );


### PR DESCRIPTION
i ran into this issue recently when fetching the gas price from our newly spun up test chain. also have anecdotal evidence that it happened to another MUD developer.