### PR TITLE
ci: release canaries as premajor

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint": "eslint . --ext .ts",
     "release": "yarn && lerna publish --no-private --force-publish && yarn retype:updateversion",
     "release:ci": "yarn && lerna publish --no-private --force-publish --yes --no-verify-access && yarn retype:updateversion",
-    "release:canary": "lerna publish --canary --no-private --force-publish",
+    "release:canary": "lerna publish premajor --canary --no-private --force-publish",
     "release:manual": "node scripts/workspaceRun.mjs release",
     "release:yalc": "(yarn entry:dist && yarn lerna exec npx yalc push); yarn entry:src",
     "foundryup": "curl -L https://foundry.paradigm.xyz | bash && bash ~/.foundry/bin/foundryup",


### PR DESCRIPTION
small change to the command used in the npm canary action to publish canaries at `2.0.0-alpha.x` instead of `1.41.1-alpha.x` 