### PR TITLE
fix(cli): add back in resolveTableId export for use with mudConfig

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 export { loadStoreConfig } from "./config/loadStoreConfig.js";
 export { parseStoreConfig } from "./config/parseStoreConfig.js";
 export { loadWorldConfig, resolveWorldConfig, parseWorldConfig } from "./config/world/index.js";
+export { resolveTableId } from "./config/dynamicResolution.js";
 
 export type {
   StoreUserConfig,
@@ -10,6 +11,7 @@ export type {
   MUDUserConfig,
   MUDConfig,
 } from "./config/index.js";
+
 export { storeConfig, mudConfig } from "./config/index.js";
 
 export * from "./constants.js";


### PR DESCRIPTION
Removed in #517 but didn't realize we needed this in https://github.com/latticexyz/v2sandbox/pull/7