### PR TITLE
fix(cli): use --prune-history in devnode to avoid filling disk

### DIFF
--- a/packages/cli/src/commands/devnode.ts
+++ b/packages/cli/src/commands/devnode.ts
@@ -21,7 +21,16 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   console.log("Clearing devnode history");
   const userHomeDir = homedir();
   rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
-  const { child } = await execLog("anvil", ["-b", String(blocktime), "--block-base-fee-per-gas", "0"]);
+
+  const { child } = await execLog("anvil", [
+    "-b",
+    String(blocktime),
+    "--block-base-fee-per-gas",
+    "0",
+    // temporarily disable state history to avoid filling disk while anvil is running
+    // https://github.com/foundry-rs/foundry/issues/3623
+    "--prune-history",
+  ]);
 
   process.on("SIGINT", () => {
     console.log("\ngracefully shutting down from SIGINT (Crtl-C)");


### PR DESCRIPTION
Temporary workaround for https://github.com/foundry-rs/foundry/issues/3623

This may impact the ability to trace anvil txs, but that seems better than filling someone's disk after leaving anvil running.

(This change is motivated by the fact that this happened to me a few times in the last week, waking up to none of my other OSX apps working because my disk was _completely_ full, due to 1.5TB of anvil logs.)