### PR TITLE
build(ci): enable merge queue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
We tried the merge queue, but it spins forever because we need `merge_group` events for our required CI steps.