### PR TITLE
refactor(network): rename GodID to SingletonID

### DIFF
--- a/packages/create-mud/templates/react/packages/client/src/App.tsx
+++ b/packages/create-mud/templates/react/packages/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { GodID as SingletonID, TxQueue } from "@latticexyz/network";
+import { SingletonID, TxQueue } from "@latticexyz/network";
 import { World } from "@latticexyz/recs";
 import { SystemTypes } from "contracts/types/SystemTypes";
 import { useComponentValue } from "@latticexyz/react";

--- a/packages/create-mud/templates/react/packages/client/src/index.tsx
+++ b/packages/create-mud/templates/react/packages/client/src/index.tsx
@@ -6,7 +6,7 @@ import { SystemAbis } from "contracts/types/SystemAbis.mjs";
 import { defineNumberComponent } from "@latticexyz/std-client";
 import { config } from "./config";
 import { App } from "./App";
-import { GodID as SingletonID } from "@latticexyz/network";
+import { SingletonID } from "@latticexyz/network";
 
 const rootElement = document.getElementById("react-root");
 if (!rootElement) throw new Error("React root not found");
@@ -28,14 +28,11 @@ export const components = {
 };
 
 // This is where the magic happens
-setupMUDNetwork<typeof components, SystemTypes>(
-  config,
-  world,
-  components,
-  SystemAbis
-).then(({ startSync, systems }) => {
-  // After setting up the network, we can tell MUD to start the synchronization process.
-  startSync();
+setupMUDNetwork<typeof components, SystemTypes>(config, world, components, SystemAbis).then(
+  ({ startSync, systems }) => {
+    // After setting up the network, we can tell MUD to start the synchronization process.
+    startSync();
 
-  root.render(<App world={world} systems={systems} components={components} />);
-});
+    root.render(<App world={world} systems={systems} components={components} />);
+  }
+);

--- a/packages/network/src/workers/SyncWorker.spec.ts
+++ b/packages/network/src/workers/SyncWorker.spec.ts
@@ -9,7 +9,7 @@ import { Components, EntityID } from "@latticexyz/recs";
 import { createCacheStore, storeEvent } from "./CacheStore";
 import * as syncUtils from "./syncUtils";
 import "fake-indexeddb/auto";
-import { GodID, SyncState } from "./constants";
+import { SingletonID, SyncState } from "./constants";
 import { createLatestEventStreamRPC, createLatestEventStreamService } from "./syncUtils";
 
 // Test constants
@@ -168,7 +168,7 @@ describe("Sync.worker", () => {
       type: NetworkEvents.NetworkComponentUpdate,
       component: keccak256("component.LoadingState"),
       value: { state: SyncState.LIVE, msg: "Streaming live events", percentage: 100 },
-      entity: GodID,
+      entity: SingletonID,
       txHash: "worker",
       lastEventInTx: false,
       blockNumber: 99,

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -46,7 +46,7 @@ import {
   fetchEventsInBlockRangeChunked,
 } from "./syncUtils";
 import { createBlockNumberStream } from "../createBlockNumberStream";
-import { GodID, SyncState } from "./constants";
+import { SingletonID, SyncState } from "./constants";
 import { debug as parentDebug } from "./debug";
 
 const debug = parentDebug.extend("SyncWorker");
@@ -90,7 +90,7 @@ export class SyncWorker<C extends Components> implements DoWork<Input, NetworkEv
       type: NetworkEvents.NetworkComponentUpdate,
       component: keccak256("component.LoadingState"),
       value: newLoadingState as unknown as ComponentValue<SchemaOf<C[keyof C]>>,
-      entity: GodID,
+      entity: SingletonID,
       txHash: "worker",
       lastEventInTx: false,
       blockNumber,

--- a/packages/network/src/workers/constants.ts
+++ b/packages/network/src/workers/constants.ts
@@ -6,4 +6,7 @@ export enum SyncState {
   LIVE,
 }
 
-export const GodID = "0x060d" as EntityID;
+export const SingletonID = "0x060d" as EntityID;
+
+/** @deprecated Import SingletonID instead */
+export const GodID = SingletonID;

--- a/packages/solecs/src/SingletonID.sol
+++ b/packages/solecs/src/SingletonID.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+uint256 constant SingletonID = 0x60D;

--- a/packages/std-client/src/utils.ts
+++ b/packages/std-client/src/utils.ts
@@ -17,7 +17,7 @@ import {
 } from "@latticexyz/recs";
 import { Coord, keccak256 } from "@latticexyz/utils";
 import { BigNumber } from "ethers";
-import { Clock, GodID } from "@latticexyz/network";
+import { Clock, SingletonID } from "@latticexyz/network";
 import { deferred } from "@latticexyz/utils";
 import { filter } from "rxjs";
 
@@ -55,10 +55,10 @@ export function getGameConfig(
   world: World,
   gameConfigComponent: Component<{ startTime: Type.String; turnLength: Type.String; actionCooldownLength: Type.String }>
 ) {
-  const godEntityIndex = world.entityToIndex.get(GodID);
-  if (godEntityIndex == null) return;
+  const singletonEntity = world.entityToIndex.get(SingletonID);
+  if (singletonEntity == null) return;
 
-  return getComponentValue(gameConfigComponent, godEntityIndex);
+  return getComponentValue(gameConfigComponent, singletonEntity);
 }
 
 export function isUntraversable(

--- a/tutorials/emojimon/step-4.md
+++ b/tutorials/emojimon/step-4.md
@@ -14,7 +14,7 @@ First, we need to wrap our `Position` component with `overridableComponent`. Thi
 import { world } from "./world";
 import { SystemAbis } from "contracts/types/SystemAbis.mjs";
 import { EntityID, overridableComponent } from "@latticexyz/recs";
-import { GodID as singletonEntityId } from "@latticexyz/network";
+import { SingletonID } from "@latticexyz/network";
 …
 export const setup = async () => {
   …
@@ -29,7 +29,7 @@ export const setup = async () => {
   return {
     ...result,
     world,
-    singletonEntityId,
+    singletonEntityId: SingletonID,
     singletonEntity,
     playerEntityId,
     playerEntity,


### PR DESCRIPTION
refactor(network): rename GodID to SingletonID
feat(solecs): add SingletonID

We currently have an implicit expectation of a "god ID" being present for emitting loading state data, etc. This is also a generally useful pattern for defining global state (e.g. game config).

I don't love the "god ID" name so I am also renaming it to "singleton ID" for clarity.

(I made these changes in the emojimon tutorial already, so porting upstream for cleanliness!)