### PR TITLE
build(store/world): release mud.config.mjs from store and world

### DIFF
--- a/packages/store/.gitignore
+++ b/packages/store/.gitignore
@@ -8,3 +8,4 @@ DOCS.md
 artifacts
 yarn-error.log
 API
+dist

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -5,3 +5,4 @@
 !types/**
 !package.json
 !README.md
+!dist/**

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,6 +4,10 @@
   "version": "1.41.0",
   "description": "Store",
   "types": "./types/ethers-contracts/",
+  "exports": {
+    "./mud.config.mjs": "./dist/mud.config.mjs",
+    "./*": "./*"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/latticexyz/mud.git",
@@ -15,7 +19,7 @@
     "codegen": "ts-node ./scripts/codegen.ts",
     "tablegen": "../cli/dist/mud.js tablegen",
     "test": "yarn codegen && forge test",
-    "build": "yarn codegen && rimraf out && forge build && yarn dist && yarn types",
+    "build": "yarn codegen && rimraf out && forge build && yarn dist && yarn types && tsup",
     "dist": "rimraf abi && mkdir abi && cp -rf out/*.sol/*.json abi/ && yarn rimraf abi/*.metadata.json",
     "types": "rimraf types && typechain --target=ethers-v5 abi/*.json",
     "prettier": "prettier --write 'src/**/*.sol'",
@@ -42,6 +46,7 @@
     "solhint": "^3.3.7",
     "solidity-docgen": "^0.6.0-beta.22",
     "ts-node": "^10.9.1",
+    "tsup": "^6.7.0",
     "typechain": "^8.1.1",
     "typedoc": "^0.23.10"
   },

--- a/packages/store/tsup.config.js
+++ b/packages/store/tsup.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["mud.config.mts"],
+  outDir: "dist",
+  format: ["esm"],
+  sourcemap: false,
+  clean: true,
+  bundle: false,
+});

--- a/packages/world/.gitignore
+++ b/packages/world/.gitignore
@@ -8,3 +8,4 @@ DOCS.md
 artifacts
 yarn-error.log
 API
+dist

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -5,3 +5,4 @@
 !types/**
 !package.json
 !README.md
+!dist/**

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -4,6 +4,10 @@
   "version": "1.41.0",
   "description": "World framework",
   "types": "./types/ethers-contracts/",
+  "exports": {
+    "./mud.config.mjs": "./dist/mud.config.mjs",
+    "./*": "./*"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/latticexyz/mud.git",
@@ -15,7 +19,7 @@
     "tablegen": "../cli/dist/mud.js tablegen",
     "worldgen": "../cli/dist/mud.js worldgen",
     "test": "forge test",
-    "build": "rimraf out && forge build && yarn dist && yarn types",
+    "build": "rimraf out && forge build && yarn dist && yarn types && tsup",
     "dist": "rimraf abi && mkdir abi && cp -rf out/*.sol/*.json abi/ && yarn rimraf abi/*.metadata.json",
     "types": "rimraf types && typechain --target=ethers-v5 abi/*.json",
     "prettier": "prettier --write 'src/**/*.sol'",
@@ -41,6 +45,7 @@
     "solhint": "^3.3.7",
     "solidity-docgen": "^0.6.0-beta.22",
     "ts-node": "^10.9.1",
+    "tsup": "^6.7.0",
     "typechain": "^8.1.1",
     "typedoc": "^0.23.10"
   },

--- a/packages/world/tsup.config.js
+++ b/packages/world/tsup.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["mud.config.mts"],
+  outDir: "dist",
+  format: ["esm"],
+  sourcemap: false,
+  clean: true,
+  bundle: false,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15654,6 +15654,26 @@ tsup@^6.6.3:
     sucrase "^3.20.3"
     tree-kill "^1.2.2"
 
+tsup@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/tsup/-/tsup-6.7.0.tgz#416f350f32a07b6ae86792ad7e52b0cafc566d64"
+  integrity sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==
+  dependencies:
+    bundle-require "^4.0.0"
+    cac "^6.7.12"
+    chokidar "^3.5.1"
+    debug "^4.3.1"
+    esbuild "^0.17.6"
+    execa "^5.0.0"
+    globby "^11.0.3"
+    joycon "^3.0.1"
+    postcss-load-config "^3.0.1"
+    resolve-from "^5.0.0"
+    rollup "^3.2.5"
+    source-map "0.8.0-beta.0"
+    sucrase "^3.20.3"
+    tree-kill "^1.2.2"
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"


### PR DESCRIPTION
We're using `@latticexyz/store/mud.config.mjs` and `@latticexyz/store/mud.config.mjs`, but those files didn't exist in the released version of the packages.

This PR adds a build step for `mud.config.mts` and configures the store/world's `package.json` to expose the configs as `@latticexyz/store/mud.config.mjs` / `@latticexyz/world/mud.config.mjs`

I extensively tested locally with `yalc` to verify this approach works and fixes the build issues in https://github.com/latticexyz/v2sandbox/pull/12