### PR TITLE
feat(cli): add mud2 cli entrypoint with only v2 commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "license": "MIT",
   "bin": {
-    "mud": "./dist/mud.js"
+    "mud": "./dist/mud.js",
+    "mud2": "./dist/mud2.js"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/src/commands/deprecated/index.ts
+++ b/packages/cli/src/commands/deprecated/index.ts
@@ -1,0 +1,22 @@
+import { CommandModule } from "yargs";
+
+import bulkupload from "./bulkupload.js";
+import callSystem from "./call-system.js";
+import codegenLibdeploy from "./codegen-libdeploy.js";
+import deployContracts from "./deploy-contracts.js";
+import systemTypes from "./system-types.js";
+import test from "./test.js";
+import trace from "./trace.js";
+import types from "./types.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each command has different options
+export const commands: CommandModule<any, any>[] = [
+  bulkupload,
+  callSystem,
+  deployContracts,
+  codegenLibdeploy,
+  systemTypes,
+  test,
+  trace,
+  types,
+];

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,14 +1,5 @@
 import { CommandModule } from "yargs";
 
-import bulkupload from "./deprecated/bulkupload.js";
-import callSystem from "./deprecated/call-system.js";
-import codegenLibdeploy from "./deprecated/codegen-libdeploy.js";
-import deployContracts from "./deprecated/deploy-contracts.js";
-import systemTypes from "./deprecated/system-types.js";
-import test from "./deprecated/test.js";
-import trace from "./deprecated/trace.js";
-import types from "./deprecated/types.js";
-
 import devnode from "./devnode.js";
 import faucet from "./faucet.js";
 import gasReport from "./gas-report.js";
@@ -22,21 +13,13 @@ import testV2 from "./test-v2.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each command has different options
 export const commands: CommandModule<any, any>[] = [
-  bulkupload,
-  callSystem,
-  codegenLibdeploy,
-  deployContracts,
   deployV2,
   devnode,
   faucet,
   gasReport,
   hello,
-  systemTypes,
   tablegen,
   tsgen,
-  test,
-  trace,
-  types,
   worldgen,
   setVersion,
   testV2,

--- a/packages/cli/src/mud.ts
+++ b/packages/cli/src/mud.ts
@@ -15,7 +15,7 @@ yargs(hideBin(process.argv))
   .scriptName("mud")
   // Use the commands directory to scaffold
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- command array overload isn't typed, see https://github.com/yargs/yargs/blob/main/docs/advanced.md#esm-hierarchy
-  .command({ ...v1, ...v2 } as any)
+  .command([...v1, ...v2] as any)
   // Enable strict mode.
   .strict()
   // Custom error handler

--- a/packages/cli/src/mud2.ts
+++ b/packages/cli/src/mud2.ts
@@ -2,8 +2,7 @@
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { commands as v2 } from "./commands/index.js";
-import { commands as v1 } from "./commands/deprecated/index.js";
+import { commands } from "./commands/index.js";
 import { logError } from "./utils/errors.js";
 
 // Load .env file into process.env
@@ -15,7 +14,7 @@ yargs(hideBin(process.argv))
   .scriptName("mud")
   // Use the commands directory to scaffold
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- command array overload isn't typed, see https://github.com/yargs/yargs/blob/main/docs/advanced.md#esm-hierarchy
-  .command({ ...v1, ...v2 } as any)
+  .command(commands as any)
   // Enable strict mode.
   .strict()
   // Custom error handler

--- a/packages/cli/tsup.config.js
+++ b/packages/cli/tsup.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     "src/index.ts",
     "src/mud.ts",
+    "src/mud2.ts",
     "src/config/index.ts",
     "src/render-table/index.ts",
     "src/utils/index.ts",


### PR DESCRIPTION
- windows users are reporting errors when using the CLI that are caused by deprecated v1 commands
- This PR adds a `mud2` cli entry point that omits all v1 commands from the binary
- This should fix the windows issues, and is a transition step towards sunsetting the v1 commands (the next step could be to rename `mud -> mud1` and `mud2 -> mud`)