### PR TITLE
refactor(cli): separate parseStoreConfig from loadStoreConfig

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,4 +1,5 @@
 export * from "./commonSchemas.js";
 export * from "./loadConfig.js";
 export * from "./loadStoreConfig.js";
+export * from "./parseStoreConfig.js";
 export * from "./validation.js";

--- a/packages/cli/src/config/loadStoreConfig.ts
+++ b/packages/cli/src/config/loadStoreConfig.ts
@@ -1,89 +1,7 @@
-import { SchemaType, getStaticByteLength } from "@latticexyz/schema-type";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { fromZodErrorCustom } from "../utils/errors.js";
-import { BaseRoute, ObjectName, OrdinaryRoute, ValueName } from "./commonSchemas.js";
 import { loadConfig } from "./loadConfig.js";
-
-const TableName = ObjectName;
-const KeyName = ValueName;
-const ColumnName = ValueName;
-
-const PrimaryKey = z
-  .nativeEnum(SchemaType)
-  .refine((arg) => getStaticByteLength(arg) > 0, "Primary key must not use dynamic SchemaType");
-const PrimaryKeys = z.record(KeyName, PrimaryKey).default({ key: SchemaType.BYTES32 });
-
-const Schema = z
-  .record(ColumnName, z.nativeEnum(SchemaType))
-  .refine((arg) => Object.keys(arg).length > 0, "Table schema may not be empty");
-
-const FullTable = z
-  .object({
-    route: OrdinaryRoute.default("/tables"),
-    tableIdArgument: z.boolean().default(false),
-    storeArgument: z.boolean().default(false),
-    primaryKeys: PrimaryKeys,
-    schema: Schema,
-    dataStruct: z.boolean().optional(),
-  })
-  .transform((arg) => {
-    // default dataStruct value depends on schema's length
-    if (Object.keys(arg.schema).length === 1) {
-      arg.dataStruct ??= false;
-    } else {
-      arg.dataStruct ??= true;
-    }
-    return arg as Omit<typeof arg, "dataStruct"> & Required<Pick<typeof arg, "dataStruct">>;
-  });
-
-const DefaultSingleValueTable = z.nativeEnum(SchemaType).transform((schemaType) => {
-  return FullTable.parse({
-    schema: {
-      value: schemaType,
-    },
-  });
-});
-
-export const StoreConfig = z.object({
-  baseRoute: BaseRoute.default(""),
-  storeImportPath: z.string().default("@latticexyz/store/src/"),
-  tables: z.record(TableName, z.union([DefaultSingleValueTable, FullTable])),
-});
-
-// zod doesn't preserve doc comments
-export interface StoreUserConfig {
-  /** The base route prefix for table ids. Default is "" (empty string) */
-  baseRoute?: string;
-  /** Path for store package imports. Default is "@latticexyz/store/src/" */
-  storeImportPath?: string;
-  /**
-   * Configuration for each table.
-   *
-   * The key is the table name (capitalized).
-   *
-   * The value:
-   *  - SchemaType for a single-value table (aka ECS component).
-   *  - FullTableConfig object for multi-value tables (or for customizable options).
-   */
-  tables: Record<string, SchemaType | FullTableConfig>;
-}
-
-interface FullTableConfig {
-  /** Output path for the file, and relevant for the table id. The table id will be keccak256(concat(baseRoute,route,tableName)). Default is "tables/" */
-  route?: string;
-  /** Make methods accept `tableId` argument instead of it being a hardcoded constant. Default is false */
-  tableIdArgument?: boolean;
-  /** Include methods that accept a manual `IStore` argument. Default is false. */
-  storeArgument?: boolean;
-  /** Include a data struct and methods for it. Default is false for 1-column tables; true for multi-column tables. */
-  dataStruct?: boolean;
-  /** Table's primary key names mapped to their types. Default is `{ key: SchemaType.BYTES32 }` */
-  primaryKeys?: Record<string, SchemaType>;
-  /** Table's column names mapped to their types. Table name's 1st letter should be lowercase. */
-  schema: Record<string, SchemaType>;
-}
-
-export type StoreConfig = z.output<typeof StoreConfig>;
+import { parseStoreConfig } from "./parseStoreConfig.js";
 
 export async function loadStoreConfig(configPath?: string) {
   const config = await loadConfig(configPath);
@@ -97,8 +15,4 @@ export async function loadStoreConfig(configPath?: string) {
       throw error;
     }
   }
-}
-
-export async function parseStoreConfig(config: unknown) {
-  return StoreConfig.parse(config);
 }

--- a/packages/cli/src/config/parseStoreConfig.test-d.ts
+++ b/packages/cli/src/config/parseStoreConfig.test-d.ts
@@ -1,8 +1,8 @@
 import { describe, expectTypeOf } from "vitest";
 import { z } from "zod";
-import { StoreConfig, StoreUserConfig } from "./loadStoreConfig.js";
+import { StoreConfig, StoreUserConfig } from "./parseStoreConfig.js";
 
