### PR TITLE
fix(network): use current block number while waiting for new blocks

### DIFF
--- a/packages/network/src/createBlockNumberStream.ts
+++ b/packages/network/src/createBlockNumberStream.ts
@@ -43,7 +43,19 @@ export function createBlockNumberStream(
     () => providers.get(),
     (currProviders) => {
       const provider = currProviders?.ws || currProviders?.json;
-      provider?.on("block", (blockNumber: number) => blockNumberEvent$.next(blockNumber));
+
+      let streamEmpty = true;
+      // Get the current block number (skipped if a new block arrives faster)
+      provider?.getBlockNumber().then((blockNumber) => {
+        if (streamEmpty) {
+          blockNumberEvent$.next(blockNumber);
+        }
+      });
+      // Stream new block numbers
+      provider?.on("block", (blockNumber: number) => {
+        streamEmpty = false;
+        blockNumberEvent$.next(blockNumber);
+      });
     },
     { fireImmediately: true }
   );


### PR DESCRIPTION
Currently network waits for a new block, which means I must use a tickchain locally.
Perhaps it also delays loading for production chains with slowish block times, haven't tested that.

This fix uses the current block number if the rpc returns it before a new block. I may have missed some downstream problems, but it seems like a harmless change