### PR TITLE
feat(cli): namespace deploy output by chain id

### DIFF
--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -77,7 +77,6 @@ const commandModule: CommandModule<Options, Options> = {
 
       // Write deployment result to file (latest and timestamp)
       const chainId = await getChainId(rpc);
-      console.log("result", chainId);
       const outputDir = path.join(mudConfig.deploymentInfoDirectory, chainId.toString());
       mkdirSync(outputDir, { recursive: true });
       writeFileSync(path.join(outputDir, "latest.json"), JSON.stringify(deploymentInfo, null, 2));

--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -8,7 +8,7 @@ import { logError, MUDError } from "../utils/errors.js";
 import { forge, getRpcUrl, getSrcDirectory } from "../utils/foundry.js";
 import { mkdirSync, writeFileSync } from "fs";
 import { loadStoreConfig } from "../config/loadStoreConfig.js";
-import { deploymentInfoFilenamePrefix } from "../constants.js";
+import { getChainId } from "../utils/getChainId.js";
 
 type Options = {
   configPath?: string;
@@ -76,16 +76,12 @@ const commandModule: CommandModule<Options, Options> = {
       const deploymentInfo = await deploy(mudConfig, { ...args, rpc, privateKey });
 
       // Write deployment result to file (latest and timestamp)
-      const outputDir = mudConfig.deploymentInfoDirectory;
+      const chainId = await getChainId(rpc);
+      console.log("result", chainId);
+      const outputDir = path.join(mudConfig.deploymentInfoDirectory, chainId.toString());
       mkdirSync(outputDir, { recursive: true });
-      writeFileSync(
-        path.join(outputDir, deploymentInfoFilenamePrefix + "latest.json"),
-        JSON.stringify(deploymentInfo, null, 2)
-      );
-      writeFileSync(
-        path.join(outputDir, deploymentInfoFilenamePrefix + Date.now() + ".json"),
-        JSON.stringify(deploymentInfo, null, 2)
-      );
+      writeFileSync(path.join(outputDir, "latest.json"), JSON.stringify(deploymentInfo, null, 2));
+      writeFileSync(path.join(outputDir, Date.now() + ".json"), JSON.stringify(deploymentInfo, null, 2));
 
       console.log(chalk.bgGreen(chalk.whiteBright(`\n Deployment result (written to ${outputDir}): \n`)));
       console.log(deploymentInfo);

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,1 +1,0 @@
-export const deploymentInfoFilenamePrefix = "mud-deployment-";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,5 +14,3 @@ export type {
   MUDConfig,
 } from "./config/index.js";
 export { storeConfig, mudConfig } from "./config/index.js";
-
-export * from "./constants.js";

--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -28,7 +28,6 @@ export interface DeployConfig {
 export interface DeploymentInfo {
   blockNumber: number;
   worldAddress: string;
-  rpc: string;
 }
 
 export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): Promise<DeploymentInfo> {
@@ -302,7 +301,7 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
 
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));
 
-  return { worldAddress: await contractPromises.World, blockNumber, rpc };
+  return { worldAddress: await contractPromises.World, blockNumber };
 
   // ------------------- INTERNAL FUNCTIONS -------------------
   // (Inlined to avoid having to pass around nonce, signer and forgeOutDir)

--- a/packages/cli/src/utils/getChainId.ts
+++ b/packages/cli/src/utils/getChainId.ts
@@ -1,0 +1,10 @@
+import { ethers } from "ethers";
+
+// TODO: Use viem's getChainId
+export async function getChainId(rpc: string) {
+  const { result: chainId } = await ethers.utils.fetchJson(
+    rpc,
+    '{ "id": 42, "jsonrpc": "2.0", "method": "eth_chainId", "params": [ ] }'
+  );
+  return Number(chainId);
+}


### PR DESCRIPTION
- namespace deploy output by chain id
- change the naming schema for deploy output (just `latest.json` and `<timestamp>.json` instead of prefixed)
- remove `rpc` from the deployment json

Corresponding v2sandbox PR: https://github.com/latticexyz/v2sandbox/pull/10