### PR TITLE
chore: update discord invite to land in #welcome instead of #team

### DIFF
--- a/retype.yml
+++ b/retype.yml
@@ -19,7 +19,7 @@ links:
   - text: GitHub
     link: https://github.com/latticexyz/mud
   - text: Discord
-    link: https://discord.gg/XhZp6HbqNp
+    link: https://discord.gg/CzXAgtFqgq
   - text: Twitter
     link: https://twitter.com/latticexyz
 edit:


### PR DESCRIPTION
The previous invite link lands in #team and apparently errs for some people. Created a new one (that does not expire) to land in #welcome