### PR TITLE
fix(create-mud): attempt to fix build/install issues

### DIFF
--- a/packages/create-mud/package.json
+++ b/packages/create-mud/package.json
@@ -10,7 +10,7 @@
     "templates"
   ],
   "scripts": {
-    "prepare": "cd ../../node_modules/create-create-app && npm run build",
+    "prepare": "yarn build",
     "build": "tsup src/cli.ts --minify",
     "clean": "shx rm -rf lib",
     "dev": "tsup src/cli.ts --watch",
@@ -18,7 +18,7 @@
     "test": "echo \"TODO\""
   },
   "dependencies": {
-    "create-create-app": "git+https://github.com/holic/create-create-app#41d44df2f1b2be760eaf53281a1d6a8102a76a3d"
+    "create-create-app": "git+https://github.com/holic/create-create-app#8191d0c89c3620940c21bad35786b1f0a3b0e9fc"
   },
   "devDependencies": {
     "@types/node": "^17.0.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5920,9 +5920,9 @@ crc-32@^1.2.0:
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
   integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
 
-"create-create-app@git+https://github.com/holic/create-create-app#41d44df2f1b2be760eaf53281a1d6a8102a76a3d":
+"create-create-app@git+https://github.com/holic/create-create-app#8191d0c89c3620940c21bad35786b1f0a3b0e9fc":
   version "7.3.0"
-  resolved "git+https://github.com/holic/create-create-app#41d44df2f1b2be760eaf53281a1d6a8102a76a3d"
+  resolved "git+https://github.com/holic/create-create-app#8191d0c89c3620940c21bad35786b1f0a3b0e9fc"
   dependencies:
     "@types/yargs-interactive" "^2.1.3"
     chalk "^4"


### PR DESCRIPTION
Attempting to `yarn create mud` with the current version fails due to an unbuilt git dependency (fork of create-create-app):

```
success Installed "create-mud@1.35.0" with binaries:
      - create-mud
[#############################################################################################################################################] 396/396node:internal/modules/cjs/loader:401
      throw err;
      ^

Error: Cannot find module '/Users/kevin/.config/yarn/global/node_modules/create-mud/node_modules/create-create-app/lib/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:393:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:606:18)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:971:27)
    at Function.Module._load (node:internal/modules/cjs/loader:833:27)
    at Module.require (node:internal/modules/cjs/loader:1057:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/kevin/.config/yarn/global/node_modules/create-mud/dist/cli.js:2:20)
    at Module._compile (node:internal/modules/cjs/loader:1155:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/kevin/.config/yarn/global/node_modules/create-mud/node_modules/create-create-app/package.json',
  requestPath: 'create-create-app'
}
error Command failed.
Exit code: 1
```

I've since [checked in build artifacts](https://github.com/holic/create-create-app/commit/8191d0c89c3620940c21bad35786b1f0a3b0e9fc) in hopes that this resolves the issues.