### PR TITLE
fix: package entry points, peer dep versions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@latticexyz/cli",
   "version": "1.36.1",
   "description": "Command line interface for mud",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "license": "MIT",
   "bin": {
     "mud": "./dist/index.js"

--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -3,7 +3,7 @@
   "version": "1.36.1",
   "description": "Component Browser for RECS",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "type": "module",
   "types": "dist/index.d.ts",
   "repository": {
@@ -46,9 +46,9 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@latticexyz/recs": "^1.28.1",
-    "@latticexyz/std-client": "^1.28.1",
-    "@latticexyz/utils": "^1.28.1",
+    "@latticexyz/recs": "^1.36.1",
+    "@latticexyz/std-client": "^1.36.1",
+    "@latticexyz/utils": "^1.36.1",
     "lodash": "^4.17.21",
     "mobx": "^6.4.2",
     "mobx-react-lite": "^3.4.0",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "1.36.1",
   "source": "src/index.ts",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "engines": {
     "node": ">=16"
   },
@@ -30,10 +30,10 @@
   "peerDependencies": {
     "@ethersproject/providers": "^5.6.1",
     "@improbable-eng/grpc-web": "^0.15.0",
-    "@latticexyz/recs": "^1.28.1",
-    "@latticexyz/services": "^1.28.1",
-    "@latticexyz/solecs": "^1.28.1",
-    "@latticexyz/utils": "^1.28.1",
+    "@latticexyz/recs": "^1.36.1",
+    "@latticexyz/services": "^1.36.1",
+    "@latticexyz/solecs": "^1.36.1",
+    "@latticexyz/utils": "^1.36.1",
     "@protobuf-ts/grpcweb-transport": "^2.7.0",
     "async-mutex": "^0.3.2",
     "ethers": "^5.7.1",

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -2,7 +2,7 @@
   "name": "@latticexyz/noise",
   "version": "1.36.1",
   "source": "ts/index.ts",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "types": "dist/types.d.ts",
   "type": "module",
   "license": "MIT",

--- a/packages/phaserx/package.json
+++ b/packages/phaserx/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "1.36.1",
   "source": "src/index.ts",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/latticexyz/mud.git",
@@ -40,7 +40,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@latticexyz/utils": "^1.28.1",
+    "@latticexyz/utils": "^1.36.1",
     "mobx": "^6.5.0",
     "phaser": "3.60.0-beta.14",
     "rxjs": "^7.5.5"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,7 @@
     "release": "npm publish || echo 'version already published'"
   },
   "peerDependencies": {
-    "@latticexyz/recs": "^1.32.0",
+    "@latticexyz/recs": "^1.36.1",
     "mobx": "^6.4.2",
     "react": "^18.2.0",
     "rxjs": "^7.5.5"

--- a/packages/recs/package.json
+++ b/packages/recs/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "1.36.1",
   "source": "src/index.ts",
-  "main": "dist/index.js",
+  "main": "src/index.ts",
   "type": "module",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@latticexyz/utils": "^1",
+    "@latticexyz/utils": "^1.36.1",
     "mobx": "^6.4.2",
     "rxjs": "^7.5.5",
     "type-fest": "^2.14.0"

--- a/packages/std-client/package.json
+++ b/packages/std-client/package.json
@@ -50,10 +50,10 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@latticexyz/network": "^1.28.1",
-    "@latticexyz/recs": "^1.28.1",
-    "@latticexyz/solecs": "^1.28.1",
-    "@latticexyz/utils": "^1.28.1",
+    "@latticexyz/network": "^1.36.1",
+    "@latticexyz/recs": "^1.36.1",
+    "@latticexyz/solecs": "^1.36.1",
+    "@latticexyz/utils": "^1.36.1",
     "ethers": "^5.6.6",
     "lodash": "^4.17.21",
     "mobx": "^6.4.2",


### PR DESCRIPTION
lerna doesn't seem to be updating mud versions within `peerDependencies` and I noticed a bunch were out of date

also reverts the bad release that changed the `main` here: https://github.com/latticexyz/mud/commit/2e513a481c3588ea85254be6b042ddb6d9c32c5e