### PR TITLE
feat(world): ReverseMapping: infer target table id from source table id, add getKeysWithValue util

### DIFF
--- a/packages/world/gas-report.txt
+++ b/packages/world/gas-report.txt
@@ -1,14 +1,14 @@
-(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
-(test/ReverseMappingModule.t.sol) | Get list of keys with a given value [bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1))]: 9134
-(test/ReverseMappingModule.t.sol) | compute the target table selector [bytes32 targetTableSelector = getTargetTableSelector(sourceTableId)]: 3713
-(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
-(test/ReverseMappingModule.t.sol) | set a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 174769
-(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
-(test/ReverseMappingModule.t.sol) | change a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 140768
-(test/ReverseMappingModule.t.sol) | delete a record on a table with ReverseMappingModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 59457
-(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
-(test/ReverseMappingModule.t.sol) | set a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 184483
-(test/ReverseMappingModule.t.sol) | change a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 148827
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 393176
+(test/ReverseMappingModule.t.sol) | Get list of keys with a given value [bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1))]: 7672
+(test/ReverseMappingModule.t.sol) | compute the target table selector [bytes32 targetTableSelector = getTargetTableSelector(sourceTableId)]: 2245
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 393176
+(test/ReverseMappingModule.t.sol) | set a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 173310
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 393176
+(test/ReverseMappingModule.t.sol) | change a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 139308
+(test/ReverseMappingModule.t.sol) | delete a record on a table with ReverseMappingModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 57998
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 393176
+(test/ReverseMappingModule.t.sol) | set a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 181563
+(test/ReverseMappingModule.t.sol) | change a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 145908
 (test/World.t.sol) | Delete record [world.deleteRecord(namespace, file, singletonKey)]: 16115
 (test/World.t.sol) | Push data to the table [world.pushToField(namespace, file, keyTuple, 0, encodedData)]: 96477
 (test/World.t.sol) | Register a fallback system [bytes4 funcSelector1 = world.registerFunctionSelector(namespace, file, "", "")]: 81255

--- a/packages/world/gas-report.txt
+++ b/packages/world/gas-report.txt
@@ -1,8 +1,14 @@
-(test/ReverseMappingModule.t.sol) | set a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 170649
-(test/ReverseMappingModule.t.sol) | change a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 139166
-(test/ReverseMappingModule.t.sol) | delete a record on a table with ReverseMappingModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 57909
-(test/ReverseMappingModule.t.sol) | set a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 178822
-(test/ReverseMappingModule.t.sol) | change a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 145683
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
+(test/ReverseMappingModule.t.sol) | Get list of keys with a given value [bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1))]: 9134
+(test/ReverseMappingModule.t.sol) | compute the target table selector [bytes32 targetTableSelector = getTargetTableSelector(sourceTableId)]: 3713
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
+(test/ReverseMappingModule.t.sol) | set a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 174769
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
+(test/ReverseMappingModule.t.sol) | change a record on a table with ReverseMappingModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 140768
+(test/ReverseMappingModule.t.sol) | delete a record on a table with ReverseMappingModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 59457
+(test/ReverseMappingModule.t.sol) | install reverse mapping module [world.installRootModule(reverseMappingModule, abi.encode(sourceTableId))]: 394637
+(test/ReverseMappingModule.t.sol) | set a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 184483
+(test/ReverseMappingModule.t.sol) | change a field on a table with ReverseMappingModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 148827
 (test/World.t.sol) | Delete record [world.deleteRecord(namespace, file, singletonKey)]: 16115
 (test/World.t.sol) | Push data to the table [world.pushToField(namespace, file, keyTuple, 0, encodedData)]: 96477
 (test/World.t.sol) | Register a fallback system [bytes4 funcSelector1 = world.registerFunctionSelector(namespace, file, "", "")]: 81255

--- a/packages/world/src/modules/reversemapping/ReverseMappingHook.sol
+++ b/packages/world/src/modules/reversemapping/ReverseMappingHook.sol
@@ -6,8 +6,11 @@ import { IStoreHook } from "@latticexyz/store/src/IStore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { IWorld } from "@latticexyz/world/src/interfaces/IWorld.sol";
 
