### PR TITLE
feat(cli): improve store config typehints, prepare for static array support

### DIFF
--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,13 +1,17 @@
-import { StringForUnion } from "../utils/typeUtils.js";
+import { ExtractUserTypes, StringForUnion } from "../utils/typeUtils.js";
 import { StoreUserConfig, StoreConfig } from "./parseStoreConfig.js";
 import { WorldUserConfig, ResolvedWorldConfig } from "./world/index.js";
 
-export type MUDUserConfig<EnumNames extends StringForUnion = StringForUnion> = StoreUserConfig<EnumNames> &
-  WorldUserConfig;
+export type MUDUserConfig<
+  EnumNames extends StringForUnion = StringForUnion,
+  StaticUserTypes extends ExtractUserTypes<EnumNames> = ExtractUserTypes<EnumNames>
+> = StoreUserConfig<EnumNames, StaticUserTypes> & WorldUserConfig;
 export type MUDConfig = StoreConfig & ResolvedWorldConfig;
 
-/** Type helper for defining MUDUserConfig */
-export function mudConfig<EnumNames extends StringForUnion = StringForUnion>(config: MUDUserConfig<EnumNames>) {
+export function mudConfig<
+  EnumNames extends StringForUnion = never,
+  StaticUserTypes extends ExtractUserTypes<EnumNames> = ExtractUserTypes<EnumNames>
+>(config: MUDUserConfig<EnumNames, StaticUserTypes>) {
   return config;
 }
 

--- a/packages/cli/src/config/validation.ts
+++ b/packages/cli/src/config/validation.ts
@@ -151,3 +151,13 @@ export function validateSelector(name: string, ctx: RefinementCtx) {
     });
   }
 }
+
+/** Returns null if the type does not look like a static array, otherwise element and length data */
+export function parseStaticArray(abiType: string) {
+  const matches = abiType.match(/^(\w+)\[(\d+)\]$/);
+  if (matches === null) return null;
+  return {
+    elementType: matches[1],
+    staticLength: Number.parseInt(matches[2]),
+  };
+}

--- a/packages/cli/src/config/validation.ts
+++ b/packages/cli/src/config/validation.ts
@@ -155,7 +155,7 @@ export function validateSelector(name: string, ctx: RefinementCtx) {
 /** Returns null if the type does not look like a static array, otherwise element and length data */
 export function parseStaticArray(abiType: string) {
   const matches = abiType.match(/^(\w+)\[(\d+)\]$/);
-  if (matches === null) return null;
+  if (!matches) return null;
   return {
     elementType: matches[1],
     staticLength: Number.parseInt(matches[2]),

--- a/packages/cli/src/utils/typeUtils.ts
+++ b/packages/cli/src/utils/typeUtils.ts
@@ -1,5 +1,11 @@
+import { AbiType, StaticAbiType } from "@latticexyz/schema-type";
+
 export type RequireKeys<T extends Record<string, unknown>, P extends string> = T & Required<Pick<T, P>>;
 
 // This allows unions between string literals and `string` without sacrificing autocompletion.
 // Workaround for https://github.com/Microsoft/TypeScript/issues/29729
 export type StringForUnion = string & Record<never, never>;
+
+export type StaticArray = `${StaticAbiType}[${number}]`;
+// static arrays and inferred enum names get mixed together - this helper separates them
+export type ExtractUserTypes<UnknownTypes extends StringForUnion> = Exclude<UnknownTypes, AbiType | StaticArray>;


### PR DESCRIPTION
This mostly just improves typehints, in particular the specific field/key with an invalid type is now highlighted, instead of a vague ts error about enums not having correct keys.
The improvements also allow to easily plug in support for static arrays, so that they just work without defining them as user types (this PR does not actually add support for static arrays)