### PR TITLE
feat(store): add storage optimizations

### DIFF
--- a/packages/store/gas-report.txt
+++ b/packages/store/gas-report.txt
@@ -2,111 +2,111 @@
 (test/Buffer.t.sol) | get buffer length [buf.length()]: 87
 (test/Buffer.t.sol) | get buffer pointer [buf.ptr()]: 33
 (test/Buffer.t.sol) | get buffer capacity [buf.capacity()]: 7
-(test/Buffer.t.sol) | append unchecked bytes memory (8) to buffer [buf.appendUnchecked(data1)]: 486
-(test/Buffer.t.sol) | append bytes memory (8) to buffer [buf.append(data2)]: 789
-(test/Buffer.t.sol) | append unchecked bytes8 of bytes32 to buffer [buf.appendUnchecked(data1, 8)]: 359
-(test/Buffer.t.sol) | append bytes8 of bytes32 to buffer [buf.append(data2, 8)]: 661
-(test/Buffer.t.sol) | concat 3 bytes memory (32) using buffer [Buffer buf = Buffer_.concat(data1, data2, data3)]: 2676
-(test/Buffer.t.sol) | concat 3 bytes memory (32) using bytes.concat [bytes memory concat = bytes.concat(data1, data2, data3)]: 692
-(test/Buffer.t.sol) | concat 3 bytes memory (32) using abi.encodePacked [bytes memory concat2 = abi.encodePacked(data1, data2, data3)]: 692
+(test/Buffer.t.sol) | append unchecked bytes memory (8) to buffer [buf.appendUnchecked(data1)]: 478
+(test/Buffer.t.sol) | append bytes memory (8) to buffer [buf.append(data2)]: 773
+(test/Buffer.t.sol) | append unchecked bytes8 of bytes32 to buffer [buf.appendUnchecked(data1, 8)]: 351
+(test/Buffer.t.sol) | append bytes8 of bytes32 to buffer [buf.append(data2, 8)]: 645
+(test/Buffer.t.sol) | concat 3 bytes memory (32) using buffer [Buffer buf = Buffer_.concat(data1, data2, data3)]: 2638
+(test/Buffer.t.sol) | concat 3 bytes memory (32) using bytes.concat [bytes memory concat = bytes.concat(data1, data2, data3)]: 641
+(test/Buffer.t.sol) | concat 3 bytes memory (32) using abi.encodePacked [bytes memory concat2 = abi.encodePacked(data1, data2, data3)]: 641
 (test/Buffer.t.sol) | create a buffer from 8 bytes [Buffer buf = Buffer_.fromBytes(data)]: 40
 (test/Buffer.t.sol) | read bytes32 from buffer [bytes32 value = buf.read32(4)]: 102
-(test/Buffer.t.sol) | read bytes8 with offset 3 from buffer [bytes8 value2 = buf.read8(3)]: 147
-(test/Buffer.t.sol) | read bytes1 with offset 7 from buffer [bytes1 value3 = buf.read1(7)]: 147
+(test/Buffer.t.sol) | read bytes8 with offset 3 from buffer [bytes8 value2 = buf.read8(3)]: 151
+(test/Buffer.t.sol) | read bytes1 with offset 7 from buffer [bytes1 value3 = buf.read1(7)]: 151
 (test/Buffer.t.sol) | set buffer length unchecked [buf._setLengthUnchecked(8)]: 86
 (test/Buffer.t.sol) | set buffer length [buf._setLength(16)]: 192
-(test/Buffer.t.sol) | slice 4 bytes from buffer with offset 4 [bytes memory slice = buf.slice(4, 4)]: 625
+(test/Buffer.t.sol) | slice 4 bytes from buffer with offset 4 [bytes memory slice = buf.slice(4, 4)]: 635
 (test/Buffer.t.sol) | convert array pointer to uint256[] [uint256[] memory arr = Cast.toUint256Array(arrayPtr)]: 10
-(test/Buffer.t.sol) | buffer toArray with element length 4 [uint256 arrayPtr = buf.toArray(4)]: 731
+(test/Buffer.t.sol) | buffer toArray with element length 4 [uint256 arrayPtr = buf.toArray(4)]: 745
 (test/Buffer.t.sol) | convert array pointer to uint32[] [uint32[] memory arr = Cast.toUint32Array(arrayPtr)]: 10
 (test/Buffer.t.sol) | buffer (32 bytes) to bytes memory [bytes memory bufferData = buf.toBytes()]: 90
 (test/Bytes.t.sol) | compare equal bytes [bool equals = Bytes.equals(a, b)]: 202
 (test/Bytes.t.sol) | compare unequal bytes [bool equals = Bytes.equals(a, b)]: 202
