### PR TITLE
feat(cli): add `mud test-v2` command

### DIFF
--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import glob from "glob";
 import path, { basename } from "path";
-import type { CommandModule } from "yargs";
+import type { CommandModule, Options } from "yargs";
 import { loadWorldConfig } from "../config/world/index.js";
 import { deploy } from "../utils/deploy-v2.js";
 import { logError, MUDError } from "../utils/errors.js";
@@ -10,71 +10,66 @@ import { mkdirSync, writeFileSync } from "fs";
 import { loadStoreConfig } from "../config/loadStoreConfig.js";
 import { getChainId } from "../utils/getChainId.js";
 
-type Options = {
+export type DeployOptions = {
   configPath?: string;
   printConfig?: boolean;
   profile?: string;
-  privateKey: string;
   priorityFeeMultiplier: number;
   clean?: boolean;
   debug?: boolean;
+  saveDeployment?: boolean;
 };
 
-const commandModule: CommandModule<Options, Options> = {
-  command: "deploy-v2",
-
-  describe: "Deploy MUD v2 contracts",
-
-  builder(yargs) {
-    return yargs.options({
-      configPath: { type: "string", desc: "Path to the config file" },
-      clean: { type: "boolean", desc: "Remove the build forge artifacts and cache directories before building" },
-      printConfig: { type: "boolean", desc: "Print the resolved config" },
-      profile: { type: "string", desc: "The foundry profile to use" },
-      debug: { type: "boolean", desc: "Print debug logs, like full error messages" },
-      priorityFeeMultiplier: {
-        type: "number",
-        desc: "Multiply the estimated priority fee by the provided factor",
-        default: 1,
-      },
-    });
+export const yDeployOptions = {
+  configPath: { type: "string", desc: "Path to the config file" },
+  clean: { type: "boolean", desc: "Remove the build forge artifacts and cache directories before building" },
+  printConfig: { type: "boolean", desc: "Print the resolved config" },
+  profile: { type: "string", desc: "The foundry profile to use" },
+  debug: { type: "boolean", desc: "Print debug logs, like full error messages" },
+  priorityFeeMultiplier: {
+    type: "number",
+    desc: "Multiply the estimated priority fee by the provided factor",
+    default: 1,
   },
+  saveDeployment: { type: "boolean", desc: "Save the deployment info to a file", default: true },
+} satisfies Record<keyof DeployOptions, Options>;
 
-  async handler(args) {
-    args.profile = args.profile ?? process.env.FOUNDRY_PROFILE;
-    const { configPath, printConfig, profile, clean } = args;
+export async function deployHandler(args: Parameters<(typeof commandModule)["handler"]>[0]) {
+  args.profile = args.profile ?? process.env.FOUNDRY_PROFILE;
+  const { configPath, printConfig, profile, clean } = args;
 
-    const rpc = await getRpcUrl(profile);
-    console.log(
-      chalk.bgBlue(
-        chalk.whiteBright(`\n Deploying MUD v2 contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`)
-      )
-    );
+  const rpc = await getRpcUrl(profile);
+  console.log(
+    chalk.bgBlue(
+      chalk.whiteBright(`\n Deploying MUD v2 contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`)
+    )
+  );
 
-    if (clean) await forge(["clean"], { profile });
+  if (clean) await forge(["clean"], { profile });
 
-    // Run forge build
-    await forge(["build"], { profile });
+  // Run forge build
+  await forge(["build"], { profile });
 
-    // Get a list of all contract names
-    const srcDir = await getSrcDirectory();
-    const existingContracts = glob
-      .sync(`${srcDir}/**/*.sol`)
-      // Get the basename of the file
-      .map((path) => basename(path, ".sol"));
+  // Get a list of all contract names
+  const srcDir = await getSrcDirectory();
+  const existingContracts = glob
+    .sync(`${srcDir}/**/*.sol`)
+    // Get the basename of the file
+    .map((path) => basename(path, ".sol"));
 
-    // Load and resolve the config
-    const worldConfig = await loadWorldConfig(configPath, existingContracts);
-    const storeConfig = await loadStoreConfig(configPath);
-    const mudConfig = { ...worldConfig, ...storeConfig };
+  // Load and resolve the config
+  const worldConfig = await loadWorldConfig(configPath, existingContracts);
+  const storeConfig = await loadStoreConfig(configPath);
+  const mudConfig = { ...worldConfig, ...storeConfig };
 
-    if (printConfig) console.log(chalk.green("\nResolved config:\n"), JSON.stringify(mudConfig, null, 2));
+  if (printConfig) console.log(chalk.green("\nResolved config:\n"), JSON.stringify(mudConfig, null, 2));
 
-    try {
-      const privateKey = process.env.PRIVATE_KEY;
-      if (!privateKey) throw new MUDError("Missing PRIVATE_KEY environment variable");
-      const deploymentInfo = await deploy(mudConfig, { ...args, rpc, privateKey });
+  try {
+    const privateKey = process.env.PRIVATE_KEY;
+    if (!privateKey) throw new MUDError("Missing PRIVATE_KEY environment variable");
+    const deploymentInfo = await deploy(mudConfig, { ...args, rpc, privateKey });
 
+    if (args.saveDeployment) {
       // Write deployment result to file (latest and timestamp)
       const chainId = await getChainId(rpc);
       const outputDir = path.join(mudConfig.deploysDirectory, chainId.toString());
@@ -83,12 +78,27 @@ const commandModule: CommandModule<Options, Options> = {
       writeFileSync(path.join(outputDir, Date.now() + ".json"), JSON.stringify(deploymentInfo, null, 2));
 
       console.log(chalk.bgGreen(chalk.whiteBright(`\n Deployment result (written to ${outputDir}): \n`)));
-      console.log(deploymentInfo);
-    } catch (error: any) {
-      logError(error);
-      process.exit(1);
     }
 
+    console.log(deploymentInfo);
+    return deploymentInfo;
+  } catch (error: any) {
+    logError(error);
+    process.exit(1);
+  }
+}
+
+const commandModule: CommandModule<DeployOptions, DeployOptions> = {
+  command: "deploy-v2",
+
+  describe: "Deploy MUD v2 contracts",
+
+  builder(yargs) {
+    return yargs.options(yDeployOptions);
+  },
+
+  async handler(args) {
+    await deployHandler(args);
     process.exit(0);
   },
 };

--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -18,6 +18,7 @@ export type DeployOptions = {
   clean?: boolean;
   debug?: boolean;
   saveDeployment?: boolean;
+  rpc?: string;
 };
 
 export const yDeployOptions = {
@@ -32,13 +33,14 @@ export const yDeployOptions = {
     default: 1,
   },
   saveDeployment: { type: "boolean", desc: "Save the deployment info to a file", default: true },
+  rpc: { type: "string", desc: "The RPC URL to use. Defaults to the RPC url from the local foundry.toml" },
 } satisfies Record<keyof DeployOptions, Options>;
 
 export async function deployHandler(args: Parameters<(typeof commandModule)["handler"]>[0]) {
   args.profile = args.profile ?? process.env.FOUNDRY_PROFILE;
   const { configPath, printConfig, profile, clean } = args;
 
-  const rpc = await getRpcUrl(profile);
+  const rpc = args.rpc ?? (await getRpcUrl(profile));
   console.log(
     chalk.bgBlue(
       chalk.whiteBright(`\n Deploying MUD v2 contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`)

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -18,6 +18,7 @@ import tsgen from "./tsgen.js";
 import deployV2 from "./deploy-v2.js";
 import worldgen from "./worldgen.js";
 import setVersion from "./set-version.js";
+import testV2 from "./test-v2.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each command has different options
 export const commands: CommandModule<any, any>[] = [
@@ -38,4 +39,5 @@ export const commands: CommandModule<any, any>[] = [
   types,
   worldgen,
   setVersion,
+  testV2,
 ];

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -1,8 +1,10 @@
 import type { CommandModule } from "yargs";
 import { deployHandler, DeployOptions } from "./deploy-v2.js";
 import { yDeployOptions } from "./deploy-v2.js";
+import { anvil } from "../utils/foundry.js";
+import chalk from "chalk";
 
-type Options = DeployOptions;
+type Options = DeployOptions & { port?: number; forkUrl?: string; worldAddress?: string };
 
 const commandModule: CommandModule<Options, Options> = {
   command: "test-v2",
@@ -10,13 +12,35 @@ const commandModule: CommandModule<Options, Options> = {
   describe: "Run tests in MUD v2 contracts",
 
   builder(yargs) {
-    return yargs.options({ ...yDeployOptions });
+    return yargs.options({
+      ...yDeployOptions,
+      port: { type: "number", description: "Port to run internal node for fork testing on", default: 4242 },
+      forkUrl: { type: "string", description: "Run tests by forking from a node" },
+      worldAddress: {
+        type: "string",
+        description: "Address of an existing world contract. If provided, deployment is skipped.",
+      },
+    });
   },
 
   async handler(args) {
-    // Deploy the contracts
-    const deploymentInfo = await deployHandler({ ...args, saveDeployment: false });
-    console.log("deployed to ", deploymentInfo.worldAddress);
+    const anvilArgs = ["--block-base-fee-per-gas", "0"];
+    if (args.port) anvilArgs.push("--port", String(args.port));
+    if (args.forkUrl) anvilArgs.push("--fork-url", args.forkUrl);
+
+    anvil(anvilArgs);
+
+    const worldAddress =
+      args.worldAddress ??
+      (
+        await deployHandler({
+          ...args,
+          saveDeployment: false,
+          rpc: args.port ? `http://127.0.0.1:${args.port}` : undefined,
+        })
+      ).worldAddress;
+
+    console.log(chalk.blue("World address", worldAddress));
 
     process.exit(0);
   },

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -1,10 +1,14 @@
 import type { CommandModule } from "yargs";
 import { deployHandler, DeployOptions } from "./deploy-v2.js";
 import { yDeployOptions } from "./deploy-v2.js";
-import { anvil } from "../utils/foundry.js";
+import { anvil, forge, getRpcUrl, getTestDirectory } from "../utils/foundry.js";
 import chalk from "chalk";
+import { rmSync, writeFileSync } from "fs";
+import path from "path";
 
-type Options = DeployOptions & { port?: number; forkUrl?: string; worldAddress?: string };
+type Options = DeployOptions & { port?: number; worldAddress?: string; forgeOptions?: string };
+
+const WORLD_ADDRESS_FILE = ".mudtest";
 
 const commandModule: CommandModule<Options, Options> = {
   command: "test-v2",
@@ -15,20 +19,23 @@ const commandModule: CommandModule<Options, Options> = {
     return yargs.options({
       ...yDeployOptions,
       port: { type: "number", description: "Port to run internal node for fork testing on", default: 4242 },
-      forkUrl: { type: "string", description: "Run tests by forking from a node" },
       worldAddress: {
         type: "string",
-        description: "Address of an existing world contract. If provided, deployment is skipped.",
+        description:
+          "Address of an existing world contract. If provided, deployment is skipped and the RPC provided in the foundry.toml is used for fork testing.",
       },
+      forgeOptions: { type: "string", description: "Options to pass to forge test" },
     });
   },
 
   async handler(args) {
-    const anvilArgs = ["--block-base-fee-per-gas", "0"];
-    if (args.port) anvilArgs.push("--port", String(args.port));
-    if (args.forkUrl) anvilArgs.push("--fork-url", args.forkUrl);
+    // Start an internal anvil process if no world address is provided
+    if (!args.worldAddress) {
+      const anvilArgs = ["--block-base-fee-per-gas", "0", "--port", String(args.port)];
+      anvil(anvilArgs);
+    }
 
-    anvil(anvilArgs);
+    const forkRpc = args.worldAddress ? await getRpcUrl(args.profile) : `http://127.0.0.1:${args.port}`;
 
     const worldAddress =
       args.worldAddress ??
@@ -36,11 +43,26 @@ const commandModule: CommandModule<Options, Options> = {
         await deployHandler({
           ...args,
           saveDeployment: false,
-          rpc: args.port ? `http://127.0.0.1:${args.port}` : undefined,
+          rpc: forkRpc,
         })
       ).worldAddress;
 
     console.log(chalk.blue("World address", worldAddress));
+
+    // Create a temporary file to pass the world address to the tests
+    writeFileSync(WORLD_ADDRESS_FILE, worldAddress);
+
+    const userOptions = args.forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
+    try {
+      const testResult = await forge(["test", "--fork-url", forkRpc, ...userOptions], {
+        profile: args.profile,
+      });
+      console.log(testResult);
+    } catch (e) {
+      console.error(e);
+    }
+
+    rmSync(WORLD_ADDRESS_FILE);
 
     process.exit(0);
   },

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -1,0 +1,25 @@
+import type { CommandModule } from "yargs";
+import { deployHandler, DeployOptions } from "./deploy-v2.js";
+import { yDeployOptions } from "./deploy-v2.js";
+
+type Options = DeployOptions;
+
+const commandModule: CommandModule<Options, Options> = {
+  command: "test-v2",
+
+  describe: "Run tests in MUD v2 contracts",
+
+  builder(yargs) {
+    return yargs.options({ ...yDeployOptions });
+  },
+
+  async handler(args) {
+    // Deploy the contracts
+    const deploymentInfo = await deployHandler({ ...args, saveDeployment: false });
+    console.log("deployed to ", deploymentInfo.worldAddress);
+
+    process.exit(0);
+  },
+};
+
+export default commandModule;

--- a/packages/cli/src/utils/foundry.ts
+++ b/packages/cli/src/utils/foundry.ts
@@ -92,3 +92,12 @@ export async function cast(args: string[], options?: { profile?: string }): Prom
     env: { FOUNDRY_PROFILE: options?.profile },
   });
 }
+
+/**
+ * Start an anvil chain
+ * @param args The arguments to pass to anvil
+ * @returns Stdout of the command
+ */
+export async function anvil(args: string[]): Promise<string> {
+  return execLog("anvil", args);
+}

--- a/packages/std-contracts/src/test/MudV2Test.t.sol
+++ b/packages/std-contracts/src/test/MudV2Test.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+
+contract MudV2Test is Test {
+  address worldAddress;
+
+  function setUp() public virtual {
+    worldAddress = vm.parseAddress(vm.readFile(".mudtest"));
+  }
+}


### PR DESCRIPTION
* This PR adds the `mud test-v2` cli command and corresponding `MudV2Test.t.sol` base class
* Without arguments, the command uses the project's mud config to create a deployment on a fresh anvil node, and then executes fork test on that fresh deployment
* With a `--worldAddress` argument, the deployment is skipped and the fork test are executed on the provided world address (and rpc url from the `foundry.toml`)

Corresponding v2sandbox PR: https://github.com/latticexyz/v2sandbox/pull/24
