### PR TITLE
feat(cli): interactive test-runner

### DIFF
--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -6,7 +6,7 @@ import { loadStoreConfig, loadWorldConfig } from "@latticexyz/config";
 import { MUDError } from "@latticexyz/config";
 import { deploy } from "../utils/deploy-v2.js";
 import { logError } from "../utils/errors.js";
-import { forge, getRpcUrl, getSrcDirectory } from "../utils/foundry.js";
+import { forge, getRpcUrl, getSrcDirectory, FOUNDRY_OPTIONS_IGNORE_CODES } from "../utils/foundry.js";
 import { mkdirSync, writeFileSync } from "fs";
 import { getChainId } from "../utils/getChainId.js";
 
@@ -54,7 +54,7 @@ export async function deployHandler(args: Parameters<(typeof commandModule)["han
   if (clean) await forge(["clean"], { profile });
 
   // Run forge build
-  await forge(["build"], { profile });
+  await forge(["build", "--silent", ...FOUNDRY_OPTIONS_IGNORE_CODES], { profile });
 
   // Get a list of all contract names
   const srcDir = args?.srcDir ?? (await getSrcDirectory());

--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -54,7 +54,7 @@ export async function deployHandler(args: Parameters<(typeof commandModule)["han
   if (clean) await forge(["clean"], { profile });
 
   // Run forge build
-  await forge(["build", "--silent", ...FOUNDRY_OPTIONS_IGNORE_CODES], { profile });
+  await forge(["build", ...FOUNDRY_OPTIONS_IGNORE_CODES], { profile });
 
   // Get a list of all contract names
   const srcDir = args?.srcDir ?? (await getSrcDirectory());

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -21,7 +21,7 @@ import { execLog } from "../utils/execLog.js";
 
 type Options = DeployOptions & {
   port?: number;
-  interactive?: boolean;
+  watch?: boolean;
   forgeOptions?: string;
 };
 
@@ -78,7 +78,7 @@ const commandModule: CommandModule<Options, Options> = {
         description:
           "Address of an existing world contract. If provided, deployment is skipped and the RPC provided in the foundry.toml is used for fork testing.",
       },
-      interactive: { type: "boolean", alias: "i" },
+      watch: { type: "boolean", alias: "w" },
       configPath: { type: "string", desc: "Path to the config file" },
       forgeOptions: { type: "string", description: "Options to pass to forge test" },
     });
@@ -118,7 +118,7 @@ const commandModule: CommandModule<Options, Options> = {
       console.log("TODO: rerun all codegen if stale detected");
     }
 
-    if (process.env.CI || !args.interactive) {
+    if (process.env.CI || !args.watch) {
       await runCodegen();
       const worldAddress = await deployWorld();
       writeFileSync(WORLD_ADDRESS_FILE, worldAddress);

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -130,9 +130,7 @@ const commandModule: CommandModule<Options, Options> = {
           console.error(chalk.red(chalk.bold("Tests failed")));
           if (verbosity < 3) {
             console.log(
-              chalk.greenBright(
-                chalk.bold('To get additional traces for your tests, set "verbosity" in your foundry.toml to "3"')
-              )
+              chalk.yellow('To get additional traces for your tests, set "verbosity" in your foundry.toml to "3"')
             );
           }
         } else {
@@ -146,12 +144,10 @@ const commandModule: CommandModule<Options, Options> = {
 
     if (verbosity < 2) {
       console.log(
-        chalk.redBright(
-          chalk.bold(`Your Foundry config has low verbosity (${verbosity}), you won't see why your tests fail.`)
-        )
+        chalk.yellow(`Your Foundry config has low verbosity (${verbosity}), you won't see why your tests fail.`)
       );
     } else if (verbosity < 3) {
-      console.log(chalk.blueBright(`Your Foundry config has low verbosity (${verbosity}), you won't see traces.`));
+      console.log(chalk.yellow(`Your Foundry config has low verbosity (${verbosity}), you won't see traces.`));
     }
 
     const testDir = await getTestDirectory();
@@ -205,9 +201,7 @@ const commandModule: CommandModule<Options, Options> = {
               console.error(chalk.red(chalk.bold("Tests failed")));
               if (verbosity < 3) {
                 console.log(
-                  chalk.greenBright(
-                    chalk.bold('To get additional traces for your tests, set "verbosity" in your foundry.toml to "3"')
-                  )
+                  chalk.yellow('To get additional traces for your tests, set "verbosity" in your foundry.toml to "3"')
                 );
               }
             } else {

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -1,6 +1,11 @@
 import type { CommandModule } from "yargs";
 import readline from "readline";
 import chokidar from "chokidar";
+import { resolveConfigPath } from "@latticexyz/config";
+import chalk from "chalk";
+import { rmSync, writeFileSync } from "fs";
+import EventEmitter from "events";
+
 import { deployHandler, DeployOptions } from "./deploy-v2.js";
 import { yDeployOptions } from "./deploy-v2.js";
 import {
@@ -11,12 +16,8 @@ import {
   getSrcDirectory,
   getTestDirectory,
 } from "../utils/foundry.js";
-import chalk from "chalk";
-import { rmSync, writeFileSync } from "fs";
 import { CommandFailedError } from "../utils/errors.js";
 import { execLog } from "../utils/execLog.js";
-import { resolveConfigPath } from "../config/loadConfig.js";
-import EventEmitter from "events";
 
 type Options = DeployOptions & {
   port?: number;

--- a/packages/cli/src/commands/test-v2.ts
+++ b/packages/cli/src/commands/test-v2.ts
@@ -1,19 +1,46 @@
 import type { CommandModule } from "yargs";
 import readline from "readline";
+import chokidar from "chokidar";
 import { deployHandler, DeployOptions } from "./deploy-v2.js";
 import { yDeployOptions } from "./deploy-v2.js";
-import { anvil, forge, getRpcUrl, getTestDirectory } from "../utils/foundry.js";
+import {
+  anvil,
+  forge,
+  FOUNDRY_OPTIONS_IGNORE_CODES,
+  getRpcUrl,
+  getSrcDirectory,
+  getTestDirectory,
+} from "../utils/foundry.js";
 import chalk from "chalk";
 import { rmSync, writeFileSync } from "fs";
 import { CommandFailedError } from "../utils/errors.js";
 import { execLog } from "../utils/execLog.js";
+import { resolveConfigPath } from "../config/loadConfig.js";
+import EventEmitter from "events";
 
-type Options = DeployOptions & { port?: number; worldAddress?: string; forgeOptions?: string };
+type Options = DeployOptions & {
+  port?: number;
+  worldAddress?: string;
+  interactive?: boolean;
+  configPath?: string;
+  forgeOptions?: string;
+};
 
 const WORLD_ADDRESS_FILE = ".mudtest";
 
-const listenForKeyPresses = (keys: string[], exit: string) => {
-  return new Promise<string>((res, rej) => {
+const TESTS_CHANGED = "TESTS_CHANGED";
+const SOURCES_CHANGED = "SOURCES_CHANGED";
+const CONFIG_CHANGED = "CONFIG_CHANGED";
+
+const listenForKeyPressesOrEvents = (keys: string[], exit: string, events: EventEmitter) => {
+  return new Promise<[string | undefined, string[]]>((res, rej) => {
+    const resolve = (returnValue: [string | undefined, string[]]) => {
+      events.removeAllListeners();
+      res(returnValue);
+    };
+    events.on(TESTS_CHANGED, (tests) => resolve([undefined, tests]));
+    events.on(SOURCES_CHANGED, (sources) => resolve([undefined, sources]));
+    events.on(CONFIG_CHANGED, (config) => resolve([undefined, [config]]));
     readline.emitKeypressEvents(process.stdin);
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(true);
@@ -25,7 +52,7 @@ const listenForKeyPresses = (keys: string[], exit: string) => {
         if (process.stdin.isTTY) {
           process.stdin.setRawMode(false);
         }
-        res(key.name);
+        resolve([key.name, []]);
       }
     });
   });
@@ -45,6 +72,8 @@ const commandModule: CommandModule<Options, Options> = {
         description:
           "Address of an existing world contract. If provided, deployment is skipped and the RPC provided in the foundry.toml is used for fork testing.",
       },
+      interactive: { type: "boolean", alias: "i" },
+      configPath: { type: "string", desc: "Path to the config file" },
       forgeOptions: { type: "string", description: "Options to pass to forge test" },
     });
   },
@@ -59,6 +88,56 @@ const commandModule: CommandModule<Options, Options> = {
     const forkRpc = args.worldAddress ? await getRpcUrl(args.profile) : `http://127.0.0.1:${args.port}`;
     const userOptions = args.forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
     const { verbosity } = JSON.parse(await execLog("forge", ["config", "--json"]));
+
+    async function deployWorld() {
+      return (
+        args.worldAddress ??
+        (
+          await deployHandler({
+            ...args,
+            saveDeployment: false,
+            rpc: forkRpc,
+          })
+        ).worldAddress
+      );
+    }
+
+    async function runTests() {
+      return forge(["test", "--silent", ...FOUNDRY_OPTIONS_IGNORE_CODES, "--fork-url", forkRpc, ...userOptions], {
+        profile: args.profile,
+      });
+    }
+
+    async function runCodegen() {
+      console.log("TODO: re-run all codegen if stale detected");
+    }
+
+    if (process.env.CI || !args.interactive) {
+      await runCodegen();
+      const worldAddress = await deployWorld();
+      writeFileSync(WORLD_ADDRESS_FILE, worldAddress);
+      try {
+        await runTests();
+      } catch (e) {
+        rmSync(WORLD_ADDRESS_FILE);
+        if (e instanceof CommandFailedError) {
+          console.error(chalk.red(chalk.bold("Tests failed")));
+          if (verbosity < 3) {
+            console.log(
+              chalk.greenBright(
+                chalk.bold('To get additional traces for your tests, set "verbosity" in your foundry.toml to "3"')
+              )
+            );
+          }
+        } else {
+          console.error(e);
+        }
+        process.exit(1); // non-zero exit code in CI to notify tests failed;
+      }
+      rmSync(WORLD_ADDRESS_FILE);
+      process.exit(0);
+    }
+
     if (verbosity < 2) {
       console.log(
         chalk.redBright(
@@ -69,26 +148,49 @@ const commandModule: CommandModule<Options, Options> = {
       console.log(chalk.blueBright(`Your Foundry config has low verbosity (${verbosity}), you won't see traces.`));
     }
 
+    const testDir = await getTestDirectory();
+    const srcDir = await getSrcDirectory();
+    const configPath = await resolveConfigPath(args.configPath);
+
+    const signals: { testsChanged: string[]; sourceChanged: string[]; configChanged: boolean } = {
+      testsChanged: [],
+      sourceChanged: [],
+      configChanged: false,
+    };
+
+    function resetSignals() {
+      signals.testsChanged = [];
+      signals.sourceChanged = [];
+      signals.configChanged = false;
+    }
+
+    const signalEvents = new EventEmitter();
+
+    chokidar.watch([configPath, testDir, srcDir]).on("all", async (event, path) => {
+      if (path.includes(testDir)) {
+        signals.testsChanged.push(path);
+        signalEvents.emit(TESTS_CHANGED, signals.testsChanged);
+      } else if (path.includes(srcDir)) {
+        signals.sourceChanged.push(path);
+        signalEvents.emit(SOURCES_CHANGED, signals.sourceChanged);
+      } else if (path.includes(configPath)) {
+        signals.configChanged = true;
+        signalEvents.emit(CONFIG_CHANGED, path);
+      }
+    });
+    await new Promise((res, rej) => setTimeout(res, 100));
+    resetSignals();
+
     try {
       while ([].length === 0) {
-        const worldAddress =
-          args.worldAddress ??
-          (
-            await deployHandler({
-              ...args,
-              saveDeployment: false,
-              rpc: forkRpc,
-            })
-          ).worldAddress;
+        await runCodegen();
+        const worldAddress = await deployWorld();
         console.log(chalk.blue("World address", worldAddress));
-
         // Create a temporary file to pass the world address to the tests
         writeFileSync(WORLD_ADDRESS_FILE, worldAddress);
         while ([].length === 0) {
           try {
-            await forge(["test", "--fork-url", forkRpc, ...userOptions], {
-              profile: args.profile,
-            });
+            await runTests();
           } catch (e) {
             if (e instanceof CommandFailedError) {
               console.error(chalk.red(chalk.bold("Tests failed")));
@@ -104,19 +206,69 @@ const commandModule: CommandModule<Options, Options> = {
               break;
             }
           }
-          console.log(
-            chalk.gray(
-              chalk.green("[r]"),
-              "to rerun tests, ",
-              chalk.blue("[d]"),
-              "to re-run the deployer, and",
-              chalk.red("[q]"),
-              "to quit."
-            )
-          );
-          const keyPressed = await listenForKeyPresses(["r", "d"], "q");
-          if (keyPressed === "d") {
-            break;
+          if (signals.configChanged || signals.sourceChanged.length > 0 || signals.testsChanged.length > 0) {
+            if (signals.configChanged) {
+              console.log(chalk.green("Config changed. redeploying world"));
+              resetSignals();
+              break;
+            } else if (signals.sourceChanged.length > 0) {
+              console.log(chalk.green("System changed. redeploying world"));
+              for (const filesChanged of signals.sourceChanged) {
+                console.log(chalk.gray("changed: ", filesChanged));
+              }
+              resetSignals();
+              break;
+            } else {
+              console.log(chalk.green("Tests changed. re-running forge tests."));
+              for (const filesChanged of signals.testsChanged) {
+                console.log(chalk.gray("changed: ", filesChanged));
+              }
+              resetSignals();
+              continue;
+            }
+          } else {
+            console.log(
+              chalk.gray(
+                chalk.green("[r]"),
+                "to rerun tests, ",
+                chalk.blue("[d]"),
+                "to re-run the deployer, and",
+                chalk.red("[q]"),
+                "to quit."
+              )
+            );
+            console.log(
+              chalk.dim(chalk.blue("Changes to your systems, MUD config, or tests will re-run tests and/or deployer."))
+            );
+            const [keyPressed, filesChanged] = await listenForKeyPressesOrEvents(["r", "d"], "q", signalEvents);
+            if (filesChanged.length > 0) {
+              const file = filesChanged[0];
+              if (file.includes(configPath)) {
+                console.log(chalk.green("Config changed. redeploying world"));
+                resetSignals();
+                break;
+              } else if (file.includes(srcDir)) {
+                console.log(chalk.green("System changed. redeploying world"));
+                for (const filesChanged of signals.sourceChanged) {
+                  console.log(chalk.gray("changed: ", filesChanged));
+                }
+                resetSignals();
+                break;
+              } else {
+                console.log(chalk.green("Tests changed. re-running forge tests."));
+                for (const filesChanged of signals.testsChanged) {
+                  console.log(chalk.gray("changed: ", filesChanged));
+                }
+                resetSignals();
+                continue;
+              }
+            } else {
+              if (keyPressed == "r") {
+                continue;
+              } else if (keyPressed === "d") {
+                break;
+              }
+            }
           }
         }
       }

--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import path from "path";
-import { MUDConfig, resolveWithContext } from "@latticexyz/config";
-import { MUDError } from "@latticexyz/config";
-import { getOutDirectory, getScriptDirectory, cast, forge } from "./foundry.js";
+import { MUDConfig, resolveWithContext, MUDError } from "@latticexyz/config";
+import { getOutDirectory, getScriptDirectory, cast, forge, FOUNDRY_OPTIONS_IGNORE_CODES } from "./foundry.js";
 import { BigNumber, ContractInterface, ethers } from "ethers";
 import { IBaseWorld } from "@latticexyz/world/types/ethers-contracts/IBaseWorld.js";
 import chalk from "chalk";
@@ -289,6 +288,8 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
       [
         "script",
         postDeployScript,
+        "--silent",
+        ...FOUNDRY_OPTIONS_IGNORE_CODES,
         "--sig",
         "run(address)",
         await contractPromises.World,

--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -288,7 +288,6 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
       [
         "script",
         postDeployScript,
-        "--silent",
         ...FOUNDRY_OPTIONS_IGNORE_CODES,
         "--sig",
         "run(address)",

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -1,8 +1,11 @@
 import chalk from "chalk";
 import { ZodError } from "zod";
 import { fromZodError, ValidationError } from "zod-validation-error";
-import { NotInsideProjectError } from "@latticexyz/config";
-import { MUDError } from "@latticexyz/config";
+import { NotInsideProjectError, MUDError } from "@latticexyz/config";
+
+export class CommandFailedError extends Error {
+  name = "CommandFailed";
+}
 
 export function logError(error: unknown) {
   if (error instanceof ValidationError) {

--- a/packages/cli/src/utils/execLog.ts
+++ b/packages/cli/src/utils/execLog.ts
@@ -1,8 +1,9 @@
 import chalk from "chalk";
 import { execa, Options } from "execa";
+import { CommandFailedError } from "./errors.js";
 
 /**
- * Executes the given command, returns the stdout, and logs the command to the console.
+ * Executes the given command, returns the stdout, and logs the command to the logger.
  * Throws an error if the command fails.
  * @param command The command to execute
  * @param args The arguments to pass to the command
@@ -17,6 +18,6 @@ export async function execLog(command: string, args: string[], options?: Options
   } catch (error: any) {
     let errorMessage = error?.stderr || error?.message || "";
     errorMessage += chalk.red(`\nError running "${commandString}"`);
-    throw new Error(errorMessage);
+    throw new CommandFailedError(errorMessage);
   }
 }

--- a/packages/cli/src/utils/execLog.ts
+++ b/packages/cli/src/utils/execLog.ts
@@ -3,7 +3,7 @@ import { execa, Options } from "execa";
 import { CommandFailedError } from "./errors.js";
 
 /**
- * Executes the given command, returns the stdout, and logs the command to the logger.
+ * Executes the given command, returns the stdout, and logs the command to the console.
  * Throws an error if the command fails.
  * @param command The command to execute
  * @param args The arguments to pass to the command

--- a/packages/cli/src/utils/foundry.ts
+++ b/packages/cli/src/utils/foundry.ts
@@ -1,6 +1,12 @@
 import { execa, Options } from "execa";
 import { execLog } from "./execLog.js";
 
+export const IGNORED_ERROR_CODES = [2018 /** state mutability can be restricted to pure */];
+export const FOUNDRY_OPTIONS_IGNORE_CODES = IGNORED_ERROR_CODES.flatMap((errorCode) => [
+  "--ignored-error-codes",
+  errorCode.toString(),
+]);
+
 export interface ForgeConfig {
   // project
   src: string;

--- a/packages/config/src/loadConfig.ts
+++ b/packages/config/src/loadConfig.ts
@@ -19,7 +19,7 @@ export async function loadConfig(configPath?: string): Promise<unknown> {
   }
 }
 
-async function resolveConfigPath(configPath: string | undefined) {
+export async function resolveConfigPath(configPath: string | undefined) {
   if (configPath === undefined) {
     configPath = await getUserConfigPath();
   } else {


### PR DESCRIPTION
This adds an interactive test-runner (used with `mud test-v2 --watch`; it's also turned off when the `CI` env var is set, regardless of `--watch`)
The runner allows users to re-run their test suite without redeploying the world and all that stuff. It supports file watching or explicitly re-running tests.
- The deployer runs when the config or the systems change (there is a TODO to run all our code-generation tools when the config changes -- we don't have a `codegen` command yet).
- The tests run (without the deployer running) when the tests change.
The runner also warns the user when their Forge verbosity is too low (if their tests fail), given they won't see logs and errors from their asserts statements. 