### PR TITLE
feat(cli): use forge config for paths to src, test, out

### DIFF
--- a/packages/cli/src/commands/call-system.ts
+++ b/packages/cli/src/commands/call-system.ts
@@ -1,6 +1,8 @@
 import { defaultAbiCoder as abi } from "ethers/lib/utils";
+import path from "path";
 import { Arguments, CommandBuilder } from "yargs";
 import { execLog } from "../utils";
+import { getTestDir } from "../utils/forgeConfig";
 
 type Options = {
   rpc?: string;
@@ -40,13 +42,15 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { rpc, caller, world, systemId, argTypes, args, calldata, broadcast, callerPrivateKey, debug } = argv;
   const encodedArgs = calldata ?? (argTypes && args && abi.encode(argTypes, args)) ?? "";
+  const testDir = await getTestDir();
+
   await execLog("forge", [
     "script",
     "--fork-url",
     rpc ?? "http://localhost:8545", // default anvil rpc
     "--sig",
     "debug(address,address,string,bytes,bool)",
-    "src/test/utils/Debug.sol", // the cli expects the Debug.sol file at this path
+    path.join(testDir, "utils/Debug.sol"), // the cli expects the Debug.sol file at this path
     caller ?? "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266", // default anvil deployer
     world,
     systemId || "",

--- a/packages/cli/src/commands/call-system.ts
+++ b/packages/cli/src/commands/call-system.ts
@@ -2,7 +2,7 @@ import { defaultAbiCoder as abi } from "ethers/lib/utils";
 import path from "path";
 import { Arguments, CommandBuilder } from "yargs";
 import { execLog } from "../utils";
-import { getTestDir } from "../utils/forgeConfig";
+import { getTestDirectory } from "../utils/forgeConfig";
 
 type Options = {
   rpc?: string;
@@ -42,7 +42,7 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { rpc, caller, world, systemId, argTypes, args, calldata, broadcast, callerPrivateKey, debug } = argv;
   const encodedArgs = calldata ?? (argTypes && args && abi.encode(argTypes, args)) ?? "";
-  const testDir = await getTestDir();
+  const testDir = await getTestDirectory();
 
   await execLog("forge", [
     "script",

--- a/packages/cli/src/commands/deploy-contracts.ts
+++ b/packages/cli/src/commands/deploy-contracts.ts
@@ -2,7 +2,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { DeployOptions, generateAndDeploy, hsr } from "../utils";
 import openurl from "openurl";
 import chalk from "chalk";
-import { getSrcDir } from "../utils/forgeConfig";
+import { getSrcDirectory } from "../utils/forgeConfig";
 
 type Options = DeployOptions & {
   watch?: boolean;
@@ -66,7 +66,7 @@ export const handler = async (args: Arguments<Options>): Promise<void> => {
   // Set up watcher for system files to redeploy on change
   if (args.watch) {
     const { config, rpc, gasPrice } = args;
-    const srcDir = await getSrcDir();
+    const srcDir = await getSrcDirectory();
 
     hsr(srcDir, async (systems: string[]) => {
       try {

--- a/packages/cli/src/commands/deploy-contracts.ts
+++ b/packages/cli/src/commands/deploy-contracts.ts
@@ -2,6 +2,7 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { DeployOptions, generateAndDeploy, hsr } from "../utils";
 import openurl from "openurl";
 import chalk from "chalk";
+import { getSrcDir } from "../utils/forgeConfig";
 
 type Options = DeployOptions & {
   watch?: boolean;
@@ -65,8 +66,9 @@ export const handler = async (args: Arguments<Options>): Promise<void> => {
   // Set up watcher for system files to redeploy on change
   if (args.watch) {
     const { config, rpc, gasPrice } = args;
+    const srcDir = await getSrcDir();
 
-    hsr("./src", async (systems: string[]) => {
+    hsr(srcDir, async (systems: string[]) => {
       try {
         return await generateAndDeploy({
           config,

--- a/packages/cli/src/commands/system-types.ts
+++ b/packages/cli/src/commands/system-types.ts
@@ -1,13 +1,13 @@
 import type { Arguments, CommandBuilder } from "yargs";
 import { generateSystemTypes } from "../utils";
+import { systemsDir } from "../utils/constants";
 
 type Options = {
   outputDir: string;
 };
 
 export const command = "system-types";
-export const desc =
-  "Generates system type file. Note: assumes contracts of all systems in <forge src path>/systems folder, ABIs of all systems in ./abi and typechain generated types in ./types/ethers-contracts";
+export const desc = `Generates system type file. Note: assumes contracts of all systems in <forge src path>/${systemsDir} folder, ABIs of all systems in ./abi and typechain generated types in ./types/ethers-contracts`;
 
 export const builder: CommandBuilder<Options, Options> = (yargs) =>
   yargs.options({

--- a/packages/cli/src/commands/system-types.ts
+++ b/packages/cli/src/commands/system-types.ts
@@ -2,21 +2,15 @@ import type { Arguments, CommandBuilder } from "yargs";
 import { generateSystemTypes } from "../utils";
 
 type Options = {
-  inputDir: string;
   outputDir: string;
 };
 
 export const command = "system-types";
 export const desc =
-  "Generates system type file. Note: assumes ABIs of all systems in ./abi and typechain generated types in ./types/ethers-contracts";
+  "Generates system type file. Note: assumes contracts of all systems in <forge src path>/systems folder, ABIs of all systems in ./abi and typechain generated types in ./types/ethers-contracts";
 
 export const builder: CommandBuilder<Options, Options> = (yargs) =>
   yargs.options({
-    inputDir: {
-      type: "string",
-      description: "source systems directory, defaults to ./src/systems",
-      default: "./src/systems",
-    },
     outputDir: {
       type: "string",
       description: "generated types directory, defaults to ./types",
@@ -25,6 +19,6 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
   });
 
 export const handler = async (args: Arguments<Options>): Promise<void> => {
-  const { inputDir, outputDir } = args;
-  await generateSystemTypes(inputDir, outputDir);
+  const { outputDir } = args;
+  await generateSystemTypes(outputDir);
 };

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,9 +1,9 @@
 import type { Arguments, CommandBuilder } from "yargs";
 import { execLog, generateLibDeploy, resetLibDeploy } from "../utils";
+import { getTestDir } from "../utils/forgeConfig";
 
 type Options = {
   forgeOpts?: string;
-  testDir: string;
   config: string;
   v: number;
 };
@@ -14,13 +14,13 @@ export const desc = "Run contract tests";
 export const builder: CommandBuilder<Options, Options> = (yargs) =>
   yargs.options({
     forgeOpts: { type: "string", desc: "Options passed to `forge test` command" },
-    testDir: { type: "string", default: "./src/test", desc: "Test directory" },
     config: { type: "string", default: "./deploy.json", desc: "Component and system deployment configuration" },
     v: { type: "number", default: 2, desc: "Verbosity for forge test" },
   });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  const { forgeOpts, testDir, config, v } = argv;
+  const { forgeOpts, config, v } = argv;
+  const testDir = await getTestDir();
 
   // Generate LibDeploy.sol
   console.log("Generate LibDeploy.sol");

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,6 +1,6 @@
 import type { Arguments, CommandBuilder } from "yargs";
 import { execLog, generateLibDeploy, resetLibDeploy } from "../utils";
-import { getTestDir } from "../utils/forgeConfig";
+import { getTestDirectory } from "../utils/forgeConfig";
 
 type Options = {
   forgeOpts?: string;
@@ -20,7 +20,7 @@ export const builder: CommandBuilder<Options, Options> = (yargs) =>
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { forgeOpts, config, v } = argv;
-  const testDir = await getTestDir();
+  const testDir = await getTestDirectory();
 
   // Generate LibDeploy.sol
   console.log("Generate LibDeploy.sol");

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -4,6 +4,11 @@ import { readFileSync } from "fs";
 import { Contract } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { abi as WorldAbi } from "@latticexyz/solecs/abi/World.json";
+import { getSrcDir } from "../utils/forgeConfig";
+import path from "path";
+
+const systemsDir = "systems";
+const componentsDir = "components";
 
 type Options = {
   config?: string;
@@ -36,18 +41,20 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const World = new Contract(world, WorldAbi, provider);
 
   if (deployData) {
+    const srcDir = await getSrcDir();
+
     // Create component labels
     const componentPromises = deployData.components.map(async (component: string) => {
-      const path = `${wd}/src/components/${component}.sol`;
-      const id = extractIdFromFile(path);
+      const filePath = path.join(wd, srcDir, componentsDir, `${component}.sol`);
+      const id = extractIdFromFile(filePath);
       if (!id) return;
       const address = await World.getComponent(keccak256(id));
       return [component, address];
     });
     // Create system labels
     const systemPromises = deployData.systems.map(async (system: { name: string }) => {
-      const path = `${wd}/src/systems/${system.name}.sol`;
-      const id = extractIdFromFile(path);
+      const filePath = path.join(wd, srcDir, systemsDir, `${system.name}.sol`);
+      const id = extractIdFromFile(filePath);
       if (!id) return;
       const address = await World.getSystemAddress(keccak256(id));
       return [system.name, address];

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "fs";
 import { Contract } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { abi as WorldAbi } from "@latticexyz/solecs/abi/World.json";
-import { getSrcDir } from "../utils/forgeConfig";
+import { getSrcDirectory } from "../utils/forgeConfig";
 import path from "path";
 import { componentsDir, systemsDir } from "../utils/constants";
 
@@ -39,7 +39,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const World = new Contract(world, WorldAbi, provider);
 
   if (deployData) {
-    const srcDir = await getSrcDir();
+    const srcDir = await getSrcDirectory();
 
     // Create component labels
     const componentPromises = deployData.components.map(async (component: string) => {

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -6,9 +6,7 @@ import { JsonRpcProvider } from "@ethersproject/providers";
 import { abi as WorldAbi } from "@latticexyz/solecs/abi/World.json";
 import { getSrcDir } from "../utils/forgeConfig";
 import path from "path";
-
-const systemsDir = "systems";
-const componentsDir = "components";
+import { componentsDir, systemsDir } from "../utils/constants";
 
 type Options = {
   config?: string;

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -1,15 +1,17 @@
 import { execa } from "execa";
 import { copyFileSync, mkdirSync, readdirSync, rmSync } from "fs";
 import path from "path";
+import { getOutDir } from "./forgeConfig";
 
-export async function forgeBuild(out = "out", options?: { clear?: boolean }) {
+export async function forgeBuild(options?: { clear?: boolean }) {
   if (options?.clear) {
+    const out = await getOutDir();
     console.log("Clearing forge build output directory", out);
     rmSync(out, { recursive: true, force: true });
   }
 
   console.log("Running forge build");
-  const child = execa("forge", ["build", "-o", out], {
+  const child = execa("forge", ["build"], {
     stdio: ["inherit", "pipe", "inherit"],
   });
 

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -1,11 +1,11 @@
 import { execa } from "execa";
 import { copyFileSync, mkdirSync, readdirSync, rmSync } from "fs";
 import path from "path";
-import { getOutDir } from "./forgeConfig";
+import { getOutDirectory } from "./forgeConfig";
 
 export async function forgeBuild(options?: { clear?: boolean }) {
   if (options?.clear) {
-    const out = await getOutDir();
+    const out = await getOutDirectory();
     console.log("Clearing forge build output directory", out);
     rmSync(out, { recursive: true, force: true });
   }
@@ -18,7 +18,7 @@ export async function forgeBuild(options?: { clear?: boolean }) {
   return (await child).stdout;
 }
 
-function getContractsInDir(dir: string, exclude?: string[]) {
+function getContractsInDirectory(dir: string, exclude?: string[]) {
   return readdirSync(dir)
     .filter((item) => item.includes(".sol"))
     .map((item) => item.replace(".sol", ""))
@@ -41,7 +41,7 @@ export function filterAbi(abiIn = "./out", abiOut = "./abi", exclude: string[] =
 
   // Only include World, LibQuery, *Component, *System
   const include = ["Component", "System", "World", "LibQuery"];
-  const contracts = getContractsInDir(abiIn, exclude).filter((item) => include.find((i) => item.includes(i)));
+  const contracts = getContractsInDirectory(abiIn, exclude).filter((item) => include.find((i) => item.includes(i)));
 
   console.log("Selected ABIs: ", contracts);
 

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const systemsDir = "systems";
+export const componentsDir = "components";

--- a/packages/cli/src/utils/forgeConfig.ts
+++ b/packages/cli/src/utils/forgeConfig.ts
@@ -35,3 +35,11 @@ export async function getSrcDir() {
 export async function getTestDir() {
   return (await getForgeConfig()).test;
 }
+
+/**
+ * Get the value of "out" from forge config.
+ * The path to put contract artifacts in, relative to the root of the project.
+ */
+export async function getOutDir() {
+  return (await getForgeConfig()).out;
+}

--- a/packages/cli/src/utils/forgeConfig.ts
+++ b/packages/cli/src/utils/forgeConfig.ts
@@ -24,7 +24,7 @@ export async function getForgeConfig() {
  * Get the value of "src" from forge config.
  * The path to the contract sources relative to the root of the project.
  */
-export async function getSrcDir() {
+export async function getSrcDirectory() {
   return (await getForgeConfig()).src;
 }
 
@@ -32,7 +32,7 @@ export async function getSrcDir() {
  * Get the value of "test" from forge config.
  * The path to the test contract sources relative to the root of the project.
  */
-export async function getTestDir() {
+export async function getTestDirectory() {
   return (await getForgeConfig()).test;
 }
 
@@ -40,6 +40,6 @@ export async function getTestDir() {
  * Get the value of "out" from forge config.
  * The path to put contract artifacts in, relative to the root of the project.
  */
-export async function getOutDir() {
+export async function getOutDirectory() {
   return (await getForgeConfig()).out;
 }

--- a/packages/cli/src/utils/forgeConfig.ts
+++ b/packages/cli/src/utils/forgeConfig.ts
@@ -1,0 +1,37 @@
+import { execa } from "execa";
+
+export interface ForgeConfig {
+  // project
+  src: string;
+  test: string;
+  out: string;
+  libs: string[];
+
+  // all unspecified keys (this interface is far from comprehensive)
+  [key: string]: unknown;
+}
+
+/**
+ * Get forge config as a parsed json object.
+ */
+export async function getForgeConfig() {
+  const { stdout } = await execa("forge", ["config", "--json"], { stdio: ["inherit", "pipe", "pipe"] });
+
+  return JSON.parse(stdout) as ForgeConfig;
+}
+
+/**
+ * Get the value of "src" from forge config.
+ * The path to the contract sources relative to the root of the project.
+ */
+export async function getSrcDir() {
+  return (await getForgeConfig()).src;
+}
+
+/**
+ * Get the value of "test" from forge config.
+ * The path to the test contract sources relative to the root of the project.
+ */
+export async function getTestDir() {
+  return (await getForgeConfig()).test;
+}

--- a/packages/cli/src/utils/types.ts
+++ b/packages/cli/src/utils/types.ts
@@ -5,7 +5,7 @@ import { extractIdFromFile } from "./ids";
 import { rmSync, writeFileSync } from "fs";
 import path from "path";
 import { filterAbi, forgeBuild } from "./build";
-import { getSrcDir } from "./forgeConfig";
+import { getOutDir, getSrcDir } from "./forgeConfig";
 
 const systemsDir = "systems";
 
@@ -130,9 +130,9 @@ ${systems.map((system, index) => `  "${ids[index]}": ${system}.abi,`).join("\n")
 export async function generateTypes(abiDir?: string, outputDir = "./types", options?: { clear?: boolean }) {
   if (!abiDir) {
     console.log("Compiling contracts");
-    const buildOutput = "./out";
+    const buildOutput = await getOutDir();
     abiDir = "./abi";
-    await forgeBuild(buildOutput, options);
+    await forgeBuild(options);
     filterAbi(buildOutput, abiDir);
   }
 

--- a/packages/cli/src/utils/types.ts
+++ b/packages/cli/src/utils/types.ts
@@ -6,8 +6,7 @@ import { rmSync, writeFileSync } from "fs";
 import path from "path";
 import { filterAbi, forgeBuild } from "./build";
 import { getOutDir, getSrcDir } from "./forgeConfig";
-
-const systemsDir = "systems";
+import { systemsDir } from "./constants";
 
 export async function generateAbiTypes(
   inputDir: string,

--- a/packages/cli/src/utils/types.ts
+++ b/packages/cli/src/utils/types.ts
@@ -5,7 +5,7 @@ import { extractIdFromFile } from "./ids";
 import { rmSync, writeFileSync } from "fs";
 import path from "path";
 import { filterAbi, forgeBuild } from "./build";
-import { getOutDir, getSrcDir } from "./forgeConfig";
+import { getOutDirectory, getSrcDirectory } from "./forgeConfig";
 import { systemsDir } from "./constants";
 
 export async function generateAbiTypes(
@@ -47,7 +47,7 @@ export async function generateSystemTypes(outputDir: string, options?: { clear?:
   let ids: string[] = [];
   let typePaths: string[] = [];
 
-  const srcDir = await getSrcDir();
+  const srcDir = await getSrcDirectory();
   const systemsPath = path.join(srcDir, systemsDir, "*.sol");
 
   const [resolve, , promise] = deferred<void>();
@@ -129,7 +129,7 @@ ${systems.map((system, index) => `  "${ids[index]}": ${system}.abi,`).join("\n")
 export async function generateTypes(abiDir?: string, outputDir = "./types", options?: { clear?: boolean }) {
   if (!abiDir) {
     console.log("Compiling contracts");
-    const buildOutput = await getOutDir();
+    const buildOutput = await getOutDirectory();
     abiDir = "./abi";
     await forgeBuild(options);
     filterAbi(buildOutput, abiDir);

--- a/packages/cli/src/utils/types.ts
+++ b/packages/cli/src/utils/types.ts
@@ -5,6 +5,9 @@ import { extractIdFromFile } from "./ids";
 import { rmSync, writeFileSync } from "fs";
 import path from "path";
 import { filterAbi, forgeBuild } from "./build";
+import { getSrcDir } from "./forgeConfig";
+
+const systemsDir = "systems";
 
 export async function generateAbiTypes(
   inputDir: string,
@@ -31,7 +34,7 @@ export async function generateAbiTypes(
   console.log(`Successfully generated ${result.filesGenerated} files`);
 }
 
-export async function generateSystemTypes(inputDir: string, outputDir: string, options?: { clear?: boolean }) {
+export async function generateSystemTypes(outputDir: string, options?: { clear?: boolean }) {
   if (options?.clear) {
     console.log("Clearing system type output files", outputDir);
     rmSync(path.join(outputDir, "/SystemTypes.ts"), { force: true });
@@ -45,7 +48,8 @@ export async function generateSystemTypes(inputDir: string, outputDir: string, o
   let ids: string[] = [];
   let typePaths: string[] = [];
 
-  const systemsPath = `${inputDir}/*.sol`;
+  const srcDir = await getSrcDir();
+  const systemsPath = path.join(srcDir, systemsDir, "*.sol");
 
   const [resolve, , promise] = deferred<void>();
   glob(systemsPath, {}, (_, matches) => {
@@ -133,5 +137,5 @@ export async function generateTypes(abiDir?: string, outputDir = "./types", opti
   }
 
   await generateAbiTypes(abiDir, path.join(outputDir, "ethers-contracts"), options);
-  await generateSystemTypes("./src/systems", outputDir, options);
+  await generateSystemTypes(outputDir, options);
 }


### PR DESCRIPTION
Adds forge config getter; and replaces all hardcoded instances of `src`, `test`, `out` with getDir functions.
I also add some constants for `systems` and `components` dirs to the top of the files where they're used.

`inputDir` is removed from systemTypes because it only allows overriding the hardcoded `src`, which now isn't hardcoded (overriding `systems` directory wouldn't work well, and isn't useful for just 1 command).

`src` and `out` changes are seamless, but `test` changes require users to:
- either add `test = src/test` to `foundry.toml`
- or move their `src/test` to `test`
