### PR TITLE
docs: add current directory since 'docker build' requires PATH as arg…

### DIFF
--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -26,7 +26,7 @@ There are Dockerfiles for each service available at the root of this repo -- `Do
 Each service can be built and used within a Kubernetes cluster (via a resource that can pull the container image) by pushing the images to a container registry. For example, to build the snapshot server via the Dockerfile, we can build the image
 
 ```
-docker build -f Dockerfile.snapshot --tag ghcr.io/latticexyz/mud-ecs-snapshot:<YOUR_TAG>
+docker build -f Dockerfile.snapshot . --tag ghcr.io/latticexyz/mud-ecs-snapshot:<YOUR_TAG>
 ```
 
 and then push to the container registry


### PR DESCRIPTION
Dear mud team,
I would like to help adding document
since docker build need PATH as augment 
example
```sh
docker build .
```

Therefore I would like to add . as current directory in the example docuement

Thank you :)