-(test/Bytes.t.sol) | create uint32 array from bytes memory [uint32[] memory output = Bytes.toUint32Array(tight)]: 825
-(test/Bytes.t.sol) | create bytes from bytes array [bytes memory output = Bytes.from(input)]: 1359
-(test/Bytes.t.sol) | create bytes from uint16 array [bytes memory output = Bytes.from(input)]: 781
-(test/Bytes.t.sol) | create bytes from uint32 array [bytes memory output = Bytes.from(input)]: 685
-(test/Bytes.t.sol) | create bytes from uint8 array [bytes memory output = Bytes.from(input)]: 685
+(test/Bytes.t.sol) | create uint32 array from bytes memory [uint32[] memory output = Bytes.toUint32Array(tight)]: 835
+(test/Bytes.t.sol) | create bytes from bytes array [bytes memory output = Bytes.from(input)]: 1290
+(test/Bytes.t.sol) | create bytes from uint16 array [bytes memory output = Bytes.from(input)]: 791
+(test/Bytes.t.sol) | create bytes from uint32 array [bytes memory output = Bytes.from(input)]: 695
+(test/Bytes.t.sol) | create bytes from uint8 array [bytes memory output = Bytes.from(input)]: 695
 (test/Bytes.t.sol) | set bytes1 in bytes32 [Bytes.setBytes1(input, 8, 0xff)]: 7
 (test/Bytes.t.sol) | set bytes2 in bytes32 [Bytes.setBytes2(input, 8, 0xffff)]: 7
 (test/Bytes.t.sol) | set bytes4 in bytes32 [Bytes.setBytes4(input, 8, 0xffffffff)]: 7
-(test/Bytes.t.sol) | slice bytes (with copying) with offset 1 and length 3 [bytes memory b = Bytes.slice(a, 1, 3)]: 506
+(test/Bytes.t.sol) | slice bytes (with copying) with offset 1 and length 3 [bytes memory b = Bytes.slice(a, 1, 3)]: 516
 (test/Bytes.t.sol) | slice bytes3 with offset 1 [bytes3 b = Bytes.slice3(a, 1)]: 77
 (test/Bytes.t.sol) | slice bytes32 with offset 10 [bytes32 output = Bytes.slice32(input, 10)]: 74
 (test/Bytes.t.sol) | tightly pack bytes24 array into bytes array [bytes memory tight = Bytes.from(input)]: 477
 (test/Bytes.t.sol) | create uint32 array from bytes memory [bytes24[] memory output = Bytes.toBytes24Array(tight)]: 614
 (test/Bytes.t.sol) | create bytes32 from bytes memory with offset 0 [bytes32 output = Bytes.toBytes32(input, 0)]: 22
-(test/Bytes.t.sol) | create bytes32 array from bytes memory [bytes32[] memory output = Bytes.toBytes32Array(input)]: 1101
-(test/Bytes.t.sol) | create bytes32 array from bytes memory with uneven length [bytes32[] memory output = Bytes.toBytes32Array(input)]: 1414
+(test/Bytes.t.sol) | create bytes32 array from bytes memory [bytes32[] memory output = Bytes.toBytes32Array(input)]: 1110
+(test/Bytes.t.sol) | create bytes32 array from bytes memory with uneven length [bytes32[] memory output = Bytes.toBytes32Array(input)]: 1425
 (test/Bytes.t.sol) | create bytes32 from bytes memory with offset 16 [bytes32 output = Bytes.toBytes32(input, 16)]: 22
