### PR TITLE
feat(cli): log client world URL

### DIFF
--- a/packages/cli/src/commands/deploy-contracts.ts
+++ b/packages/cli/src/commands/deploy-contracts.ts
@@ -60,6 +60,9 @@ export const handler = async (args: Arguments<Options>): Promise<void> => {
   if (worldAddress && args.openUrl) {
     const url = new URL(args.openUrl);
     url.searchParams.set("worldAddress", worldAddress);
+    console.log("");
+    console.log(chalk.cyan("Opening client URL to", url.toString()));
+    console.log("");
     openurl.open(url.toString());
   }
 


### PR DESCRIPTION
Certain OS/platforms can't open URL automatically, so we should at least log it in the console to make it easier to access.