### PR TITLE
feat(react): option for useEntityQuery to re-render on value changes

### DIFF
--- a/packages/react/src/useEntityQuery.test.ts
+++ b/packages/react/src/useEntityQuery.test.ts
@@ -34,11 +34,13 @@ describe("useEntityQuery", () => {
     const entity3 = createEntity(world, []);
 
     const { result } = renderHook(() => useEntityQuery([Has(Position)]));
+    const { result: resultOnValueChange } = renderHook(() => useEntityQuery([Has(Position)], true));
 
     expect(result.current.length).toBe(2);
     expect(result.current).toContain(entity1);
     expect(result.current).toContain(entity2);
     expect(result.current).not.toContain(entity3);
+    expect(resultOnValueChange.current).toEqual(result.current);
 
     act(() => {
       setComponent(Position, entity3, { x: 0, y: 0 });
@@ -48,6 +50,7 @@ describe("useEntityQuery", () => {
     expect(result.current).toContain(entity1);
     expect(result.current).toContain(entity2);
     expect(result.current).toContain(entity3);
+    expect(resultOnValueChange.current).toEqual(result.current);
 
     act(() => {
       removeComponent(Position, entity1);
@@ -58,6 +61,7 @@ describe("useEntityQuery", () => {
     expect(result.current).not.toContain(entity1);
     expect(result.current).toContain(entity2);
     expect(result.current).not.toContain(entity3);
+    expect(resultOnValueChange.current).toEqual(result.current);
 
     act(() => {
       removeComponent(Position, entity2);
@@ -72,6 +76,7 @@ describe("useEntityQuery", () => {
     const entity3 = createEntity(world, []);
 
     const { result } = renderHook(() => useEntityQuery([Has(Position)]));
+    const { result: resultOnValueChange } = renderHook(() => useEntityQuery([Has(Position)], true));
 
     expect(result.all).toHaveLength(2);
     expect(result.current).toHaveLength(2);
@@ -79,12 +84,14 @@ describe("useEntityQuery", () => {
     expect(result.current).toContain(entity2);
     expect(result.current).not.toContain(entity3);
 
-    // Changing the an entity's component value should NOT re-render
+    // Changing an entity's component value should NOT re-render,
+    // unless recomputeOnValueChange === true
     act(() => {
       setComponent(Position, entity2, { x: 0, y: 0 });
     });
 
     expect(result.all).toHaveLength(2);
+    expect(resultOnValueChange.all).toHaveLength(3);
 
     // Changing a different component value should NOT re-render
     act(() => {
@@ -93,6 +100,7 @@ describe("useEntityQuery", () => {
     });
 
     expect(result.all).toHaveLength(2);
+    expect(resultOnValueChange.all).toHaveLength(3);
 
     // Changing which entities have the component should re-render
     act(() => {
@@ -100,6 +108,7 @@ describe("useEntityQuery", () => {
     });
 
     expect(result.all).toHaveLength(3);
+    expect(resultOnValueChange.all).toHaveLength(4);
     expect(result.current).toHaveLength(3);
     expect(result.current).toContain(entity1);
     expect(result.current).toContain(entity2);
@@ -111,6 +120,7 @@ describe("useEntityQuery", () => {
     });
 
     expect(result.all).toHaveLength(4);
+    expect(resultOnValueChange.all).toHaveLength(5);
     expect(result.current).toHaveLength(2);
     expect(result.current).toContain(entity2);
     expect(result.current).toContain(entity3);

--- a/packages/react/src/useEntityQuery.test.ts
+++ b/packages/react/src/useEntityQuery.test.ts
@@ -33,8 +33,10 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery([Has(Position)]));
-    const { result: resultOnValueChange } = renderHook(() => useEntityQuery([Has(Position)], true));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)], { recomputeOnValueChange: false }));
+    const { result: resultOnValueChange } = renderHook(() =>
+      useEntityQuery([Has(Position)], { recomputeOnValueChange: true })
+    );
 
     expect(result.current.length).toBe(2);
     expect(result.current).toContain(entity1);
@@ -75,8 +77,10 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery([Has(Position)]));
-    const { result: resultOnValueChange } = renderHook(() => useEntityQuery([Has(Position)], true));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)], { recomputeOnValueChange: false }));
+    const { result: resultOnValueChange } = renderHook(() =>
+      useEntityQuery([Has(Position)], { recomputeOnValueChange: true })
+    );
 
     expect(result.all).toHaveLength(2);
     expect(result.current).toHaveLength(2);

--- a/packages/react/src/useEntityQuery.test.ts
+++ b/packages/react/src/useEntityQuery.test.ts
@@ -33,9 +33,9 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery([Has(Position)], { recomputeOnValueChange: false }));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)], { updateOnValueChange: false }));
     const { result: resultOnValueChange } = renderHook(() =>
-      useEntityQuery([Has(Position)], { recomputeOnValueChange: true })
+      useEntityQuery([Has(Position)], { updateOnValueChange: true })
     );
 
     expect(result.current.length).toBe(2);
@@ -77,9 +77,9 @@ describe("useEntityQuery", () => {
     const entity2 = createEntity(world, [withValue(Position, { x: 2, y: 2 })]);
     const entity3 = createEntity(world, []);
 
-    const { result } = renderHook(() => useEntityQuery([Has(Position)], { recomputeOnValueChange: false }));
+    const { result } = renderHook(() => useEntityQuery([Has(Position)], { updateOnValueChange: false }));
     const { result: resultOnValueChange } = renderHook(() =>
-      useEntityQuery([Has(Position)], { recomputeOnValueChange: true })
+      useEntityQuery([Has(Position)], { updateOnValueChange: true })
     );
 
     expect(result.all).toHaveLength(2);
@@ -89,7 +89,7 @@ describe("useEntityQuery", () => {
     expect(result.current).not.toContain(entity3);
 
     // Changing an entity's component value should NOT re-render,
-    // unless recomputeOnValueChange === true
+    // unless updateOnValueChange === true
     act(() => {
       setComponent(Position, entity2, { x: 0, y: 0 });
     });

--- a/packages/react/src/useEntityQuery.ts
+++ b/packages/react/src/useEntityQuery.ts
@@ -12,11 +12,11 @@ import { distinctUntilChanged, map } from "rxjs";
  * and triggers a re-render as new query results come in.
  *
  * @param fragments Query fragments to match against, executed from left to right.
- * @param options.recomputeOnValueChange False - re-renders only on entity array changes. True (default) - also on component value changes.
+ * @param options.updateOnValueChange False - re-renders only on entity array changes. True (default) - also on component value changes.
  * @returns Set of entities matching the query fragments.
  */
-export function useEntityQuery(fragments: QueryFragment[], options?: { recomputeOnValueChange?: boolean }) {
-  const recomputeOnValueChange = options?.recomputeOnValueChange ?? true;
+export function useEntityQuery(fragments: QueryFragment[], options?: { updateOnValueChange?: boolean }) {
+  const updateOnValueChange = options?.updateOnValueChange ?? true;
 
   const stableFragments = useDeepMemo(fragments);
   const query = useMemo(() => defineQuery(stableFragments, { runOnInit: true }), [stableFragments]);
@@ -25,13 +25,13 @@ export function useEntityQuery(fragments: QueryFragment[], options?: { recompute
   useEffect(() => {
     setEntities([...query.matching]);
     let observable = query.update$.pipe(map(() => [...query.matching]));
-    if (!recomputeOnValueChange) {
+    if (!updateOnValueChange) {
       // re-render only on entity array changes
       observable = observable.pipe(distinctUntilChanged((a, b) => isEqual(a, b)));
     }
     const subscription = observable.subscribe((entities) => setEntities(entities));
     return () => subscription.unsubscribe();
-  }, [query, recomputeOnValueChange]);
+  }, [query, updateOnValueChange]);
 
   return entities;
 }

--- a/packages/react/src/useEntityQuery.ts
+++ b/packages/react/src/useEntityQuery.ts
@@ -12,10 +12,12 @@ import { distinctUntilChanged, map } from "rxjs";
  * and triggers a re-render as new query results come in.
  *
  * @param fragments Query fragments to match against, executed from left to right.
- * @param recomputeOnValueChange False - re-renders only on entity array changes. True - also on component value changes.
+ * @param options.recomputeOnValueChange False - re-renders only on entity array changes. True (default) - also on component value changes.
  * @returns Set of entities matching the query fragments.
  */
-export function useEntityQuery(fragments: QueryFragment[], recomputeOnValueChange = false) {
+export function useEntityQuery(fragments: QueryFragment[], options?: { recomputeOnValueChange?: boolean }) {
+  const recomputeOnValueChange = options?.recomputeOnValueChange ?? true;
+
   const stableFragments = useDeepMemo(fragments);
   const query = useMemo(() => defineQuery(stableFragments, { runOnInit: true }), [stableFragments]);
   const [entities, setEntities] = useState([...query.matching]);


### PR DESCRIPTION
I have 2 use-cases for this:
1. Getting values from 2+ components using a custom query (e.g. `HasValue` for one, `Has` for the other)
2. Complex chain of methods that use different components to resolve foreign keys. These methods are reused in different hooks with different nesting depths. The only way I see to do this semi-cleanly is to use non-hook getters that call each other while specifying which components they depend on, and then make it all re-render based on any changes to that array of components

1 can maybe be also solved with a more generalized `getComponentValues`
2 would need some deep foreign key support in recs or something, and even then it may not solve everything