### PR TITLE
feat(network): Allow for eip-1559 (type 2) transactions in `network`

### DIFF
--- a/packages/network/src/createTxQueue.ts
+++ b/packages/network/src/createTxQueue.ts
@@ -119,12 +119,13 @@ export function createTxQueue<C extends Contracts>(
 
         // Populate config
         const configOverrides = {
-          gasPrice: gasPrice$.getValue(),
+          maxPriorityFeePerGas: gasPrice$.getValue() * 2,
+          maxFeePerGas: gasPrice$.getValue() * 4,
           ...overrides,
           nonce,
           gasLimit,
         };
-        if (options?.devMode) configOverrides.gasPrice = 0;
+        if (options?.devMode) configOverrides.maxPriorityFeePerGas = 0;
 
         // Populate tx
         const populatedTx = await member(...argsWithoutOverrides, configOverrides);


### PR DESCRIPTION
Problem was manually setting gasPrice in `createTxQueue` was forcing transactions to be submitted as legacy type, because you can't submit an eip1559 while overriding gasPrice.

This update instead sets the value of `maxPriorityFeePerGas` and `maxFeePerGas` which are the proper ways to set gas price using eip1559 anyway.