-(test/Gas.t.sol) | abi encode [bytes memory abiEncoded = abi.encode(mixed)]: 963
-(test/Gas.t.sol) | abi decode [Mixed memory abiDecoded = abi.decode(abiEncoded, (Mixed))]: 1746
-(test/Gas.t.sol) | custom encode [bytes memory customEncoded = customEncode(mixed)]: 1449
-(test/Gas.t.sol) | custom decode [Mixed memory customDecoded = customDecode(customEncoded)]: 2644
-(test/Gas.t.sol) | pass abi encoded bytes to external contract [someContract.doSomethingWithBytes(abiEncoded)]: 6552
-(test/Gas.t.sol) | pass custom encoded bytes to external contract [someContract.doSomethingWithBytes(customEncoded)]: 1378
-(test/MixedTable.t.sol) | store Mixed struct in storage (native solidity) [testMixed = mixed]: 92050
-(test/MixedTable.t.sol) | register MixedTable schema [MixedTable.registerSchema()]: 32463
-(test/MixedTable.t.sol) | set record in MixedTable [MixedTable.set({ key: key, u32: 1, u128: 2, a32: a32, s: s })]: 114307
-(test/MixedTable.t.sol) | get record from MixedTable [Mixed memory mixed = MixedTable.get(key)]: 20338
-(test/PackedCounter.t.sol) | get value at index of PackedCounter [packedCounter.atIndex(3)]: 261
-(test/PackedCounter.t.sol) | set value at index of PackedCounter [packedCounter = packedCounter.setAtIndex(2, 5)]: 799
-(test/PackedCounter.t.sol) | pack uint16 array into PackedCounter [PackedCounter packedCounter = PackedCounterLib.pack(counters)]: 2152
+(test/Gas.t.sol) | abi encode [bytes memory abiEncoded = abi.encode(mixed)]: 930
+(test/Gas.t.sol) | abi decode [Mixed memory abiDecoded = abi.decode(abiEncoded, (Mixed))]: 1713
+(test/Gas.t.sol) | custom encode [bytes memory customEncoded = customEncode(mixed)]: 1393
+(test/Gas.t.sol) | custom decode [Mixed memory customDecoded = customDecode(customEncoded)]: 2772
+(test/Gas.t.sol) | pass abi encoded bytes to external contract [someContract.doSomethingWithBytes(abiEncoded)]: 6537
+(test/Gas.t.sol) | pass custom encoded bytes to external contract [someContract.doSomethingWithBytes(customEncoded)]: 1342
+(test/MixedTable.t.sol) | store Mixed struct in storage (native solidity) [testMixed = mixed]: 92016
+(test/MixedTable.t.sol) | register MixedTable schema [MixedTable.registerSchema()]: 32467
+(test/MixedTable.t.sol) | set record in MixedTable [MixedTable.set({ key: key, u32: 1, u128: 2, a32: a32, s: s })]: 109771
+(test/MixedTable.t.sol) | get record from MixedTable [Mixed memory mixed = MixedTable.get(key)]: 16089
+(test/PackedCounter.t.sol) | get value at index of PackedCounter [packedCounter.atIndex(3)]: 272
+(test/PackedCounter.t.sol) | set value at index of PackedCounter [packedCounter = packedCounter.setAtIndex(2, 5)]: 830
+(test/PackedCounter.t.sol) | pack uint16 array into PackedCounter [PackedCounter packedCounter = PackedCounterLib.pack(counters)]: 2148
 (test/PackedCounter.t.sol) | get total of PackedCounter [packedCounter.total()]: 33
-(test/RouteTable.t.sol) | register RouteTable schema [RouteTable.registerSchema()]: 30414
-(test/RouteTable.t.sol) | set RouteTable record [RouteTable.set(key, addr, selector, executionMode)]: 38341
-(test/RouteTable.t.sol) | get RouteTable record [Route memory systemEntry = RouteTable.get(key)]: 6536
-(test/Schema.t.sol) | encode schema with 6 entries [SchemaLib.encode]: 6195
-(test/Schema.t.sol) | get schema type at index [SchemaType schemaType1 = schema.atIndex(0)]: 191
+(test/RouteTable.t.sol) | register RouteTable schema [RouteTable.registerSchema()]: 30411
+(test/RouteTable.t.sol) | set RouteTable record [RouteTable.set(key, addr, selector, executionMode)]: 36733
+(test/RouteTable.t.sol) | get RouteTable record [Route memory systemEntry = RouteTable.get(key)]: 4790
+(test/Schema.t.sol) | encode schema with 6 entries [SchemaLib.encode]: 6172
+(test/Schema.t.sol) | get schema type at index [SchemaType schemaType1 = schema.atIndex(0)]: 200
 (test/Schema.t.sol) | get number of dynamic fields from schema [uint256 num = schema.numDynamicFields()]: 80
 (test/Schema.t.sol) | get number of static fields from schema [uint256 num = schema.numStaticFields()]: 91
 (test/Schema.t.sol) | get static data length from schema [uint256 length = schema.staticDataLength()]: 39
 (test/Schema.t.sol) | check if schema is empty (non-empty schema) [bool empty = encodedSchema.isEmpty()]: 13
 (test/Schema.t.sol) | check if schema is empty (empty schema) [bool empty = encodedSchema.isEmpty()]: 13
