### PR TITLE
fix(cli): exit if generateDeploy fails in deploy-contracts setup

### DIFF
--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -1,13 +1,19 @@
+import { execa } from "execa";
 import { copyFileSync, mkdirSync, readdirSync, rmSync } from "fs";
 import path from "path";
-import { execLog } from "./exec";
 
-export function forgeBuild(out = "out", options?: { clear?: boolean }) {
+export async function forgeBuild(out = "out", options?: { clear?: boolean }) {
   if (options?.clear) {
     console.log("Clearing forge build output directory", out);
     rmSync(out, { recursive: true, force: true });
   }
-  return execLog("forge", ["build", "-o", out]);
+
+  console.log("Running forge build");
+  const child = execa("forge", ["build", "-o", out], {
+    stdio: ["inherit", "pipe", "inherit"],
+  });
+
+  return (await child).stdout;
 }
 
 function getContractsInDir(dir: string, exclude?: string[]) {

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -100,10 +100,6 @@ export async function generateAndDeploy(args: DeployOptions) {
     );
     deployedWorldAddress = result.deployedWorldAddress;
     initialBlockNumber = result.initialBlockNumber;
-
-    // Extract world address from deploy script
-  } catch (e) {
-    console.error(e);
   } finally {
     // Remove generated LibDeploy
     console.log("Cleaning up deployment script");


### PR DESCRIPTION
Fixes #376
This is just a quick fix and doesn't solve the issue of logs being generally hard to read.
`generateAndDeploy` caught and ignored all errors, whereas it should only ignore them during HMR. (has been bothering me for a while)
`execLog` is also kind of a mess, it'd be best to eventually replace it with `execa` in other places too