### PR TITLE
test(store): add script to simulate store events on local chain for development purposes

### DIFF
--- a/packages/store/.gitignore
+++ b/packages/store/.gitignore
@@ -8,3 +8,4 @@ DOCS.md
 artifacts
 yarn-error.log
 API
+broadcast

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -22,7 +22,8 @@
     "link": "yarn link",
     "docs": "rimraf API && hardhat docgen && echo 'label: API\norder: 50' > API/index.yml",
     "release": "npm publish || echo 'version already published'",
-    "gasreport": " ../cli/dist/index.js gas-report --path test/** --save gas-report.txt"
+    "gasreport": " ../cli/dist/index.js gas-report --path test/** --save gas-report.txt",
+    "script": "forge script script/Store.s.sol --broadcast --tc StoreScript --fork-url http://localhost:8545 --private-keys 0x733ad1797d0d71ceab7c17971f5635385716e55c46e06aa23fdb3d1426884957 --with-gas-price 0 -vvvv"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^9.0.0",

--- a/packages/store/script/Store.s.sol
+++ b/packages/store/script/Store.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "forge-std/Script.sol";
+import { StoreView } from "../src/StoreView.sol";
+import { StoreCore } from "../src/StoreCore.sol";
+import { Schema, SchemaLib } from "../src/Schema.sol";
+import { SchemaType } from "../src/Types.sol";
+
+contract Store is StoreView {
+  function registerSchema(bytes32 table, Schema schema) public override {
+    StoreCore.registerSchema(table, schema);
+  }
+
+  function setRecord(
+    bytes32 table,
+    bytes32[] memory key,
+    bytes memory data
+  ) public override {
+    StoreCore.setRecord(table, key, data);
+  }
+
+  function setField(
+    bytes32 table,
+    bytes32[] memory key,
+    uint8 schemaIndex,
+    bytes memory data
+  ) public override {
+    StoreCore.setField(table, key, schemaIndex, data);
+  }
+}
+
+contract StoreScript is Script {
+  function run() public {
+    vm.startBroadcast();
+
+    uint256 blockNumber = block.number;
+
+    // Deploy a new store
+    Store store = new Store();
+
+    // Register a table in the store
+    Schema schema = SchemaLib.encode(SchemaType.Uint32, SchemaType.Uint128);
+    bytes32 table = keccak256("test/tableid");
+    store.registerSchema(table, schema);
+
+    // Set a value in the table
+    bytes32[] memory key = new bytes32[](1);
+    key[0] = keccak256("test/key");
+    bytes memory value = abi.encodePacked(uint32(42), uint128(1337));
+    store.setRecord(table, key, value);
+
+    // Update the field at schema index 1
+    store.setField(table, key, 1, abi.encodePacked(uint128(31337)));
+
+    console.log("Store deployed at address %s at block %s", address(store), blockNumber);
+  }
+}

--- a/packages/store/script/Store.s.sol
+++ b/packages/store/script/Store.s.sol
@@ -7,7 +7,7 @@ import { StoreCore } from "../src/StoreCore.sol";
 import { Schema, SchemaLib } from "../src/Schema.sol";
 import { SchemaType } from "../src/Types.sol";
 
-contract Store is StoreView {
+contract ScriptStore is StoreView {
   function registerSchema(bytes32 table, Schema schema) public override {
     StoreCore.registerSchema(table, schema);
   }
@@ -37,7 +37,7 @@ contract StoreScript is Script {
     uint256 blockNumber = block.number;
 
     // Deploy a new store
-    Store store = new Store();
+    ScriptStore store = new ScriptStore();
 
     // Register a table in the store
     Schema schema = SchemaLib.encode(SchemaType.Uint32, SchemaType.Uint128);


### PR DESCRIPTION
Run `yarn script` in `packags/store` to deploy a new store on a local chain and set a record and a field on it to emit the `MudStoreSetRecord` and `MudStoreSetRecord` events. Requires a local node with gas price 0 to be running at `http://localhost:8545` (eg via `anvil --block-base-fee-per-gas 0`) 