### PR TITLE
build: pin solc version to 0.8.13

### DIFF
--- a/packages/cli/foundry.toml
+++ b/packages/cli/foundry.toml
@@ -7,3 +7,4 @@ verbosity = 1
 libs = ["../../node_modules", "../solecs", "../std-contracts"]
 src = "src"
 out = "out"
+solc_version = "0.8.13"

--- a/packages/noise/foundry.toml
+++ b/packages/noise/foundry.toml
@@ -7,3 +7,4 @@ verbosity = 1
 libs = ["../../node_modules"]
 src = "contracts"
 out = "out"
+solc_version = "0.8.13"

--- a/packages/solecs/foundry.toml
+++ b/packages/solecs/foundry.toml
@@ -7,3 +7,4 @@ verbosity = 1
 libs = ["../../node_modules"]
 src = "src"
 out = "out"
+solc_version = "0.8.13"

--- a/packages/std-contracts/foundry.toml
+++ b/packages/std-contracts/foundry.toml
@@ -7,3 +7,4 @@ verbosity = 1
 libs = ["../../node_modules", "../solecs"]
 src = "src"
 out = "out"
+solc_version = "0.8.13"


### PR DESCRIPTION
pinning solc to 0.8.13 for now to fix failing github action