### PR TITLE
fix(network): add explicit return type to createFaucetService

### DIFF
--- a/packages/network/src/createFaucetService.ts
+++ b/packages/network/src/createFaucetService.ts
@@ -1,11 +1,14 @@
 import { FaucetServiceDefinition } from "@latticexyz/services/protobuf/ts/faucet/faucet";
-import { createChannel, createClient } from "nice-grpc-web";
+import { createChannel, createClient, RawClient } from "nice-grpc-web";
+import { FromTsProtoServiceDefinition } from "nice-grpc-web/lib/service-definitions/ts-proto";
 
 /**
  * Create a FaucetServiceClient
  * @param url FaucetService URL
  * @returns FaucetServiceClient
  */
-export function createFaucetService(url: string) {
+export function createFaucetService(
+  url: string
+): RawClient<FromTsProtoServiceDefinition<typeof FaucetServiceDefinition>> {
   return createClient(FaucetServiceDefinition, createChannel(url));
 }


### PR DESCRIPTION
Hopefully fixes the bug created (revealed?) by #328
Seems related to https://github.com/microsoft/TypeScript/issues/42873

