### PR TITLE
feat(cli): add initialization libs to deploy

### DIFF
--- a/packages/cli/src/contracts/LibDeploy.ejs
+++ b/packages/cli/src/contracts/LibDeploy.ejs
@@ -25,6 +25,13 @@ import { <%= component %>, ID as <%= component %>ID } from "components/<%- compo
 import { <%= system.name %>, ID as <%= system.name %>ID } from "systems/<%- system.name %>.sol";
 <% }); -%>
 
+<% if (libs.length > 0) { -%>
+// Init Libraries (requires 'libraries=...' remapping in project's remappings.txt)
+<% libs.forEach(({name}) => { -%>
+import { <%= name %> } from "libraries/<%- name %>.sol";
+<% }); -%>
+<% } -%>
+
 struct DeployResult {
   IWorld world;
   address deployer;
@@ -100,5 +107,9 @@ library LibDeploy {
 <% } -%>
     console.log(address(system));
 <% });-%>
+
+<% libs.forEach(({name, func}) => { -%>
+    if(init) <%= name -%>.<%= func ?? 'init' -%>(world);
+<% }); -%>
   }
 }

--- a/packages/cli/src/utils/codegen.ts
+++ b/packages/cli/src/utils/codegen.ts
@@ -17,6 +17,9 @@ export async function generateLibDeploy(configPath: string, out: string, systems
   // Parse config
   const config = JSON.parse(await readFile(configPath, { encoding: "utf8" }));
 
+  // Init libs are optional
+  config.libs ??= [];
+
   // Filter systems
   if (systems) {
     const systemsArray = Array.isArray(systems) ? systems : [systems];


### PR DESCRIPTION
deploy.json already has "init" for systems.
But systems are contracts. Scripts are best run through libraries.

Example:
An expensive `addItem` function, which adds a game item prototype with all its properties. Say it costs 1mil gas per item. I have an initializer which adds 100 of those. 100mil gas exceeds the limit.
- If the 100 adds are in a system contract, it will revert. And making a bunch of wrapper init systems is a really bad idea.
- If the 100 adds are in a library, `forge script` can at least split it into several transactions. But also the real contract calls (component sets) use only a small portion of all that gas.

(this is a simplified edge case, my real use case is unfinished and more convoluted, but similar enough, e.g. [InitEquipmentAffixSystem](https://github.com/dk1a/wanderer-cycle/blob/d0892364000075b2afeca610a6883b8d0445acb5/packages/contracts/src/init/InitEquipmentAffixSystem.sol) uses way more than the transaction gas limit)

I tested that it minimally works via a slightly modified [emojimon](https://github.com/dk1a/emojimon), if you wanna just clone it.

Some concerns:
- `libs` may not be the best name, open to suggestions
- The whole idea of modifying `LibDeploy` may be a bit too hardcodey. Maybe having a user-controllable `Deploy.sol` would be best. But that's way beyond the scope of this simple PR. (#309 kinda goes in that direction a bit, making scripts more local)