### PR TITLE
feat(network): add fastTxExecute util

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mud",
   "version": "0.0.0",
-  "description": "Mud is the fabric of autonomous worlds",
+  "description": "MUD is the fabric of autonomous worlds",
   "repository": {
     "type": "git",
     "url": "https://github.com/latticexyz/mud.git"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "lodash": "^4.17.21",
-    "vitest": "^0.29.8"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@ethersproject/providers": "^5.6.1",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "vitest": "^0.29.8"
   },
   "peerDependencies": {
     "@ethersproject/providers": "^5.6.1",

--- a/packages/network/src/createFastTxExecutor.ts
+++ b/packages/network/src/createFastTxExecutor.ts
@@ -1,6 +1,7 @@
-import { ArgumentsType } from "vitest";
 import { BigNumber, Contract, Overrides, Signer } from "ethers";
 import { JsonRpcProvider } from "@ethersproject/providers";
+
+type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never;
 
 /**
  * Create a stateful util to execute transactions as fast as possible.

--- a/packages/network/src/createFastTxExecutor.ts
+++ b/packages/network/src/createFastTxExecutor.ts
@@ -5,6 +5,11 @@ import { JsonRpcProvider } from "@ethersproject/providers";
 /**
  * Create a stateful util to execute transactions as fast as possible.
  * Internal state includes the current nonce and the current gas price.
+ *
+ * Note: since the signer's nonce is managed in the internal state of this
+ * function, using the same signer to send transactions outside of this function
+ * or creating multiple instances of this function with the same signer will result
+ * in nonce errors.
  */
 export async function createFastTxExecutor(
   signer: Signer & { provider: JsonRpcProvider },

--- a/packages/network/src/createFastTxExecutor.ts
+++ b/packages/network/src/createFastTxExecutor.ts
@@ -1,0 +1,111 @@
+import { ArgumentsType } from "vitest";
+import { BigNumber, Overrides, Signer } from "ethers";
+import { Provider } from "@ethersproject/providers";
+
+export async function createFastTxExecutor(
+  signer: Signer & { provider: Provider },
+  globalOptions: { priorityFeeMultiplier: number } = { priorityFeeMultiplier: 1.1 }
+) {
+  const currentNonce = {
+    nonce: await signer.getTransactionCount(),
+  };
+
+  const gasConfig: {
+    maxPriorityFeePerGas?: number;
+    maxFeePerGas?: BigNumber;
+  } = {};
+  updateFeePerGas(globalOptions.priorityFeeMultiplier);
+
+  /**
+   * Only await gas estimation (for speed), only execute if gas estimation succeeds (for safety)
+   */
+  async function fastTxExecute<C extends { estimateGas: any; [key: string]: any }, F extends keyof C>(
+    contract: C,
+    func: F,
+    args: ArgumentsType<C[F]>,
+    options: {
+      retryCount?: number;
+      debug?: boolean;
+    } = { retryCount: 0, debug: false }
+  ): Promise<Awaited<ReturnType<C[F]>>> {
+    const functionName = `${func as string}(${args.map((arg) => `'${arg}'`).join(",")})`;
+
+    try {
+      const { argsWithoutOverrides, overrides } = separateOverridesFromArgs(args);
+
+      console.log(`executing transaction: ${functionName} with nonce ${currentNonce.nonce}`);
+      const gasLimit = overrides.gasLimit ?? (await contract.estimateGas[func].apply(null, args));
+      console.log(`gas limit: ${gasLimit}`);
+
+      const txPromise = contract[func].apply(null, [
+        ...argsWithoutOverrides,
+        // Overrides are applied last, so they can override all other options
+        { gasLimit, nonce: currentNonce.nonce++, ...gasConfig, ...overrides },
+      ]);
+      return txPromise;
+    } catch (error: any) {
+      if (options.debug) console.error(error);
+
+      // Handle "transaction already imported" errors
+      if (error?.message.includes("transaction already imported")) {
+        if (options.retryCount === 0) {
+          // If the deployment failed because the transaction was already imported,
+          // retry with a higher priority fee
+          updateFeePerGas(globalOptions.priorityFeeMultiplier * 1.1);
+          return fastTxExecute(contract, func, args, { retryCount: options.retryCount++ });
+        } else throw new Error(`Gas estimation error for ${functionName}: ${error?.reason}`);
+      }
+
+      // Rethrow all other errors
+      throw error;
+    }
+  }
+
+  /**
+   * Set the maxFeePerGas and maxPriorityFeePerGas based on the current base fee and the given multiplier.
+   * The multiplier is used to allow replacing pending transactions.
+   * @param multiplier Multiplier to apply to the base fee
+   */
+  async function updateFeePerGas(multiplier: number) {
+    // Compute maxFeePerGas and maxPriorityFeePerGas like ethers, but allow for a multiplier to allow replacing pending transactions
+    const feeData = await signer.provider.getFeeData();
+    if (!feeData.lastBaseFeePerGas) throw new Error("Can not fetch lastBaseFeePerGas from RPC");
+
+    // Set the priority fee to 0 for development chains with no base fee, to allow transactions from unfunded wallets
+    gasConfig.maxPriorityFeePerGas = feeData.lastBaseFeePerGas.eq(0) ? 0 : Math.floor(1_500_000_000 * multiplier);
+    gasConfig.maxFeePerGas = feeData.lastBaseFeePerGas.mul(2).add(gasConfig.maxPriorityFeePerGas);
+  }
+
+  return {
+    fastTxExecute,
+    updateFeePerGas,
+    gasConfig: gasConfig as Readonly<typeof gasConfig>,
+    currentNonce: currentNonce as Readonly<typeof currentNonce>,
+  };
+}
+
+function separateOverridesFromArgs<T>(args: Array<T>) {
+  // Extract existing overrides from function call
+  const hasOverrides = args.length > 0 && isOverrides(args[args.length - 1]);
+  const overrides = (hasOverrides ? args[args.length - 1] : {}) as Overrides;
+  const argsWithoutOverrides = hasOverrides ? args.slice(0, args.length - 1) : args;
+
+  return { argsWithoutOverrides, overrides };
+}
+
+function isOverrides(obj: any): obj is Overrides {
+  if (typeof obj !== "object" || Array.isArray(obj) || obj === null) return false;
+  return (
+    "gasLimit" in obj ||
+    "gasPrice" in obj ||
+    "maxFeePerGas" in obj ||
+    "maxPriorityFeePerGas" in obj ||
+    "nonce" in obj ||
+    "type" in obj ||
+    "accessList" in obj ||
+    "customData" in obj ||
+    "value" in obj ||
+    "blockTag" in obj ||
+    "from" in obj
+  );
+}

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -15,3 +15,4 @@ export * from "./createRelayStream";
 export * from "./createBlockNumberStream";
 export * from "./createFaucetService";
 export * from "./utils";
+export * from "./createFastTxExecutor";


### PR DESCRIPTION
Moving some of the magic of `createTxQueue` into a simpler helper function. Totally optional for consumers, but here are some quick benchmarks for sending tx on the testnet:

With manual gas limit:
<img width="427" alt="CleanShot 2023-03-30 at 16 29 48@2x" src="https://user-images.githubusercontent.com/89248902/228870276-d07d4816-9d3a-4bec-82e1-7ce444e1d82b.png">

Without manual gas limit:
<img width="409" alt="CleanShot 2023-03-30 at 16 26 55@2x" src="https://user-images.githubusercontent.com/89248902/228870288-423bb0b1-1841-4c59-b417-1e8f5b582478.png">

Usually consumers in MUD don't have to await the result but only sending the transaction, so the first of the two numbers is more relevant

Corresponding v2sandbox branch: https://github.com/latticexyz/v2sandbox/pull/20