-(test/Schema.t.sol) | validate schema [encodedSchema.validate()]: 22314
-(test/Storage.t.sol) | store 1 storage slot [Storage.store({ storagePointer: storagePointer, data: originalDataFirstSlot })]: 23411
-(test/Storage.t.sol) | store 34 bytes over 3 storage slots (with offset and safeTrail)) [Storage.store({ storagePointer: storagePointer, offset: 31, data: data1 })]: 25518
-(test/Storage.t.sol) | load 34 bytes over 3 storage slots (with offset and safeTrail)) [bytes memory data = Storage.load({ storagePointer: storagePointer, length: 34, offset: 31 })]: 4083
-(test/StoreCore.t.sol) | access non-existing record [bytes memory data1 = StoreCore.getRecord(table, key)]: 10062
-(test/StoreCore.t.sol) | access static field of non-existing record [bytes memory data2 = StoreCore.getField(table, key, 0)]: 4466
-(test/StoreCore.t.sol) | access dynamic field of non-existing record [bytes memory data3 = StoreCore.getField(table, key, 1)]: 3923
-(test/StoreCore.t.sol) | delete record (complex data, 3 slots) [StoreCore.deleteRecord(table, key)]: 10903
-(test/StoreCore.t.sol) | Check for existence of table (existent) [StoreCore.hasTable(table)]: 992
-(test/StoreCore.t.sol) | check for existence of table (non-existent) [StoreCore.hasTable(table2)]: 2993
-(test/StoreCore.t.sol) | register subscriber [StoreCore.registerHook(table, subscriber)]: 70266
-(test/StoreCore.t.sol) | set record on table with subscriber [StoreCore.setRecord(table, key, data)]: 78379
-(test/StoreCore.t.sol) | set static field on table with subscriber [StoreCore.setField(table, key, 0, data)]: 34174
-(test/StoreCore.t.sol) | delete record on table with subscriber [StoreCore.deleteRecord(table, key)]: 28719
-(test/StoreCore.t.sol) | register subscriber [StoreCore.registerHook(table, subscriber)]: 70266
-(test/StoreCore.t.sol) | set (dynamic) record on table with subscriber [StoreCore.setRecord(table, key, data)]: 174696
-(test/StoreCore.t.sol) | set (dynamic) field on table with subscriber [StoreCore.setField(table, key, 1, arrayDataBytes)]: 36910
-(test/StoreCore.t.sol) | delete (dynamic) record on table with subscriber [StoreCore.deleteRecord(table, key)]: 30269
-(test/StoreCore.t.sol) | StoreCore: register schema [StoreCore.registerSchema(table, schema)]: 26369
-(test/StoreCore.t.sol) | StoreCore: get schema (warm) [Schema loadedSchema = StoreCore.getSchema(table)]: 937
-(test/StoreCore.t.sol) | set complex record with dynamic data (4 slots) [StoreCore.setRecord(table, key, data)]: 110435
-(test/StoreCore.t.sol) | get complex record with dynamic data (4 slots) [bytes memory loadedData = StoreCore.getRecord(table, key)]: 12661
-(test/StoreCore.t.sol) | compare: Set complex record with dynamic data using native solidity [testStruct = _testStruct]: 116839
-(test/StoreCore.t.sol) | compare: Set complex record with dynamic data using abi.encode [testMapping[1234] = abi.encode(_testStruct)]: 267366
-(test/StoreCore.t.sol) | set dynamic length of dynamic index 0 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 10)]: 23649
-(test/StoreCore.t.sol) | set dynamic length of dynamic index 1 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 1, 99)]: 1750
-(test/StoreCore.t.sol) | reduce dynamic length of dynamic index 0 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 5)]: 1738
-(test/StoreCore.t.sol) | set static field (1 slot) [StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes))]: 38021
-(test/StoreCore.t.sol) | get static field (1 slot) [bytes memory loadedData = StoreCore.getField(table, key, 0)]: 4557
-(test/StoreCore.t.sol) | set static field (overlap 2 slot) [StoreCore.setField(table, key, 1, abi.encodePacked(secondDataBytes))]: 33764
-(test/StoreCore.t.sol) | get static field (overlap 2 slot) [loadedData = StoreCore.getField(table, key, 1)]: 6321
-(test/StoreCore.t.sol) | set dynamic field (1 slot, first dynamic field) [StoreCore.setField(table, key, 2, thirdDataBytes)]: 57262
-(test/StoreCore.t.sol) | get dynamic field (1 slot, first dynamic field) [loadedData = StoreCore.getField(table, key, 2)]: 5317
-(test/StoreCore.t.sol) | set dynamic field (1 slot, second dynamic field) [StoreCore.setField(table, key, 3, fourthDataBytes)]: 35386
-(test/StoreCore.t.sol) | get dynamic field (1 slot, second dynamic field) [loadedData = StoreCore.getField(table, key, 3)]: 5332
-(test/StoreCore.t.sol) | set static record (1 slot) [StoreCore.setRecord(table, key, data)]: 37215
-(test/StoreCore.t.sol) | get static record (1 slot) [bytes memory loadedData = StoreCore.getRecord(table, key, schema)]: 4084
-(test/StoreCore.t.sol) | set static record (2 slots) [StoreCore.setRecord(table, key, data)]: 60072
-(test/StoreCore.t.sol) | get static record (2 slots) [bytes memory loadedData = StoreCore.getRecord(table, key, schema)]: 4968
+(test/Schema.t.sol) | validate schema [encodedSchema.validate()]: 22716
+(test/Storage.t.sol) | store 1 storage slot [Storage.store({ storagePointer: storagePointer, data: originalDataFirstSlot })]: 22511
+(test/Storage.t.sol) | store 34 bytes over 3 storage slots (with offset and safeTrail)) [Storage.store({ storagePointer: storagePointer, offset: 31, data: data1 })]: 23165
+(test/Storage.t.sol) | load 34 bytes over 3 storage slots (with offset and safeTrail)) [bytes memory data = Storage.load({ storagePointer: storagePointer, length: 34, offset: 31 })]: 1105
+(test/StoreCore.t.sol) | access non-existing record [bytes memory data1 = StoreCore.getRecord(table, key)]: 8286
+(test/StoreCore.t.sol) | access static field of non-existing record [bytes memory data2 = StoreCore.getField(table, key, 0)]: 2741
+(test/StoreCore.t.sol) | access dynamic field of non-existing record [bytes memory data3 = StoreCore.getField(table, key, 1)]: 3335
+(test/StoreCore.t.sol) | delete record (complex data, 3 slots) [StoreCore.deleteRecord(table, key)]: 9322
+(test/StoreCore.t.sol) | Check for existence of table (existent) [StoreCore.hasTable(table)]: 952
+(test/StoreCore.t.sol) | check for existence of table (non-existent) [StoreCore.hasTable(table2)]: 2953
+(test/StoreCore.t.sol) | register subscriber [StoreCore.registerHook(table, subscriber)]: 68032
+(test/StoreCore.t.sol) | set record on table with subscriber [StoreCore.setRecord(table, key, data)]: 73867
+(test/StoreCore.t.sol) | set static field on table with subscriber [StoreCore.setField(table, key, 0, data)]: 29652
+(test/StoreCore.t.sol) | delete record on table with subscriber [StoreCore.deleteRecord(table, key)]: 24287
+(test/StoreCore.t.sol) | register subscriber [StoreCore.registerHook(table, subscriber)]: 68032
+(test/StoreCore.t.sol) | set (dynamic) record on table with subscriber [StoreCore.setRecord(table, key, data)]: 167294
+(test/StoreCore.t.sol) | set (dynamic) field on table with subscriber [StoreCore.setField(table, key, 1, arrayDataBytes)]: 32342
+(test/StoreCore.t.sol) | delete (dynamic) record on table with subscriber [StoreCore.deleteRecord(table, key)]: 25875
+(test/StoreCore.t.sol) | StoreCore: register schema [StoreCore.registerSchema(table, schema)]: 26379
+(test/StoreCore.t.sol) | StoreCore: get schema (warm) [Schema loadedSchema = StoreCore.getSchema(table)]: 897
+(test/StoreCore.t.sol) | set complex record with dynamic data (4 slots) [StoreCore.setRecord(table, key, data)]: 105939
+(test/StoreCore.t.sol) | get complex record with dynamic data (4 slots) [bytes memory loadedData = StoreCore.getRecord(table, key)]: 8329
+(test/StoreCore.t.sol) | compare: Set complex record with dynamic data using native solidity [testStruct = _testStruct]: 116815
+(test/StoreCore.t.sol) | compare: Set complex record with dynamic data using abi.encode [testMapping[1234] = abi.encode(_testStruct)]: 267532
+(test/StoreCore.t.sol) | set dynamic length of dynamic index 0 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 10)]: 23636
+(test/StoreCore.t.sol) | set dynamic length of dynamic index 1 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 1, 99)]: 1737
+(test/StoreCore.t.sol) | reduce dynamic length of dynamic index 0 [StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 5)]: 1728
+(test/StoreCore.t.sol) | set static field (1 slot) [StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes))]: 36420
+(test/StoreCore.t.sol) | get static field (1 slot) [bytes memory loadedData = StoreCore.getField(table, key, 0)]: 2832
+(test/StoreCore.t.sol) | set static field (overlap 2 slot) [StoreCore.setField(table, key, 1, abi.encodePacked(secondDataBytes))]: 31581
+(test/StoreCore.t.sol) | get static field (overlap 2 slot) [loadedData = StoreCore.getField(table, key, 1)]: 3866
+(test/StoreCore.t.sol) | set dynamic field (1 slot, first dynamic field) [StoreCore.setField(table, key, 2, thirdDataBytes)]: 55639
+(test/StoreCore.t.sol) | get dynamic field (1 slot, first dynamic field) [loadedData = StoreCore.getField(table, key, 2)]: 3549
+(test/StoreCore.t.sol) | set dynamic field (1 slot, second dynamic field) [StoreCore.setField(table, key, 3, fourthDataBytes)]: 33758
+(test/StoreCore.t.sol) | get dynamic field (1 slot, second dynamic field) [loadedData = StoreCore.getField(table, key, 3)]: 3564
+(test/StoreCore.t.sol) | set static record (1 slot) [StoreCore.setRecord(table, key, data)]: 35619
+(test/StoreCore.t.sol) | get static record (1 slot) [bytes memory loadedData = StoreCore.getRecord(table, key, schema)]: 2378
+(test/StoreCore.t.sol) | set static record (2 slots) [StoreCore.setRecord(table, key, data)]: 58186
+(test/StoreCore.t.sol) | get static record (2 slots) [bytes memory loadedData = StoreCore.getRecord(table, key, schema)]: 2711
 (test/StoreSwitch.t.sol) | check if delegatecall [isDelegate = StoreSwitch.isDelegateCall()]: 671
 (test/StoreSwitch.t.sol) | check if delegatecall [isDelegate = StoreSwitch.isDelegateCall()]: 627
 (test/System.t.sol) | extract msg.sender from calldata [address sender = _msgSender()]: 24
