### PR TITLE
feat(network): add option to sync in main thread instead of worker

### DIFF
--- a/packages/network/src/createSyncWorker.ts
+++ b/packages/network/src/createSyncWorker.ts
@@ -2,7 +2,7 @@ import { Components } from "@latticexyz/recs";
 import { fromWorker } from "@latticexyz/utils";
 import { map, Observable, Subject, timer } from "rxjs";
 import { NetworkEvent } from "./types";
-import { Input, Ack, ack } from "./workers/SyncWorker";
+import { Input, Ack, ack, SyncWorker } from "./workers/SyncWorker";
 
 /**
  * Create a new SyncWorker ({@link Sync.worker.ts}) to performn contract/client state sync.
@@ -14,22 +14,39 @@ import { Input, Ack, ack } from "./workers/SyncWorker";
  * dispose: function to dispose of the sync worker
  * }
  */
-export function createSyncWorker<C extends Components = Components>(ack$?: Observable<Ack>) {
+export function createSyncWorker<C extends Components = Components>(
+  ack$?: Observable<Ack>,
+  options?: { thread?: "main" | "worker" }
+) {
+  const thread = options?.thread || "worker";
   const input$ = new Subject<Input>();
-  const worker = new Worker(new URL("./workers/Sync.worker.ts", import.meta.url), { type: "module" });
   const ecsEvents$ = new Subject<NetworkEvent<C>[]>();
+  let dispose: () => void;
 
   // Send ack every 16ms if no external ack$ is provided
   ack$ = ack$ || timer(0, 16).pipe(map(() => ack));
   const ackSub = ack$.subscribe(input$);
 
-  // Pass in a "config stream", receive a stream of ECS events
-  const subscription = fromWorker<Input, NetworkEvent<C>[]>(worker, input$).subscribe(ecsEvents$);
-  const dispose = () => {
-    worker.terminate();
-    subscription?.unsubscribe();
-    ackSub?.unsubscribe();
-  };
+  // If thread option is "worker", create a new web worker to sync the state
+  if (thread === "worker") {
+    const worker = new Worker(new URL("./workers/Sync.worker.ts", import.meta.url), { type: "module" });
+
+    // Pass in a "config stream", receive a stream of ECS events
+    const subscription = fromWorker<Input, NetworkEvent<C>[]>(worker, input$).subscribe(ecsEvents$);
+    dispose = () => {
+      worker.terminate();
+      subscription?.unsubscribe();
+      ackSub?.unsubscribe();
+    };
+  } else {
+    // Otherwise sync the state in the main thread
+    // Pass in a "config stream", receive a stream of ECS events
+    const subscription = new SyncWorker<C>().work(input$).subscribe(ecsEvents$);
+    dispose = () => {
+      subscription?.unsubscribe();
+      ackSub?.unsubscribe();
+    };
+  }
 
   return {
     ecsEvents$,

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -238,7 +238,7 @@ export class SyncWorker<C extends Components> implements DoWork<Input, NetworkEv
           (percentage: number) => this.setLoadingState({ percentage }),
           config.pruneOptions
         );
-      } else {
+      } else if (!disableCache) {
         this.setLoadingState({ state: SyncState.INITIAL, msg: "Fetching initial state from cache", percentage: 0 });
         initialState = await loadIndexDbCacheStore(indexDbCache);
         this.setLoadingState({ percentage: 100 });

--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -33,7 +33,7 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
   world: World,
   contractComponents: C,
   SystemAbis: { [key in keyof SystemTypes]: ContractInterface },
-  options?: { initialGasPrice?: number; fetchSystemCalls?: boolean }
+  options?: { initialGasPrice?: number; fetchSystemCalls?: boolean; syncThread?: "main" | "worker" }
 ) {
   const SystemsRegistry = findOrDefineComponent(
     contractComponents,
@@ -158,7 +158,7 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
     provider: { externalProvider: _, ...providerConfig },
     ...syncWorkerConfig
   } = networkConfig;
-  const { ecsEvents$, input$, dispose } = createSyncWorker<C>(ack$);
+  const { ecsEvents$, input$, dispose } = createSyncWorker<C>(ack$, { thread: options?.syncThread });
   world.registerDisposer(dispose);
   function startSync() {
     input$.next({


### PR DESCRIPTION
Adds an option to `createSyncWorker` (and `setupMUDNetwork`) to instantiate the "SyncWorker" in the main thread instead of a worker thread.