### PR TITLE
docs(emojimon): fix step 4, optimistic rendering for clicks

### DIFF
--- a/tutorials/emojimon/step-4.md
+++ b/tutorials/emojimon/step-4.md
@@ -54,23 +54,30 @@ import { useMUD } from "./MUDContext";
 
 export const GameBoard = () => {
   …
-  useEffect(() => {
-    const moveTo = async (x: number, y: number) => {
-      const positionId = uuid();
-      Position.addOverride(positionId, {
-        entity: playerEntity,
-        value: { x, y },
-      });
+  const moveTo = async (x: number, y: number) => {
+    const positionId = uuid();
+    Position.addOverride(positionId, {
+      entity: playerEntity,
+      value: { x, y },
+    });
 
-      try {
-        const tx = await systems["system.Move"].executeTyped({ x, y });
-        await tx.wait();
-      } finally {
-        Position.removeOverride(positionId);
-      }
-    };
+    try {
+      const tx = await systems["system.Move"].executeTyped({ x, y });
+      await tx.wait();
+    } finally {
+      Position.removeOverride(positionId);
+    }
+  };
+  useEffect(() => {
 
     const moveBy = async (deltaX: number, deltaY: number) => {
+…
+return (
+    …
+            onClick={async () => {
+              await moveTo(x,y)
+            }}
+   …
 ```
 
 Wow, isn't that so much snappier? It hardly feels like a blockchain game anymore.


### PR DESCRIPTION
I was getting an error in which the emoji didn't render -- the fix is in the "Override position value" in Step 4 of the tutorial. I realized that the Click handler was not calling `moveTo`. By moving it up in scope, and adding to `onClick` for each element in the grid, I was able to get the emoji to appear. 

For the edit on the bottom, I wanted optimistic responsivity for clicking as well as keystrokes. Without this edit, the keystroke and clicking function would be broken. 