### PR TITLE
feat(cli): deprecate create command

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -10,23 +10,21 @@ type Options = {
 export const command = "create <name>";
 export const desc = "Sets up a mud project into <name>. Requires yarn.";
 
+export const deprecated = true;
+
 export const builder: CommandBuilder<Options, Options> = (yargs) =>
   yargs
     .options({
-      template: { type: "string", desc: "Template to be used (available: [minimal])", default: "minimal" },
+      template: { type: "string", desc: "Template to be used (available: [minimal, react])", default: "minimal" },
     })
     .positional("name", { type: "string", default: "mud-app" });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const { name, template } = argv;
-  console.log(chalk.yellow.bold("Creating new mud project in", name));
-  let result = await execLog("git", ["clone", `https://github.com/latticexyz/mud-template-${template}`, name]);
+  console.log(chalk.red.bold("⚠️  This command will be removed soon. Use `yarn create mud` instead."));
+
+  const result = await execLog("yarn", ["create", "mud", name, "--template", template]);
   if (result.exitCode != 0) process.exit(result.exitCode);
 
-  console.log(chalk.yellow.bold("Installing dependencies..."));
-  result = await execLog("yarn", ["--cwd", `./${name}`]);
-  if (result.exitCode != 0) process.exit(result.exitCode);
-
-  console.log(chalk.yellow.bold(`Done! Run \`yarn dev\` in ${name} to get started.`));
   process.exit(0);
 };


### PR DESCRIPTION
Deprecates `mud create` cli command in favor of `yarn create mud`. This is a "bridge" commit that deprecates the command but still allows it to run (by using `yarn create mud` under the hood). In a future version, we should remove this command all together. Happy to do this sooner if you think that's warranted.

Also deprecated+archived the template repos:
https://github.com/latticexyz/mud-template-minimal
https://github.com/latticexyz/mud-template-react