### PR TITLE
refactor(react): improve useEntityQuery usage/rendering

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,6 +20,15 @@
     "build": "rimraf dist && rollup -c rollup.config.js",
     "release": "npm publish || echo 'version already published'"
   },
+  "peerDependencies": {
+    "@latticexyz/recs": "^1.32.0",
+    "mobx": "^6.4.2",
+    "react": "^18.2.0",
+    "rxjs": "^7.5.5"
+  },
+  "dependencies": {
+    "fast-deep-equal": "^3.1.3"
+  },
   "devDependencies": {
     "@latticexyz/recs": "^1.34.0",
     "@rollup/plugin-json": "^4.1.0",
@@ -43,12 +52,6 @@
     "typedoc": "0.23.21",
     "typedoc-plugin-markdown": "^3.13.6",
     "typescript": "^4.5.5"
-  },
-  "peerDependencies": {
-    "@latticexyz/recs": "^1.32.0",
-    "mobx": "^6.4.2",
-    "react": "^18.2.0",
-    "rxjs": "^7.5.5"
   },
   "gitHead": "218f56893d268b0c5157a3e4c603b859e287a343"
 }

--- a/packages/react/src/useEntityQuery.test.ts
+++ b/packages/react/src/useEntityQuery.test.ts
@@ -9,9 +9,10 @@ import {
   withValue,
   Has,
   setComponent,
+  HasValue,
+  removeComponent,
 } from "@latticexyz/recs";
 import { useEntityQuery } from "./useEntityQuery";
-import { useMemo } from "react";
 
 describe("useEntityQuery", () => {
   let world: World;
@@ -32,12 +33,37 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery(useMemo(() => [Has(Position)], [])));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)]));
 
     expect(result.current.length).toBe(2);
     expect(result.current).toContain(entity1);
     expect(result.current).toContain(entity2);
     expect(result.current).not.toContain(entity3);
+
+    act(() => {
+      setComponent(Position, entity3, { x: 0, y: 0 });
+    });
+
+    expect(result.current.length).toBe(3);
+    expect(result.current).toContain(entity1);
+    expect(result.current).toContain(entity2);
+    expect(result.current).toContain(entity3);
+
+    act(() => {
+      removeComponent(Position, entity1);
+      removeComponent(Position, entity3);
+    });
+
+    expect(result.current.length).toBe(1);
+    expect(result.current).not.toContain(entity1);
+    expect(result.current).toContain(entity2);
+    expect(result.current).not.toContain(entity3);
+
+    act(() => {
+      removeComponent(Position, entity2);
+    });
+
+    expect(result.current.length).toBe(0);
   });
 
   it("should re-render only when Position changes", () => {
@@ -45,27 +71,79 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery(useMemo(() => [Has(Position)], [])));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)]));
 
-    expect(result.all.length).toBe(2);
+    expect(result.all).toHaveLength(2);
+    expect(result.current).toHaveLength(2);
+    expect(result.current).toContain(entity1);
+    expect(result.current).toContain(entity2);
+    expect(result.current).not.toContain(entity3);
 
+    // Changing the an entity's component value should NOT re-render
     act(() => {
       setComponent(Position, entity2, { x: 0, y: 0 });
     });
 
-    expect(result.all.length).toBe(3);
+    expect(result.all).toHaveLength(2);
 
+    // Changing a different component value should NOT re-render
     act(() => {
       setComponent(OwnedBy, entity2, { value: world.entities[entity1] });
       setComponent(OwnedBy, entity3, { value: world.entities[entity1] });
     });
 
-    expect(result.all.length).toBe(3);
+    expect(result.all).toHaveLength(2);
 
+    // Changing which entities have the component should re-render
     act(() => {
       setComponent(Position, entity3, { x: 0, y: 0 });
     });
 
-    expect(result.all.length).toBe(4);
+    expect(result.all).toHaveLength(3);
+    expect(result.current).toHaveLength(3);
+    expect(result.current).toContain(entity1);
+    expect(result.current).toContain(entity2);
+    expect(result.current).toContain(entity3);
+
+    // Changing which entities have the component should re-render
+    act(() => {
+      removeComponent(Position, entity1);
+    });
+
+    expect(result.all).toHaveLength(4);
+    expect(result.current).toHaveLength(2);
+    expect(result.current).toContain(entity2);
+    expect(result.current).toContain(entity3);
+  });
+
+  it("should re-render as hook arguments change", () => {
+    // TODO: reduce re-renders during argument changes?
+
+    const entity1 = createEntity(world, [withValue(Position, { x: 1, y: 1 })]);
+    const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
+    const entity3 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
+
+    const { result, rerender } = renderHook(({ x, y }) => useEntityQuery([HasValue(Position, { x, y })]), {
+      initialProps: { x: 1, y: 1 },
+    });
+
+    expect(result.all).toHaveLength(2);
+    expect(result.current).toHaveLength(1);
+    expect(result.current).toContain(entity1);
+
+    rerender({ x: 1, y: 1 });
+    expect(result.all).toHaveLength(3);
+    expect(result.current).toHaveLength(1);
+    expect(result.current).toContain(entity1);
+
+    rerender({ x: 2, y: 2 });
+    expect(result.all).toHaveLength(6);
+    expect(result.current).toHaveLength(2);
+    expect(result.current).toContain(entity2);
+    expect(result.current).toContain(entity3);
+
+    rerender({ x: -1, y: -1 });
+    expect(result.all).toHaveLength(9);
+    expect(result.current).toHaveLength(0);
   });
 });

--- a/packages/react/src/utils/useDeepMemo.ts
+++ b/packages/react/src/utils/useDeepMemo.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+import isEqual from "fast-deep-equal";
+
+export const useDeepMemo = <T>(currentValue: T): T => {
+  const [stableValue, setStableValue] = useState(currentValue);
+
+  useEffect(() => {
+    if (!isEqual(currentValue, stableValue)) {
+      setStableValue(currentValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentValue]);
+
+  return stableValue;
+};


### PR DESCRIPTION
closes #379

Adds better memoizing to `useEntityQuery` arguments so that you don't have to memoize values passed into it (which is currently causing an ~infinite loop if you're not careful).