-describe("loadStoreConfig", () => {
+describe("StoreUserConfig", () => {
   // Typecheck manual interfaces against zod
   expectTypeOf<StoreUserConfig>().toEqualTypeOf<z.input<typeof StoreConfig>>();
   // type equality isn't deep for optionals

--- a/packages/cli/src/config/parseStoreConfig.ts
+++ b/packages/cli/src/config/parseStoreConfig.ts
@@ -1,0 +1,88 @@
+import { SchemaType, getStaticByteLength } from "@latticexyz/schema-type";
+import { z } from "zod";
+import { BaseRoute, ObjectName, OrdinaryRoute, ValueName } from "./commonSchemas.js";
+
+const TableName = ObjectName;
+const KeyName = ValueName;
+const ColumnName = ValueName;
+
+const PrimaryKey = z
+  .nativeEnum(SchemaType)
+  .refine((arg) => getStaticByteLength(arg) > 0, "Primary key must not use dynamic SchemaType");
+const PrimaryKeys = z.record(KeyName, PrimaryKey).default({ key: SchemaType.BYTES32 });
+
+const Schema = z
+  .record(ColumnName, z.nativeEnum(SchemaType))
+  .refine((arg) => Object.keys(arg).length > 0, "Table schema may not be empty");
+
+const FullTable = z
+  .object({
+    route: OrdinaryRoute.default("/tables"),
+    tableIdArgument: z.boolean().default(false),
+    storeArgument: z.boolean().default(false),
+    primaryKeys: PrimaryKeys,
+    schema: Schema,
+    dataStruct: z.boolean().optional(),
+  })
+  .transform((arg) => {
+    // default dataStruct value depends on schema's length
+    if (Object.keys(arg.schema).length === 1) {
+      arg.dataStruct ??= false;
+    } else {
+      arg.dataStruct ??= true;
+    }
+    return arg as Omit<typeof arg, "dataStruct"> & Required<Pick<typeof arg, "dataStruct">>;
+  });
+
+const DefaultSingleValueTable = z.nativeEnum(SchemaType).transform((schemaType) => {
+  return FullTable.parse({
+    schema: {
+      value: schemaType,
+    },
+  });
+});
+
+export const StoreConfig = z.object({
+  baseRoute: BaseRoute.default(""),
+  storeImportPath: z.string().default("@latticexyz/store/src/"),
+  tables: z.record(TableName, z.union([DefaultSingleValueTable, FullTable])),
+});
+
+// zod doesn't preserve doc comments
+export interface StoreUserConfig {
+  /** The base route prefix for table ids. Default is "" (empty string) */
+  baseRoute?: string;
+  /** Path for store package imports. Default is "@latticexyz/store/src/" */
+  storeImportPath?: string;
+  /**
+   * Configuration for each table.
+   *
+   * The key is the table name (capitalized).
+   *
+   * The value:
+   *  - SchemaType for a single-value table (aka ECS component).
+   *  - FullTableConfig object for multi-value tables (or for customizable options).
+   */
+  tables: Record<string, SchemaType | FullTableConfig>;
+}
+
+interface FullTableConfig {
+  /** Output path for the file, and relevant for the table id. The table id will be keccak256(concat(baseRoute,route,tableName)). Default is "tables/" */
+  route?: string;
+  /** Make methods accept `tableId` argument instead of it being a hardcoded constant. Default is false */
+  tableIdArgument?: boolean;
+  /** Include methods that accept a manual `IStore` argument. Default is false. */
+  storeArgument?: boolean;
+  /** Include a data struct and methods for it. Default is false for 1-column tables; true for multi-column tables. */
+  dataStruct?: boolean;
+  /** Table's primary key names mapped to their types. Default is `{ key: SchemaType.BYTES32 }` */
+  primaryKeys?: Record<string, SchemaType>;
+  /** Table's column names mapped to their types. Table name's 1st letter should be lowercase. */
+  schema: Record<string, SchemaType>;
+}
+
+export type StoreConfig = z.output<typeof StoreConfig>;
+
+export async function parseStoreConfig(config: unknown) {
+  return StoreConfig.parse(config);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
-import { loadStoreConfig, parseStoreConfig } from "./config/loadStoreConfig.js";
+import { parseStoreConfig } from "./config/parseStoreConfig.js";
+import { loadStoreConfig } from "./config/loadStoreConfig.js";
 import { renderTablesFromConfig } from "./render-table/renderTablesFromConfig.js";
 import { renderTable } from "./render-table/renderTable.js";
 
-export type { StoreUserConfig, StoreConfig } from "./config/loadStoreConfig.js";
+export type { StoreUserConfig, StoreConfig } from "./config/parseStoreConfig.js";
 
 export { loadStoreConfig, parseStoreConfig, renderTablesFromConfig, renderTable };

--- a/packages/cli/src/render-table/renderTablesFromConfig.ts
+++ b/packages/cli/src/render-table/renderTablesFromConfig.ts
@@ -1,6 +1,6 @@
 import { renderTable } from "./renderTable.js";
 import { SchemaType, SchemaTypeArrayToElement, SchemaTypeId, getStaticByteLength } from "@latticexyz/schema-type";
-import { StoreConfig } from "../config/loadStoreConfig.js";
+import { StoreConfig } from "../config/parseStoreConfig.js";
 import {
   RenderTableDynamicField,
   RenderTableField,


### PR DESCRIPTION
Splitting out "parse" from "load" to avoid `path` import issues on client in prep for https://github.com/latticexyz/mud/pull/415