### PR TITLE
refactor(store): rename events

### DIFF
--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -5,9 +5,9 @@ import { SchemaType } from "./Types.sol";
 import { Schema } from "./Schema.sol";
 
 interface IStore {
-  event MudStoreSetRecord(bytes32 table, bytes32[] key, bytes data);
-  event MudStoreSetField(bytes32 table, bytes32[] key, uint8 schemaIndex, bytes data);
-  event MudStoreDeleteRecord(bytes32 table, bytes32[] key);
+  event StoreSetRecord(bytes32 table, bytes32[] key, bytes data);
+  event StoreSetField(bytes32 table, bytes32[] key, uint8 schemaIndex, bytes data);
+  event StoreDeleteRecord(bytes32 table, bytes32[] key);
 
   function registerSchema(bytes32 table, Schema schema) external;
 

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -14,9 +14,9 @@ import { IStoreHook } from "./IStore.sol";
 
 library StoreCore {
   // note: the preimage of the tuple of keys used to index is part of the event, so it can be used by indexers
-  event MudStoreSetRecord(bytes32 table, bytes32[] key, bytes data);
-  event MudStoreSetField(bytes32 table, bytes32[] key, uint8 schemaIndex, bytes data);
-  event MudStoreDeleteRecord(bytes32 table, bytes32[] key);
+  event StoreSetRecord(bytes32 table, bytes32[] key, bytes data);
+  event StoreSetField(bytes32 table, bytes32[] key, uint8 schemaIndex, bytes data);
+  event StoreDeleteRecord(bytes32 table, bytes32[] key);
 
   error StoreCore_TableAlreadyExists(bytes32 table);
   error StoreCore_TableNotFound(bytes32 table);
@@ -116,7 +116,7 @@ library StoreCore {
     }
 
     // Emit event to notify indexers
-    emit MudStoreSetRecord(table, key, data);
+    emit StoreSetRecord(table, key, data);
 
     // Call onSetRecord hooks (before actually modifying the state, so observers have access to the previous state if needed)
     address[] memory hooks = HooksTable.get(table);
@@ -171,7 +171,7 @@ library StoreCore {
     Schema schema = getSchema(table);
 
     // Emit event to notify indexers
-    emit MudStoreSetField(table, key, schemaIndex, data);
+    emit StoreSetField(table, key, schemaIndex, data);
 
     // Call onSetField hooks (before actually modifying the state, so observers have access to the previous state if needed)
     address[] memory hooks = HooksTable.get(table);
@@ -192,7 +192,7 @@ library StoreCore {
     Schema schema = getSchema(table);
 
     // Emit event to notify indexers
-    emit MudStoreDeleteRecord(table, key);
+    emit StoreDeleteRecord(table, key);
 
     // Call onDeleteRecord hooks (before actually modifying the state, so observers have access to the previous state if needed)
     address[] memory hooks = HooksTable.get(table);
@@ -332,7 +332,7 @@ library StoreCoreInternal {
     Storage.store({ storagePointer: location, data: schema.unwrap() });
 
     // Emit an event to notify indexers
-    emit StoreCore.MudStoreSetRecord(SCHEMA_TABLE, key, abi.encodePacked(schema.unwrap()));
+    emit StoreCore.StoreSetRecord(SCHEMA_TABLE, key, abi.encodePacked(schema.unwrap()));
   }
 
   /************************************************************************

--- a/packages/store/test/StoreCore.t.sol
+++ b/packages/store/test/StoreCore.t.sol
@@ -61,11 +61,11 @@ contract StoreCoreTest is Test, StoreView {
 
     bytes32 table = keccak256("some.table");
 
-    // Expect a MudStoreSetRecord event to be emitted
+    // Expect a StoreSetRecord event to be emitted
     bytes32[] memory key = new bytes32[](1);
     key[0] = table;
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetRecord(StoreCoreInternal.SCHEMA_TABLE, key, abi.encodePacked(schema.unwrap()));
+    emit StoreSetRecord(StoreCoreInternal.SCHEMA_TABLE, key, abi.encodePacked(schema.unwrap()));
 
     // !gasreport StoreCore: register schema
     StoreCore.registerSchema(table, schema);
@@ -155,9 +155,9 @@ contract StoreCoreTest is Test, StoreView {
     bytes32[] memory key = new bytes32[](1);
     key[0] = keccak256("some.key");
 
-    // Expect a MudStoreSetRecord event to be emitted
+    // Expect a StoreSetRecord event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetRecord(table, key, data);
+    emit StoreSetRecord(table, key, data);
 
     // !gasreport set static record (1 slot)
     StoreCore.setRecord(table, key, data);
@@ -200,9 +200,9 @@ contract StoreCoreTest is Test, StoreView {
     bytes32[] memory key = new bytes32[](1);
     key[0] = keccak256("some.key");
 
-    // Expect a MudStoreSetRecord event to be emitted
+    // Expect a StoreSetRecord event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetRecord(table, key, data);
+    emit StoreSetRecord(table, key, data);
 
     // !gasreport set static record (2 slots)
     StoreCore.setRecord(table, key, data);
@@ -262,9 +262,9 @@ contract StoreCoreTest is Test, StoreView {
     bytes32[] memory key = new bytes32[](1);
     key[0] = bytes32("some.key");
 
-    // Expect a MudStoreSetRecord event to be emitted
+    // Expect a StoreSetRecord event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetRecord(table, key, data);
+    emit StoreSetRecord(table, key, data);
 
     // Set data
     // !gasreport set complex record with dynamic data (4 slots)
@@ -313,9 +313,9 @@ contract StoreCoreTest is Test, StoreView {
     bytes32[] memory key = new bytes32[](1);
     key[0] = bytes32("some.key");
 
-    // Expect a MudStoreSetField event to be emitted
+    // Expect a StoreSetField event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetField(table, key, 0, abi.encodePacked(firstDataBytes));
+    emit StoreSetField(table, key, 0, abi.encodePacked(firstDataBytes));
 
     // Set first field
     // !gasreport set static field (1 slot)
@@ -339,9 +339,9 @@ contract StoreCoreTest is Test, StoreView {
     // Set second field
     bytes32 secondDataBytes = keccak256("some data");
 
-    // Expect a MudStoreSetField event to be emitted
+    // Expect a StoreSetField event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetField(table, key, 1, abi.encodePacked(secondDataBytes));
+    emit StoreSetField(table, key, 1, abi.encodePacked(secondDataBytes));
 
     // !gasreport set static field (overlap 2 slot)
     StoreCore.setField(table, key, 1, abi.encodePacked(secondDataBytes));
@@ -387,9 +387,9 @@ contract StoreCoreTest is Test, StoreView {
       fourthDataBytes = Bytes.from(fourthData);
     }
 
-    // Expect a MudStoreSetField event to be emitted
+    // Expect a StoreSetField event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetField(table, key, 2, thirdDataBytes);
+    emit StoreSetField(table, key, 2, thirdDataBytes);
 
     // Set third field
     // !gasreport set dynamic field (1 slot, first dynamic field)
@@ -411,9 +411,9 @@ contract StoreCoreTest is Test, StoreView {
     assertEq(bytes16(StoreCore.getField(table, key, 0)), bytes16(firstDataBytes));
     assertEq(bytes32(StoreCore.getField(table, key, 1)), bytes32(secondDataBytes));
 
-    // Expect a MudStoreSetField event to be emitted
+    // Expect a StoreSetField event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreSetField(table, key, 3, fourthDataBytes);
+    emit StoreSetField(table, key, 3, fourthDataBytes);
 
     // Set fourth field
     // !gasreport set dynamic field (1 slot, second dynamic field)
@@ -492,9 +492,9 @@ contract StoreCoreTest is Test, StoreView {
     assertEq(loadedData.length, data.length);
     assertEq(keccak256(loadedData), keccak256(data));
 
-    // Expect a MudStoreDeleteRecord event to be emitted
+    // Expect a StoreDeleteRecord event to be emitted
     vm.expectEmit(true, true, true, true);
-    emit MudStoreDeleteRecord(table, key);
+    emit StoreDeleteRecord(table, key);
 
     // Delete data
     // !gasreport delete record (complex data, 3 slots)


### PR DESCRIPTION
Nothing else is prefixed, so renaming these for consistency.