### PR TITLE
build(world): report call with weird gas

### DIFF
--- a/packages/world/gas-report.txt
+++ b/packages/world/gas-report.txt
@@ -9,6 +9,7 @@
 (test/KeysWithValueModule.t.sol) | install keys with value module [world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))]: 600319
 (test/KeysWithValueModule.t.sol) | set a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 177731
 (test/KeysWithValueModule.t.sol) | change a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 142076
+(test/World.t.sol) | Call an autonomous system [world.call("namespace", "testSystem", abi.encodeWithSelector(WorldTestSystem.emitCallType.selector))]: 8797746687694640000
 (test/World.t.sol) | Delete record [world.deleteRecord(namespace, file, singletonKey)]: 16115
 (test/World.t.sol) | Push data to the table [world.pushToField(namespace, file, keyTuple, 0, encodedData)]: 96477
 (test/World.t.sol) | Register a fallback system [bytes4 funcSelector1 = world.registerFunctionSelector(namespace, file, "", "")]: 81251

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -580,6 +580,7 @@ contract WorldTest is Test {
     // Call the sysyem
     vm.expectEmit(true, true, true, true);
     emit WorldTestSystemLog("call");
+    // !gasreport Call an autonomous system
     world.call("namespace", "testSystem", abi.encodeWithSelector(WorldTestSystem.emitCallType.selector));
   }
 


### PR DESCRIPTION
dug into the cause of it too, seems to be when `isStore` gets called on `WorldTestSystem`, which doesn't have that method. A try-catch catches the error, but the invalid call creates the huge gas cost. Might just be a foundry glitch, not sure what's up with that