### PR TITLE
feat(cli): rename deploymentInfoDirectory to deploysDirectory, default to ./deploys

### DIFF
--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -77,7 +77,7 @@ const commandModule: CommandModule<Options, Options> = {
 
       // Write deployment result to file (latest and timestamp)
       const chainId = await getChainId(rpc);
-      const outputDir = path.join(mudConfig.deploymentInfoDirectory, chainId.toString());
+      const outputDir = path.join(mudConfig.deploysDirectory, chainId.toString());
       mkdirSync(outputDir, { recursive: true });
       writeFileSync(path.join(outputDir, "latest.json"), JSON.stringify(deploymentInfo, null, 2));
       writeFileSync(path.join(outputDir, Date.now() + ".json"), JSON.stringify(deploymentInfo, null, 2));

--- a/packages/cli/src/config/world/parseWorldConfig.ts
+++ b/packages/cli/src/config/world/parseWorldConfig.ts
@@ -42,7 +42,7 @@ export const zWorldConfig = z.object({
   overrideSystems: z.record(zSystemName, zSystemConfig).default({}),
   excludeSystems: z.array(zSystemName).default([]),
   postDeployScript: z.string().default("PostDeploy"),
-  deploymentInfoDirectory: z.string().default("."),
+  deploysDirectory: z.string().default("./deploys"),
   worldgenDirectory: z.string().default("world"),
   worldImportPath: z.string().default("@latticexyz/world/src/"),
   modules: z.array(zModuleConfig).default([]),

--- a/packages/cli/src/config/world/userTypes.ts
+++ b/packages/cli/src/config/world/userTypes.ts
@@ -61,8 +61,8 @@ export interface WorldUserConfig {
    * Script must be placed in the forge scripts directory (see foundry.toml) and have a ".s.sol" extension.
    */
   postDeployScript?: string;
-  /** Directory to write the deployment info to (Default ".") */
-  deploymentInfoDirectory?: string;
+  /** Directory to write the deployment info to (Default "./deploys") */
+  deploysDirectory?: string;
   /** Directory to output system and world interfaces of `worldgen` (Default "world") */
   worldgenDirectory?: string;
   /** Path for world package imports. Default is "@latticexyz/world/src/" */


### PR DESCRIPTION
Just a small usability improvement ("deployment info" seemed like an internal name, not a great external one). Also defaults to `./deploys` since throwing a bunch of JSON in the cwd isn't a very nice thing to do - and containing it in a dir makes it easier to clean up, gitignore, etc.