### PR TITLE
feat(world): allow KeysWithValueModule on tables with composite keys

### DIFF
--- a/packages/world/gas-report.txt
+++ b/packages/world/gas-report.txt
@@ -2,13 +2,13 @@
 (test/KeysWithValueModule.t.sol) | Get list of keys with a given value [bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1))]: 7672
 (test/KeysWithValueModule.t.sol) | compute the target table selector [bytes32 targetTableSelector = getTargetTableSelector(sourceTableId)]: 2245
 (test/KeysWithValueModule.t.sol) | install keys with value module [world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))]: 600319
-(test/KeysWithValueModule.t.sol) | set a record on a table with KeysWithValueModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 169477
+(test/KeysWithValueModule.t.sol) | set a record on a table with KeysWithValueModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))]: 169419
 (test/KeysWithValueModule.t.sol) | install keys with value module [world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))]: 600319
-(test/KeysWithValueModule.t.sol) | change a record on a table with KeysWithValueModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 135475
-(test/KeysWithValueModule.t.sol) | delete a record on a table with KeysWithValueModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 57998
+(test/KeysWithValueModule.t.sol) | change a record on a table with KeysWithValueModule installed [world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))]: 135417
+(test/KeysWithValueModule.t.sol) | delete a record on a table with KeysWithValueModule installed [world.deleteRecord(namespace, sourceFile, keyTuple1)]: 57940
 (test/KeysWithValueModule.t.sol) | install keys with value module [world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))]: 600319
-(test/KeysWithValueModule.t.sol) | set a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 177731
-(test/KeysWithValueModule.t.sol) | change a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 142076
+(test/KeysWithValueModule.t.sol) | set a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))]: 177615
+(test/KeysWithValueModule.t.sol) | change a field on a table with KeysWithValueModule installed [world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))]: 141960
 (test/World.t.sol) | Delete record [world.deleteRecord(namespace, file, singletonKey)]: 16115
 (test/World.t.sol) | Push data to the table [world.pushToField(namespace, file, keyTuple, 0, encodedData)]: 96477
 (test/World.t.sol) | Register a fallback system [bytes4 funcSelector1 = world.registerFunctionSelector(namespace, file, "", "")]: 81251

--- a/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol
+++ b/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol
@@ -19,8 +19,7 @@ import { getTargetTableSelector } from "./getTargetTableSelector.sol";
  * from value to list of keys with this value. This mapping is stored in a table registered
  * by the module at the `targetTableId` provided in the install methods arguments.
  *
- * Note: for now this module only supports tables with single keys, no composite keys.
- * Support for composite keys can be added by using a parallel array to store the key in the target table.
+ * Note: if a table with composite keys is used, only the first key is indexed
  *
  * Note: this module currently expects to be `delegatecalled` via World.installRootModule.
  * Support for installing it via `World.installModule` depends on `World.callFrom` being implemented.


### PR DESCRIPTION
- Before `KeysWithValueHook` required tables to have a single key
- With this PR also tables with composite keys are supported, but only the first key will be indexed