+import { ResourceSelector } from "../../ResourceSelector.sol";
+
 import { ReverseMapping } from "./tables/ReverseMapping.sol";
 import { ArrayLib } from "./ArrayLib.sol";
+import { getTargetTableSelector } from "./getTargetTableSelector.sol";
 
 /**
  * This is a very naive and inefficient implementation for now.
@@ -17,20 +20,13 @@ import { ArrayLib } from "./ArrayLib.sol";
  */
 contract ReverseMappingHook is IStoreHook {
   using ArrayLib for bytes32[];
+  using ResourceSelector for bytes32;
 
   error MultipleKeysNotSupported();
-  error InvalidTable(uint256 received, uint256 expected);
 
-  uint256 public immutable sourceTableId;
-  uint256 public immutable targetTableId;
-
-  constructor(uint256 _sourceTableId, uint256 _targetTableId) {
-    sourceTableId = _sourceTableId;
-    targetTableId = _targetTableId;
-  }
-
-  function onSetRecord(uint256 table, bytes32[] memory key, bytes memory data) public {
-    _sanityChecks(table, key);
+  function onSetRecord(uint256 sourceTableId, bytes32[] memory key, bytes memory data) public {
+    _requireSingleKey(key);
+    uint256 targetTableId = getTargetTableSelector(sourceTableId).toTableId();
 
     // Get the previous value
     bytes32 previousValue = keccak256(IWorld(msg.sender).getRecord(sourceTableId, key));
@@ -39,42 +35,44 @@ contract ReverseMappingHook is IStoreHook {
     if (previousValue == keccak256(data)) return;
 
     // Remove the key from the list of keys with the previous value
-    _removeKeyFromList(key[0], previousValue);
+    _removeKeyFromList(targetTableId, key[0], previousValue);
 
     // Push the key to the list of keys with the new value
     ReverseMapping.push(targetTableId, keccak256(data), key[0]);
   }
 
-  function onBeforeSetField(uint256 table, bytes32[] memory key, uint8, bytes memory) public {
-    _sanityChecks(table, key);
+  function onBeforeSetField(uint256 sourceTableId, bytes32[] memory key, uint8, bytes memory) public {
+    _requireSingleKey(key);
 
     // Remove the key from the list of keys with the previous value
     bytes32 previousValue = keccak256(IWorld(msg.sender).getRecord(sourceTableId, key));
-    _removeKeyFromList(key[0], previousValue);
+    uint256 targetTableId = getTargetTableSelector(sourceTableId).toTableId();
+    _removeKeyFromList(targetTableId, key[0], previousValue);
   }
 
-  function onAfterSetField(uint256 table, bytes32[] memory key, uint8, bytes memory) public {
-    _sanityChecks(table, key);
+  function onAfterSetField(uint256 sourceTableId, bytes32[] memory key, uint8, bytes memory) public {
+    _requireSingleKey(key);
 
     // Add the key to the list of keys with the new value
     bytes32 newValue = keccak256(IWorld(msg.sender).getRecord(sourceTableId, key));
+    uint256 targetTableId = getTargetTableSelector(sourceTableId).toTableId();
     ReverseMapping.push(targetTableId, newValue, key[0]);
   }
 
-  function onDeleteRecord(uint256 table, bytes32[] memory key) public {
-    _sanityChecks(table, key);
+  function onDeleteRecord(uint256 sourceTableId, bytes32[] memory key) public {
+    _requireSingleKey(key);
 
     // Remove the key from the list of keys with the previous value
     bytes32 previousValue = keccak256(IWorld(msg.sender).getRecord(sourceTableId, key));
-    _removeKeyFromList(key[0], previousValue);
+    uint256 targetTableId = getTargetTableSelector(sourceTableId).toTableId();
+    _removeKeyFromList(targetTableId, key[0], previousValue);
   }
 
-  function _sanityChecks(uint256 table, bytes32[] memory key) internal view {
+  function _requireSingleKey(bytes32[] memory key) internal pure {
     if (key.length > 1) revert MultipleKeysNotSupported();
-    if (table != sourceTableId) revert InvalidTable(table, sourceTableId);
   }
 
-  function _removeKeyFromList(bytes32 key, bytes32 valueHash) internal {
+  function _removeKeyFromList(uint256 targetTableId, bytes32 key, bytes32 valueHash) internal {
     // Get the keys with the previous value excluding the current key
     bytes32[] memory keysWithPreviousValue = ReverseMapping.get(targetTableId, valueHash).filter(key);
 

--- a/packages/world/src/modules/reversemapping/ReverseMappingModule.sol
+++ b/packages/world/src/modules/reversemapping/ReverseMappingModule.sol
@@ -32,8 +32,6 @@ import { getTargetTableSelector } from "./getTargetTableSelector.sol";
 contract ReverseMappingModule is IModule, WorldContext {
   using ResourceSelector for bytes32;
 
-  error CouldNotGrantAccess(string resource);
-
   // The reverse mapping hook is deployed once and infers the target table id
   // from the source table id (passed as argument to the hook methods)
   ReverseMappingHook immutable hook = new ReverseMappingHook();
@@ -43,7 +41,7 @@ contract ReverseMappingModule is IModule, WorldContext {
   }
 
   function install(bytes memory args) public override {
-    // Extract source and target table ids from args
+    // Extract source table id from args
     uint256 sourceTableId = abi.decode(args, (uint256));
     bytes32 targetTableSelector = getTargetTableSelector(sourceTableId);
 

--- a/packages/world/src/modules/reversemapping/constants.sol
+++ b/packages/world/src/modules/reversemapping/constants.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Limiting the module namespace to 12 bytes so the last 4 bytes
+// can be used for a hash of the source table to avoid collisions
+bytes12 constant MODULE_NAMESPACE = "valuekeylist";

--- a/packages/world/src/modules/reversemapping/constants.sol
+++ b/packages/world/src/modules/reversemapping/constants.sol
@@ -4,4 +4,4 @@ pragma solidity >=0.8.0;
 // Limiting the module namespace to 12 bytes so the last 4 bytes
 // can be used for an identifier of the source table namespace to avoid
 // collisions between tables with the same name in different namespaces
-bytes8 constant MODULE_NAMESPACE = "vkeylist";
+bytes8 constant MODULE_NAMESPACE = "revmap";

--- a/packages/world/src/modules/reversemapping/constants.sol
+++ b/packages/world/src/modules/reversemapping/constants.sol
@@ -2,5 +2,6 @@
 pragma solidity >=0.8.0;
 
 // Limiting the module namespace to 12 bytes so the last 4 bytes
-// can be used for a hash of the source table to avoid collisions
+// can be used for an identifier of the source table namespace to avoid
+// collisions between tables with the same name in different namespaces
 bytes12 constant MODULE_NAMESPACE = "valuekeylist";

--- a/packages/world/src/modules/reversemapping/constants.sol
+++ b/packages/world/src/modules/reversemapping/constants.sol
@@ -4,4 +4,4 @@ pragma solidity >=0.8.0;
 // Limiting the module namespace to 12 bytes so the last 4 bytes
 // can be used for an identifier of the source table namespace to avoid
 // collisions between tables with the same name in different namespaces
-bytes12 constant MODULE_NAMESPACE = "valuekeylist";
+bytes8 constant MODULE_NAMESPACE = "vkeylist";

--- a/packages/world/src/modules/reversemapping/getKeysWithValue.sol
+++ b/packages/world/src/modules/reversemapping/getKeysWithValue.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IStore } from "@latticexyz/store/src/IStore.sol";
+
+import { ResourceSelector } from "../../ResourceSelector.sol";
+import { MODULE_NAMESPACE } from "./constants.sol";
+import { getTargetTableSelector } from "./getTargetTableSelector.sol";
+
+import { ReverseMapping } from "./tables/ReverseMapping.sol";
+
+/**
+ * Get a list of keys with the given value.
+ *
+ * Note: this util can only be called within the context of a Store (e.g. from a System or Module).
+ * For usage outside of a Store, use the overload that takes an explicit store argument.
+ */
+function getKeysWithValue(uint256 tableId, bytes memory value) view returns (bytes32[] memory keysWithValue) {
+  // Get the corresponding reverse mapping table
+  uint256 reverseMappingTableId = uint256(getTargetTableSelector(tableId));
+
+  // Get the keys with the given value
+  keysWithValue = ReverseMapping.get(reverseMappingTableId, keccak256(value));
+}
+
+/**
+ * Get a list of keys with the given value for the given store.
+ */
+function getKeysWithValue(
+  IStore store,
+  uint256 tableId,
+  bytes memory value
+) view returns (bytes32[] memory keysWithValue) {
+  // Get the corresponding reverse mapping table
+  uint256 reverseMappingTableId = uint256(getTargetTableSelector(tableId));
+
+  // Get the keys with the given value
+  keysWithValue = ReverseMapping.get(reverseMappingTableId, store, keccak256(value));
+}

--- a/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
+++ b/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
@@ -7,28 +7,13 @@ import { MODULE_NAMESPACE } from "./constants.sol";
  * Get a deterministic selector for the reverse mapping table for the given source table.
  * The selector is constructed as follows:
  *  - The first 12 bytes are the module namespace
- *  - The next 4 bytes are an ASCII hash of the source table id (namespace + file)
+ *  - The next 4 bytes are the first 4 bytes of the source table namespace
  *    -- This is to avoid collisions between tables with the same name in different namespaces
- *    -- We use ASCII to make the selector readable in logs and errors
+ *       (Note that collisions are still possible if the first 4 bytes of the namespace are the same, in which case installing the module fails)
  *  - The last 16 bytes are the source table name
  */
 function getTargetTableSelector(uint256 sourceTableId) pure returns (bytes32) {
-  bytes16 tableName = ResourceSelector.getFile(ResourceSelector.from(sourceTableId));
-  bytes4 sourceTableHash = toPrintableASCII_bytes4(bytes4(keccak256(abi.encodePacked(sourceTableId))));
-  return bytes32(abi.encodePacked(MODULE_NAMESPACE, sourceTableHash, tableName));
-}
-
-/**
- * Map the given bytes to a printable ASCII character (32-126).
- */
-function toPrintableASCII_bytes1(bytes1 input) pure returns (bytes1) {
-  return bytes1(32 + uint8(input) / 3);
-}
-
-function toPrintableASCII_bytes4(bytes4 input) pure returns (bytes4) {
-  return
-    bytes4(toPrintableASCII_bytes1(input[0])) |
-    (bytes4(toPrintableASCII_bytes1(input[1])) >> 8) |
-    (bytes4(toPrintableASCII_bytes1(input[2])) >> 16) |
-    (bytes4(toPrintableASCII_bytes1(input[3])) >> 24);
+  bytes16 tableName = ResourceSelector.getFile(bytes32(sourceTableId));
+  bytes4 sourceTableNamespace = bytes4(bytes32(sourceTableId));
+  return bytes32(MODULE_NAMESPACE) | (bytes32(sourceTableNamespace) >> 96) | (bytes32(tableName) >> 128);
 }

--- a/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
+++ b/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import { ResourceSelector } from "../../ResourceSelector.sol";
+import { MODULE_NAMESPACE } from "./constants.sol";
+
+/**
+ * Get a deterministic selector for the reverse mapping table for the given source table.
+ * The selector is constructed as follows:
+ *  - The first 12 bytes are the module namespace
+ *  - The next 4 bytes are an ASCII hash of the source table id (namespace + file)
+ *    -- This is to avoid collisions between tables with the same name in different namespaces
+ *    -- We use ASCII to make the selector readable in logs and errors
+ *  - The last 16 bytes are the source table name
+ */
+function getTargetTableSelector(uint256 sourceTableId) pure returns (bytes32) {
+  bytes16 tableName = ResourceSelector.getFile(ResourceSelector.from(sourceTableId));
+  bytes4 sourceTableHash = toPrintableASCII_bytes4(bytes4(keccak256(abi.encodePacked(sourceTableId))));
+  return bytes32(abi.encodePacked(MODULE_NAMESPACE, sourceTableHash, tableName));
+}
+
+/**
+ * Map the given bytes to a printable ASCII character (32-126).
+ */
+function toPrintableASCII_bytes1(bytes1 input) pure returns (bytes1) {
+  return bytes1(32 + uint8(input) / 3);
+}
+
+function toPrintableASCII_bytes4(bytes4 input) pure returns (bytes4) {
+  return
+    bytes4(toPrintableASCII_bytes1(input[0])) |
+    (bytes4(toPrintableASCII_bytes1(input[1])) >> 8) |
+    (bytes4(toPrintableASCII_bytes1(input[2])) >> 16) |
+    (bytes4(toPrintableASCII_bytes1(input[3])) >> 24);
+}

--- a/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
+++ b/packages/world/src/modules/reversemapping/getTargetTableSelector.sol
@@ -6,14 +6,14 @@ import { MODULE_NAMESPACE } from "./constants.sol";
 /**
  * Get a deterministic selector for the reverse mapping table for the given source table.
  * The selector is constructed as follows:
- *  - The first 12 bytes are the module namespace
- *  - The next 4 bytes are the first 4 bytes of the source table namespace
+ *  - The first 8 bytes are the module namespace
+ *  - The next 8 bytes are the first 8 bytes of the source table namespace
  *    -- This is to avoid collisions between tables with the same name in different namespaces
  *       (Note that collisions are still possible if the first 4 bytes of the namespace are the same, in which case installing the module fails)
  *  - The last 16 bytes are the source table name
  */
 function getTargetTableSelector(uint256 sourceTableId) pure returns (bytes32) {
   bytes16 tableName = ResourceSelector.getFile(bytes32(sourceTableId));
-  bytes4 sourceTableNamespace = bytes4(bytes32(sourceTableId));
-  return bytes32(MODULE_NAMESPACE) | (bytes32(sourceTableNamespace) >> 96) | (bytes32(tableName) >> 128);
+  bytes8 sourceTableNamespace = bytes8(bytes32(sourceTableId));
+  return bytes32(MODULE_NAMESPACE) | (bytes32(sourceTableNamespace) >> 64) | (bytes32(tableName) >> 128);
 }

--- a/packages/world/test/ReverseMappingModule.t.sol
+++ b/packages/world/test/ReverseMappingModule.t.sol
@@ -173,11 +173,11 @@ contract ReverseMappingModuleTest is Test {
     // !gasreport compute the target table selector
     bytes32 targetTableSelector = getTargetTableSelector(sourceTableId);
 
-    // The first 12 bytes are the module namespace
-    assertEq(bytes12(targetTableSelector), MODULE_NAMESPACE);
+    // The first 8 bytes are the module namespace
+    assertEq(bytes8(targetTableSelector), MODULE_NAMESPACE);
 
     // followed by the first 4 bytes of the source table namespace
-    assertEq(bytes4(targetTableSelector << 96), bytes4(namespace));
+    assertEq(bytes8(targetTableSelector << 64), bytes8(namespace));
 
     // The last 16 bytes are the source file
     assertEq(targetTableSelector.getFile(), sourceFile);

--- a/packages/world/test/ReverseMappingModule.t.sol
+++ b/packages/world/test/ReverseMappingModule.t.sol
@@ -173,8 +173,12 @@ contract ReverseMappingModuleTest is Test {
     // !gasreport compute the target table selector
     bytes32 targetTableSelector = getTargetTableSelector(sourceTableId);
 
-    // The first 12 bytes are the module namespace, followed by 4 bytes of the hash of the source table id
+    // The first 12 bytes are the module namespace
     assertEq(bytes12(targetTableSelector), MODULE_NAMESPACE);
+
+    // followed by the first 4 bytes of the source table namespace
+    assertEq(bytes4(targetTableSelector << 96), bytes4(namespace));
+
     // The last 16 bytes are the source file
     assertEq(targetTableSelector.getFile(), sourceFile);
   }


### PR DESCRIPTION
This PR removes the need to install a different ReverseMappingHook for each table the hook is registered by inferring the target table id from the source table id. This also removes the need for users to manually define the target table id in the mud config, and enables a `getKeysWithValue` function that doesn't require users to keep track of mapping between source table and target table (or require us to do a storage access to do the mapping).