-(test/Vector2Table.t.sol) | register Vector2Table schema [Vector2Table.registerSchema()]: 28654
-(test/Vector2Table.t.sol) | set Vector2Table record [Vector2Table.set({ key: key, x: 1, y: 2 })]: 38307
-(test/Vector2Table.t.sol) | get Vector2Table record [Vector2 memory vector = Vector2Table.get(key)]: 6422
-(test/World.t.sol) | call autonomous system via World contract [WorldWithWorldTestSystem(address(world)).WorldTestSystem_move(entity, 1, 2)]: 48619
-(test/World.t.sol) | call delegate system via World contract [WorldWithWorldTestSystem(address(world)).WorldTestSystem_move(entity, 1, 2)]: 46405
+(test/Vector2Table.t.sol) | register Vector2Table schema [Vector2Table.registerSchema()]: 28644
+(test/Vector2Table.t.sol) | set Vector2Table record [Vector2Table.set({ key: key, x: 1, y: 2 })]: 36699
+(test/Vector2Table.t.sol) | get Vector2Table record [Vector2 memory vector = Vector2Table.get(key)]: 4680
+(test/World.t.sol) | call autonomous system via World contract [WorldWithWorldTestSystem(address(world)).WorldTestSystem_move(entity, 1, 2)]: 45252
+(test/World.t.sol) | call delegate system via World contract [WorldWithWorldTestSystem(address(world)).WorldTestSystem_move(entity, 1, 2)]: 43059

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -8,9 +8,7 @@ import { Memory } from "./Memory.sol";
 import "./Buffer.sol";
 
 /**
- * @dev This implementation is very gas efficient.
- * TODO Probably not fully optimized.
- * Full assmebly may be a bit more efficient than unchecked blocks, but would be even less readable.
+ * TODO Probably not fully optimized
  */
 library Storage {
   function store(uint256 storagePointer, bytes memory data) internal {
@@ -166,7 +164,7 @@ library Storage {
   }
 
   /**
-   * @notice Append raw bytes from storage at the given storagePointer, offset, and length to the given buffer
+   * @notice Append raw bytes from storage at the given storagePointer, offset, and length to the given memoryPointer
    */
   function load(
     uint256 storagePointer,

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -7,13 +7,20 @@ import { Bytes } from "./Bytes.sol";
 import { Memory } from "./Memory.sol";
 import "./Buffer.sol";
 
+/**
+ * @dev This implementation is very gas efficient.
+ * TODO Probably not fully optimized.
+ * Full assmebly may be a bit more efficient than unchecked blocks, but would be even less readable.
+ */
 library Storage {
   function store(uint256 storagePointer, bytes memory data) internal {
     store(storagePointer, 0, data);
   }
 
   function store(uint256 storagePointer, bytes32 data) internal {
-    _storeWord(storagePointer, data);
+    assembly {
+      sstore(storagePointer, data)
+    }
   }
 
   function store(
@@ -30,7 +37,6 @@ library Storage {
 
   /**
    * @notice Stores raw bytes to storage at the given storagePointer and offset (keeping the rest of the word intact)
-   * @dev This implementation is optimized for readability, but not very gas efficient. We should optimize this using assembly once we've settled on a spec.
    */
   function store(
     uint256 storagePointer,
@@ -39,42 +45,86 @@ library Storage {
     uint256 length
   ) internal {
     // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-    storagePointer += offset / 32;
-    offset %= 32;
+    unchecked {
+      storagePointer += offset / 32;
+      offset %= 32;
+    }
 
-    uint256 numWords = Utils.divCeil(length + offset, 32);
-    uint256 bytesWritten;
+    // For the first word, if there is an offset, apply a mask to beginning
+    if (offset > 0) {
+      // Get the word's remaining length after the offset
+      uint256 wordRemainder;
+      // (safe because of `offset %= 32` at the start)
+      unchecked {
+        wordRemainder = 32 - offset;
+      }
 
-    for (uint256 i; i < numWords; i++) {
-      // If this is the first word, and there is an offset, apply a mask to beginning
-      if ((i == 0 && offset > 0)) {
-        uint256 _lengthTostore = length + offset > 32 ? 32 - offset : length; // // the number of bytes to store
-        _storePartialWord(
-          storagePointer, // the word to update
-          _lengthTostore,
-          offset, // the offset in bytes to start writing
-          Memory.load({ memoryPointer: memoryPointer }) // Pass the first 32 bytes of the data
-        );
-        bytesWritten += _lengthTostore;
-        // If this is the last word, and there is a partial word, apply a mask to the end
-      } else if (i == numWords - 1 && (length + offset) % 32 > 0) {
-        _storePartialWord(
-          storagePointer + i, // the word to update
-          (length + offset) % 32, // the number of bytes to store
-          0, // the offset in bytes to start writing
-          Memory.load({ memoryPointer: memoryPointer, offset: bytesWritten }) // the data to store
-        );
+      uint256 mask = Utils.leftMask(length);
+      /// @solidity memory-safe-assembly
+      assembly {
+        // Load data from memory and offset it to match storage
+        let bitOffset := mul(offset, 8)
+        mask := shr(bitOffset, mask)
+        let offsetData := shr(bitOffset, mload(memoryPointer))
 
-        // Else, just store the word
-      } else {
-        _storeWord(storagePointer + i, Memory.load({ memoryPointer: memoryPointer, offset: bytesWritten }));
-        bytesWritten += 32;
+        sstore(
+          storagePointer,
+          or(
+            // Store the middle part
+            and(offsetData, mask),
+            // Preserve the surrounding parts
+            and(sload(storagePointer), not(mask))
+          )
+        )
+      }
+      // Return if done
+      if (length <= wordRemainder) return;
+
+      // Advance pointers
+      storagePointer += 1;
+      // (safe because of `length <= prefixLength` earlier)
+      unchecked {
+        memoryPointer += wordRemainder;
+        length -= wordRemainder;
+      }
+    }
+
+    // Store full words
+    while (length >= 32) {
+      /// @solidity memory-safe-assembly
+      assembly {
+        sstore(storagePointer, mload(memoryPointer))
+      }
+      storagePointer += 1;
+      // (safe unless length is improbably large)
+      unchecked {
+        memoryPointer += 32;
+        length -= 32;
+      }
+    }
+
+    // For the last partial word, apply a mask to the end
+    if (length > 0) {
+      uint256 mask = Utils.leftMask(length);
+      /// @solidity memory-safe-assembly
+      assembly {
+        sstore(
+          storagePointer,
+          or(
+            // store the left part
+            and(mload(memoryPointer), mask),
+            // preserve the right part
+            and(sload(storagePointer), not(mask))
+          )
+        )
       }
     }
   }
 
-  function load(uint256 storagePointer) internal view returns (bytes32) {
-    return _loadWord(storagePointer);
+  function load(uint256 storagePointer) internal view returns (bytes32 word) {
+    assembly {
+      word := sload(storagePointer)
+    }
   }
 
   function load(uint256 storagePointer, uint256 length) internal view returns (bytes memory) {
@@ -88,10 +138,31 @@ library Storage {
     uint256 storagePointer,
     uint256 length,
     uint256 offset
-  ) internal view returns (bytes memory) {
-    Buffer buffer = Buffer_.allocate(uint128(length));
-    load(storagePointer, length, offset, buffer);
-    return buffer.toBytes();
+  ) internal view returns (bytes memory result) {
+    // TODO this will probably use less gas via manual memory allocation
+    result = new bytes(length);
+    uint256 memoryPointer;
+    assembly {
+      memoryPointer := add(result, 0x20)
+    }
+    load(storagePointer, length, offset, memoryPointer);
+    return result;
+  }
+
+  /**
+   * @notice Load into the buffer from storage at the given storagePointer, offset, and length
+   */
+  function load(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset,
+    Buffer buffer
+  ) internal view {
+    uint256 bufferLength = buffer.length();
+    load(storagePointer, length, offset, buffer.ptr() + bufferLength);
+
+    // Update the current buffer length
+    buffer._setLengthUnchecked(uint128(bufferLength + length));
   }
 
   /**
@@ -101,94 +172,80 @@ library Storage {
     uint256 storagePointer,
     uint256 length,
     uint256 offset,
-    Buffer buffer
+    uint256 memoryPointer
   ) internal view {
     // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-    storagePointer += offset / 32;
-    offset %= 32;
+    unchecked {
+      storagePointer += offset / 32;
+      offset %= 32;
+    }
 
-    uint256 numWords = Utils.divCeil(length + offset, 32);
-    uint256 _lengthToload;
+    // For the first word, if there is an offset, apply a mask to beginning
+    if (offset > 0) {
+      // Get the word's remaining length after the offset
+      uint256 wordRemainder;
+      // (safe because of `offset %= 32` at the start)
+      unchecked {
+        wordRemainder = 32 - offset;
+      }
 
-    for (uint256 i; i < numWords; i++) {
-      // If this is the first word, and there is an offset, apply a mask to beginning (and possibly the end if length + offset is less than 32)
-      if ((i == 0 && offset > 0)) {
-        _lengthToload = length + offset > 32 ? 32 - offset : length; // the number of bytes to load
-        buffer.appendUnchecked(
-          _loadPartialWord(
-            storagePointer, // the slot to start loading from
-            _lengthToload,
-            offset // the offset in bytes to start loading from
-          ),
-          uint128(_lengthToload)
-        );
+      uint256 mask = Utils.leftMask(wordRemainder);
+      /// @solidity memory-safe-assembly
+      assembly {
+        // Load data from storage and offset it to match memory
+        let offsetData := shl(mul(offset, 8), sload(storagePointer))
 
-        // If this is the last word, and there is a partial word, apply a mask to the end
-      } else if (i == numWords - 1 && (length + offset) % 32 > 0) {
-        _lengthToload = (length + offset) % 32; //  the relevant length of the trailing word
-        buffer.appendUnchecked(
-          _loadPartialWord(
-            storagePointer + i, // the word to load from
-            _lengthToload,
-            0 // the offset in bytes to start loading from
-          ),
-          uint128(_lengthToload)
-        );
+        mstore(
+          memoryPointer,
+          or(
+            // store the middle part
+            and(offsetData, mask),
+            // preserve the surrounding parts
+            and(mload(memoryPointer), not(mask))
+          )
+        )
+      }
+      // Return if done
+      if (length <= wordRemainder) return;
 
-        // Else, just load the word
-      } else {
-        buffer.appendUnchecked(_loadWord(storagePointer + i), 32);
+      // Advance pointers
+      storagePointer += 1;
+      // (safe because of `length <= prefixLength` earlier)
+      unchecked {
+        memoryPointer += wordRemainder;
+        length -= wordRemainder;
       }
     }
-  }
 
-  /**
-   * @notice Load a full word from storage into memory
-   */
-  function _loadWord(uint256 storagePointer) internal view returns (bytes32 data) {
-    assembly {
-      data := sload(storagePointer)
-    }
-  }
-
-  /**
-   * @notice Load a partial word from storage into memory
-   */
-  function _loadPartialWord(
-    uint256 storagePointer,
-    uint256 length,
-    uint256 offset
-  ) internal view returns (bytes32) {
-    // Load current value from storage
-    bytes32 storageValue;
-    assembly {
-      storageValue := sload(storagePointer)
+    // Load full words
+    while (length >= 32) {
+      /// @solidity memory-safe-assembly
+      assembly {
+        mstore(memoryPointer, sload(storagePointer))
+      }
+      storagePointer += 1;
+      // (safe unless length is improbably large)
+      unchecked {
+        memoryPointer += 32;
+        length -= 32;
+      }
     }
 
-    // create a mask for the bits we want to update
-    return (storageValue << (offset * 8)) & bytes32(Utils.leftMask(length * 8));
-  }
-
-  function _storeWord(uint256 storagePointer, bytes32 data) internal {
-    assembly {
-      sstore(storagePointer, data)
-    }
-  }
-
-  function _storePartialWord(
-    uint256 storagePointer,
-    uint256 length, // in bytes
-    uint256 offset, // in bytes
-    bytes32 data
-  ) internal {
-    bytes32 current;
-    assembly {
-      current := sload(storagePointer)
-    }
-    bytes32 mask = bytes32(Utils.leftMask(length * 8) >> (offset * 8)); // create a mask for the bits we want to update
-    bytes32 updated = (current & ~mask) | ((data >> (offset * 8)) & mask); // apply mask to data
-    assembly {
-      sstore(storagePointer, updated)
+    // For the last partial word, apply a mask to the end
+    if (length > 0) {
+      uint256 mask = Utils.leftMask(length);
+      /// @solidity memory-safe-assembly
+      assembly {
+        mstore(
+          memoryPointer,
+          or(
+            // store the left part
+            and(sload(storagePointer), mask),
+            // preserve the right part
+            and(mload(memoryPointer), not(mask))
+          )
+        )
+      }
     }
   }
 }

--- a/packages/store/src/Utils.sol
+++ b/packages/store/src/Utils.sol
@@ -8,12 +8,20 @@ library Utils {
 
   /**
    * Adapted from https://github.com/dk1a/solidity-stringutils/blob/main/src/utils/mem.sol#L149-L167
-   * @dev Left-aligned bit mask (e.g. for partial mload/mstore).
-   * For length >= 32 returns type(uint256).max
+   * @dev Left-aligned byte mask (e.g. for partial mload/mstore).
+   * For byteLength >= 32 returns type(uint256).max
+   *
+   * length 0:   0x000000...000000
+   * length 1:   0xff0000...000000
+   * length 2:   0xffff00...000000
+   * ...
+   * length 30:  0xffffff...ff0000
+   * length 31:  0xffffff...ffff00
+   * length 32+: 0xffffff...ffffff
    */
-  function leftMask(uint256 bitLength) internal pure returns (uint256) {
+  function leftMask(uint256 byteLength) internal pure returns (uint256) {
     unchecked {
-      return ~(type(uint256).max >> (bitLength));
+      return ~(type(uint256).max >> (byteLength * 8));
     }
   }
 }


### PR DESCRIPTION
Replaced #378

> why are we adding the buffer's length to the buffer's pointer to get the memory pointer?

I no longer use appendUnchecked in Storage. That's a temporary hack so that the new Storage works before I finish the Buffer overhaul