### PR TITLE
fix(cli): account for getRecord's trimming

### DIFF
--- a/packages/cli/contracts/src/tables/Dynamics.sol
+++ b/packages/cli/contracts/src/tables/Dynamics.sol
@@ -73,10 +73,21 @@ library Dynamics {
     StoreSwitch.registerSchema(_tableId, getSchema(), getKeySchema());
   }
 
+  /** Register the table's schema (using the specified store) */
+  function registerSchema(IStore _store) internal {
+    _store.registerSchema(_tableId, getSchema(), getKeySchema());
+  }
+
   /** Set the table's metadata */
   function setMetadata() internal {
     (string memory _tableName, string[] memory _fieldNames) = getMetadata();
     StoreSwitch.setMetadata(_tableId, _tableName, _fieldNames);
+  }
+
+  /** Set the table's metadata (using the specified store) */
+  function setMetadata(IStore _store) internal {
+    (string memory _tableName, string[] memory _fieldNames) = getMetadata();
+    _store.setMetadata(_tableId, _tableName, _fieldNames);
   }
 
   /** Get staticB32 */
@@ -88,6 +99,15 @@ library Dynamics {
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
+  /** Get staticB32 (using the specified store) */
+  function getStaticB32(IStore _store, bytes32 key) internal view returns (bytes32[1] memory staticB32) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
+    return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
   /** Set staticB32 */
   function setStaticB32(bytes32 key, bytes32[1] memory staticB32) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -96,12 +116,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
 
+  /** Set staticB32 (using the specified store) */
+  function setStaticB32(IStore _store, bytes32 key, bytes32[1] memory staticB32) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
+  }
+
   /** Push an element to staticB32 */
   function pushStaticB32(bytes32 key, bytes32 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to staticB32 (using the specified store) */
+  function pushStaticB32(IStore _store, bytes32 key, bytes32 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Get staticI32 */
@@ -113,6 +149,15 @@ library Dynamics {
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
+  /** Get staticI32 (using the specified store) */
+  function getStaticI32(IStore _store, bytes32 key) internal view returns (int32[2] memory staticI32) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
+    return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
+  }
+
   /** Set staticI32 */
   function setStaticI32(bytes32 key, int32[2] memory staticI32) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -121,12 +166,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
 
+  /** Set staticI32 (using the specified store) */
+  function setStaticI32(IStore _store, bytes32 key, int32[2] memory staticI32) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
+  }
+
   /** Push an element to staticI32 */
   function pushStaticI32(bytes32 key, int32 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to staticI32 (using the specified store) */
+  function pushStaticI32(IStore _store, bytes32 key, int32 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Get staticU128 */
@@ -138,6 +199,15 @@ library Dynamics {
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
+  /** Get staticU128 (using the specified store) */
+  function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
+    return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
+  }
+
   /** Set staticU128 */
   function setStaticU128(bytes32 key, uint128[3] memory staticU128) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -146,12 +216,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
 
+  /** Set staticU128 (using the specified store) */
+  function setStaticU128(IStore _store, bytes32 key, uint128[3] memory staticU128) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
+  }
+
   /** Push an element to staticU128 */
   function pushStaticU128(bytes32 key, uint128 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to staticU128 (using the specified store) */
+  function pushStaticU128(IStore _store, bytes32 key, uint128 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Get staticAddrs */
@@ -163,6 +249,15 @@ library Dynamics {
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
+  /** Get staticAddrs (using the specified store) */
+  function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
+    return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
+  }
+
   /** Set staticAddrs */
   function setStaticAddrs(bytes32 key, address[4] memory staticAddrs) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -171,12 +266,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
 
+  /** Set staticAddrs (using the specified store) */
+  function setStaticAddrs(IStore _store, bytes32 key, address[4] memory staticAddrs) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
+  }
+
   /** Push an element to staticAddrs */
   function pushStaticAddrs(bytes32 key, address _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to staticAddrs (using the specified store) */
+  function pushStaticAddrs(IStore _store, bytes32 key, address _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
   /** Get staticBools */
@@ -188,6 +299,15 @@ library Dynamics {
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
+  /** Get staticBools (using the specified store) */
+  function getStaticBools(IStore _store, bytes32 key) internal view returns (bool[5] memory staticBools) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 4);
+    return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
+  }
+
   /** Set staticBools */
   function setStaticBools(bytes32 key, bool[5] memory staticBools) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -196,12 +316,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
 
+  /** Set staticBools (using the specified store) */
+  function setStaticBools(IStore _store, bytes32 key, bool[5] memory staticBools) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
+  }
+
   /** Push an element to staticBools */
   function pushStaticBools(bytes32 key, bool _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 4, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to staticBools (using the specified store) */
+  function pushStaticBools(IStore _store, bytes32 key, bool _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 4, abi.encodePacked((_element)));
   }
 
   /** Get u64 */
@@ -213,6 +349,15 @@ library Dynamics {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
+  /** Get u64 (using the specified store) */
+  function getU64(IStore _store, bytes32 key) internal view returns (uint64[] memory u64) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 5);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
+  }
+
   /** Set u64 */
   function setU64(bytes32 key, uint64[] memory u64) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -221,12 +366,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 5, EncodeArray.encode((u64)));
   }
 
+  /** Set u64 (using the specified store) */
+  function setU64(IStore _store, bytes32 key, uint64[] memory u64) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 5, EncodeArray.encode((u64)));
+  }
+
   /** Push an element to u64 */
   function pushU64(bytes32 key, uint64 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 5, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to u64 (using the specified store) */
+  function pushU64(IStore _store, bytes32 key, uint64 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 5, abi.encodePacked((_element)));
   }
 
   /** Get str */
@@ -238,6 +399,15 @@ library Dynamics {
     return (string(_blob));
   }
 
+  /** Get str (using the specified store) */
+  function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 6);
+    return (string(_blob));
+  }
+
   /** Set str */
   function setStr(bytes32 key, string memory str) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
@@ -246,12 +416,28 @@ library Dynamics {
     StoreSwitch.setField(_tableId, _primaryKeys, 6, bytes((str)));
   }
 
+  /** Set str (using the specified store) */
+  function setStr(IStore _store, bytes32 key, string memory str) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 6, bytes((str)));
+  }
+
   /** Push a slice to str */
   function pushStr(bytes32 key, string memory _slice) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 6, bytes((_slice)));
+  }
+
+  /** Push a slice to str (using the specified store) */
+  function pushStr(IStore _store, bytes32 key, string memory _slice) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 6, bytes((_slice)));
   }
 
   /** Get b */
@@ -263,12 +449,29 @@ library Dynamics {
     return (bytes(_blob));
   }
 
+  /** Get b (using the specified store) */
+  function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 7);
+    return (bytes(_blob));
+  }
+
   /** Set b */
   function setB(bytes32 key, bytes memory b) internal {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 7, bytes((b)));
+  }
+
+  /** Set b (using the specified store) */
+  function setB(IStore _store, bytes32 key, bytes memory b) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setField(_tableId, _primaryKeys, 7, bytes((b)));
   }
 
   /** Push a slice to b */
@@ -279,12 +482,29 @@ library Dynamics {
     StoreSwitch.pushToField(_tableId, _primaryKeys, 7, bytes((_slice)));
   }
 
+  /** Push a slice to b (using the specified store) */
+  function pushB(IStore _store, bytes32 key, bytes memory _slice) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.pushToField(_tableId, _primaryKeys, 7, bytes((_slice)));
+  }
+
   /** Get the full data */
   function get(bytes32 key) internal view returns (DynamicsData memory _table) {
     bytes32[] memory _primaryKeys = new bytes32[](1);
     _primaryKeys[0] = bytes32((key));
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
+    return decode(_blob);
+  }
+
+  /** Get the full data (using the specified store) */
+  function get(IStore _store, bytes32 key) internal view returns (DynamicsData memory _table) {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
   }
 
@@ -308,9 +528,46 @@ library Dynamics {
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
 
+  /** Set the full data using individual values (using the specified store) */
+  function set(
+    IStore _store,
+    bytes32 key,
+    bytes32[1] memory staticB32,
+    int32[2] memory staticI32,
+    uint128[3] memory staticU128,
+    address[4] memory staticAddrs,
+    bool[5] memory staticBools,
+    uint64[] memory u64,
+    string memory str,
+    bytes memory b
+  ) internal {
+    bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools, u64, str, b);
+
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.setRecord(_tableId, _primaryKeys, _data);
+  }
+
   /** Set the full data using the data struct */
   function set(bytes32 key, DynamicsData memory _table) internal {
     set(
+      key,
+      _table.staticB32,
+      _table.staticI32,
+      _table.staticU128,
+      _table.staticAddrs,
+      _table.staticBools,
+      _table.u64,
+      _table.str,
+      _table.b
+    );
+  }
+
+  /** Set the full data using the data struct (using the specified store) */
+  function set(IStore _store, bytes32 key, DynamicsData memory _table) internal {
+    set(
+      _store,
       key,
       _table.staticB32,
       _table.staticI32,
@@ -328,40 +585,44 @@ library Dynamics {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
-    uint256 _start;
-    uint256 _end = 32;
+    // Store trims the blob if dynamic fields are all empty
+    if (_blob.length > 0) {
+      uint256 _start;
+      // skip static data length + dynamic lengths word
+      uint256 _end = 32;
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(0);
-    _table.staticB32 = toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(0);
+      _table.staticB32 = toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(1);
-    _table.staticI32 = toStaticArray_int32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_int32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(1);
+      _table.staticI32 = toStaticArray_int32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_int32());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(2);
-    _table.staticU128 = toStaticArray_uint128_3(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint128());
+      _start = _end;
+      _end += _encodedLengths.atIndex(2);
+      _table.staticU128 = toStaticArray_uint128_3(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint128());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(3);
-    _table.staticAddrs = toStaticArray_address_4(SliceLib.getSubslice(_blob, _start, _end).decodeArray_address());
+      _start = _end;
+      _end += _encodedLengths.atIndex(3);
+      _table.staticAddrs = toStaticArray_address_4(SliceLib.getSubslice(_blob, _start, _end).decodeArray_address());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(4);
-    _table.staticBools = toStaticArray_bool_5(SliceLib.getSubslice(_blob, _start, _end).decodeArray_bool());
+      _start = _end;
+      _end += _encodedLengths.atIndex(4);
+      _table.staticBools = toStaticArray_bool_5(SliceLib.getSubslice(_blob, _start, _end).decodeArray_bool());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(5);
-    _table.u64 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint64());
+      _start = _end;
+      _end += _encodedLengths.atIndex(5);
+      _table.u64 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint64());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(6);
-    _table.str = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+      _start = _end;
+      _end += _encodedLengths.atIndex(6);
+      _table.str = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(7);
-    _table.b = (bytes(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+      _start = _end;
+      _end += _encodedLengths.atIndex(7);
+      _table.b = (bytes(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+    }
   }
 
   /** Tightly pack full data using this table's schema */
@@ -406,6 +667,14 @@ library Dynamics {
     _primaryKeys[0] = bytes32((key));
 
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
+  }
+
+  /* Delete all data for given keys (using the specified store) */
+  function deleteRecord(IStore _store, bytes32 key) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+
+    _store.deleteRecord(_tableId, _primaryKeys);
   }
 }
 

--- a/packages/cli/contracts/src/tables/Singleton.sol
+++ b/packages/cli/contracts/src/tables/Singleton.sol
@@ -53,10 +53,21 @@ library Singleton {
     StoreSwitch.registerSchema(_tableId, getSchema(), getKeySchema());
   }
 
+  /** Register the table's schema (using the specified store) */
+  function registerSchema(IStore _store) internal {
+    _store.registerSchema(_tableId, getSchema(), getKeySchema());
+  }
+
   /** Set the table's metadata */
   function setMetadata() internal {
     (string memory _tableName, string[] memory _fieldNames) = getMetadata();
     StoreSwitch.setMetadata(_tableId, _tableName, _fieldNames);
+  }
+
+  /** Set the table's metadata (using the specified store) */
+  function setMetadata(IStore _store) internal {
+    (string memory _tableName, string[] memory _fieldNames) = getMetadata();
+    _store.setMetadata(_tableId, _tableName, _fieldNames);
   }
 
   /** Get v1 */
@@ -67,11 +78,26 @@ library Singleton {
     return (int256(uint256(Bytes.slice32(_blob, 0))));
   }
 
+  /** Get v1 (using the specified store) */
+  function getV1(IStore _store) internal view returns (int256 v1) {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
+    return (int256(uint256(Bytes.slice32(_blob, 0))));
+  }
+
   /** Set v1 */
   function setV1(int256 v1) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
+  }
+
+  /** Set v1 (using the specified store) */
+  function setV1(IStore _store, int256 v1) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
   /** Get v2 */
@@ -82,6 +108,14 @@ library Singleton {
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
+  /** Get v2 (using the specified store) */
+  function getV2(IStore _store) internal view returns (uint32[2] memory v2) {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
+    return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+  }
+
   /** Set v2 */
   function setV2(uint32[2] memory v2) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
@@ -89,11 +123,25 @@ library Singleton {
     StoreSwitch.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
+  /** Set v2 (using the specified store) */
+  function setV2(IStore _store, uint32[2] memory v2) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
+  }
+
   /** Push an element to v2 */
   function pushV2(uint32 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to v2 (using the specified store) */
+  function pushV2(IStore _store, uint32 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Get v3 */
@@ -104,6 +152,14 @@ library Singleton {
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
+  /** Get v3 (using the specified store) */
+  function getV3(IStore _store) internal view returns (uint32[2] memory v3) {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
+    return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+  }
+
   /** Set v3 */
   function setV3(uint32[2] memory v3) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
@@ -111,11 +167,25 @@ library Singleton {
     StoreSwitch.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
+  /** Set v3 (using the specified store) */
+  function setV3(IStore _store, uint32[2] memory v3) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
+  }
+
   /** Push an element to v3 */
   function pushV3(uint32 _element) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     StoreSwitch.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to v3 (using the specified store) */
+  function pushV3(IStore _store, uint32 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Get v4 */
@@ -126,11 +196,26 @@ library Singleton {
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
+  /** Get v4 (using the specified store) */
+  function getV4(IStore _store) internal view returns (uint32[1] memory v4) {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
+    return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+  }
+
   /** Set v4 */
   function setV4(uint32[1] memory v4) internal {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     StoreSwitch.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
+  }
+
+  /** Set v4 (using the specified store) */
+  function setV4(IStore _store, uint32[1] memory v4) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
   /** Push an element to v4 */
@@ -140,11 +225,28 @@ library Singleton {
     StoreSwitch.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
+  /** Push an element to v4 (using the specified store) */
+  function pushV4(IStore _store, uint32 _element) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
+  }
+
   /** Get the full data */
   function get() internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
+    return decode(_blob);
+  }
+
+  /** Get the full data (using the specified store) */
+  function get(
+    IStore _store
+  ) internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
   }
 
@@ -157,6 +259,15 @@ library Singleton {
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
 
+  /** Set the full data using individual values (using the specified store) */
+  function set(IStore _store, int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) internal {
+    bytes memory _data = encode(v1, v2, v3, v4);
+
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.setRecord(_tableId, _primaryKeys, _data);
+  }
+
   /** Decode the tightly packed blob using this table's schema */
   function decode(
     bytes memory _blob
@@ -166,20 +277,24 @@ library Singleton {
 
     v1 = (int256(uint256(Bytes.slice32(_blob, 0))));
 
-    uint256 _start;
-    uint256 _end = 64;
+    // Store trims the blob if dynamic fields are all empty
+    if (_blob.length > 32) {
+      uint256 _start;
+      // skip static data length + dynamic lengths word
+      uint256 _end = 64;
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(0);
-    v2 = toStaticArray_uint32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(0);
+      v2 = toStaticArray_uint32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(1);
-    v3 = toStaticArray_uint32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(1);
+      v3 = toStaticArray_uint32_2(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(2);
-    v4 = toStaticArray_uint32_1(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(2);
+      v4 = toStaticArray_uint32_1(SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+    }
   }
 
   /** Tightly pack full data using this table's schema */
@@ -210,6 +325,13 @@ library Singleton {
     bytes32[] memory _primaryKeys = new bytes32[](0);
 
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
+  }
+
+  /* Delete all data for given keys (using the specified store) */
+  function deleteRecord(IStore _store) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](0);
+
+    _store.deleteRecord(_tableId, _primaryKeys);
   }
 }
 

--- a/packages/cli/contracts/src/tables/Statics.sol
+++ b/packages/cli/contracts/src/tables/Statics.sol
@@ -79,10 +79,21 @@ library Statics {
     StoreSwitch.registerSchema(_tableId, getSchema(), getKeySchema());
   }
 
+  /** Register the table's schema (using the specified store) */
+  function registerSchema(IStore _store) internal {
+    _store.registerSchema(_tableId, getSchema(), getKeySchema());
+  }
+
   /** Set the table's metadata */
   function setMetadata() internal {
     (string memory _tableName, string[] memory _fieldNames) = getMetadata();
     StoreSwitch.setMetadata(_tableId, _tableName, _fieldNames);
+  }
+
+  /** Set the table's metadata (using the specified store) */
+  function setMetadata(IStore _store) internal {
+    (string memory _tableName, string[] memory _fieldNames) = getMetadata();
+    _store.setMetadata(_tableId, _tableName, _fieldNames);
   }
 
   /** Get v1 */
@@ -108,6 +119,30 @@ library Statics {
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
+  /** Get v1 (using the specified store) */
+  function getV1(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (uint256 v1) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
+    return (uint256(Bytes.slice32(_blob, 0)));
+  }
+
   /** Set v1 */
   function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -120,6 +155,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
+  }
+
+  /** Set v1 (using the specified store) */
+  function setV1(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    uint256 v1
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
   /** Get v2 */
@@ -145,6 +204,30 @@ library Statics {
     return (int32(uint32(Bytes.slice4(_blob, 0))));
   }
 
+  /** Get v2 (using the specified store) */
+  function getV2(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (int32 v2) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
+    return (int32(uint32(Bytes.slice4(_blob, 0))));
+  }
+
   /** Set v2 */
   function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -157,6 +240,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((v2)));
+  }
+
+  /** Set v2 (using the specified store) */
+  function setV2(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    int32 v2
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((v2)));
   }
 
   /** Get v3 */
@@ -182,6 +289,30 @@ library Statics {
     return (Bytes.slice16(_blob, 0));
   }
 
+  /** Get v3 (using the specified store) */
+  function getV3(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (bytes16 v3) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
+    return (Bytes.slice16(_blob, 0));
+  }
+
   /** Set v3 */
   function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -194,6 +325,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 2, abi.encodePacked((v3)));
+  }
+
+  /** Set v3 (using the specified store) */
+  function setV3(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    bytes16 v3
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 2, abi.encodePacked((v3)));
   }
 
   /** Get v4 */
@@ -219,6 +374,30 @@ library Statics {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
+  /** Get v4 (using the specified store) */
+  function getV4(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (address v4) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
+    return (address(Bytes.slice20(_blob, 0)));
+  }
+
   /** Set v4 */
   function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -231,6 +410,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 3, abi.encodePacked((v4)));
+  }
+
+  /** Set v4 (using the specified store) */
+  function setV4(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    address v4
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 3, abi.encodePacked((v4)));
   }
 
   /** Get v5 */
@@ -256,6 +459,30 @@ library Statics {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
+  /** Get v5 (using the specified store) */
+  function getV5(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (bool v5) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 4);
+    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+  }
+
   /** Set v5 */
   function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -268,6 +495,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 4, abi.encodePacked((v5)));
+  }
+
+  /** Set v5 (using the specified store) */
+  function setV5(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    bool v5
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 4, abi.encodePacked((v5)));
   }
 
   /** Get v6 */
@@ -293,6 +544,30 @@ library Statics {
     return Enum1(uint8(Bytes.slice1(_blob, 0)));
   }
 
+  /** Get v6 (using the specified store) */
+  function getV6(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (Enum1 v6) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 5);
+    return Enum1(uint8(Bytes.slice1(_blob, 0)));
+  }
+
   /** Set v6 */
   function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -305,6 +580,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 5, abi.encodePacked(uint8(v6)));
+  }
+
+  /** Set v6 (using the specified store) */
+  function setV6(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    Enum1 v6
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 5, abi.encodePacked(uint8(v6)));
   }
 
   /** Get v7 */
@@ -330,6 +629,30 @@ library Statics {
     return Enum2(uint8(Bytes.slice1(_blob, 0)));
   }
 
+  /** Get v7 (using the specified store) */
+  function getV7(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (Enum2 v7) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getField(_tableId, _primaryKeys, 6);
+    return Enum2(uint8(Bytes.slice1(_blob, 0)));
+  }
+
   /** Set v7 */
   function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
     bytes32[] memory _primaryKeys = new bytes32[](7);
@@ -342,6 +665,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.setField(_tableId, _primaryKeys, 6, abi.encodePacked(uint8(v7)));
+  }
+
+  /** Set v7 (using the specified store) */
+  function setV7(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    Enum2 v7
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setField(_tableId, _primaryKeys, 6, abi.encodePacked(uint8(v7)));
   }
 
   /** Get the full data */
@@ -364,6 +711,30 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
+    return decode(_blob);
+  }
+
+  /** Get the full data (using the specified store) */
+  function get(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (StaticsData memory _table) {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
   }
 
@@ -398,6 +769,38 @@ library Statics {
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
 
+  /** Set the full data using individual values (using the specified store) */
+  function set(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    uint256 v1,
+    int32 v2,
+    bytes16 v3,
+    address v4,
+    bool v5,
+    Enum1 v6,
+    Enum2 v7
+  ) internal {
+    bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
+
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.setRecord(_tableId, _primaryKeys, _data);
+  }
+
   /** Set the full data using the data struct */
   function set(
     uint256 k1,
@@ -410,6 +813,37 @@ library Statics {
     StaticsData memory _table
   ) internal {
     set(k1, k2, k3, k4, k5, k6, k7, _table.v1, _table.v2, _table.v3, _table.v4, _table.v5, _table.v6, _table.v7);
+  }
+
+  /** Set the full data using the data struct (using the specified store) */
+  function set(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    StaticsData memory _table
+  ) internal {
+    set(
+      _store,
+      k1,
+      k2,
+      k3,
+      k4,
+      k5,
+      k6,
+      k7,
+      _table.v1,
+      _table.v2,
+      _table.v3,
+      _table.v4,
+      _table.v5,
+      _table.v6,
+      _table.v7
+    );
   }
 
   /** Decode the tightly packed blob using this table's schema */
@@ -454,6 +888,29 @@ library Statics {
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
+  }
+
+  /* Delete all data for given keys (using the specified store) */
+  function deleteRecord(
+    IStore _store,
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal {
+    bytes32[] memory _primaryKeys = new bytes32[](7);
+    _primaryKeys[0] = bytes32(uint256((k1)));
+    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
+    _primaryKeys[2] = bytes32((k3));
+    _primaryKeys[3] = bytes32(bytes20((k4)));
+    _primaryKeys[4] = _boolToBytes32((k5));
+    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
+    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+
+    _store.deleteRecord(_tableId, _primaryKeys);
   }
 }
 

--- a/packages/cli/contracts/test/Tablegen.t.sol
+++ b/packages/cli/contracts/test/Tablegen.t.sol
@@ -33,6 +33,11 @@ contract TablegenTest is Test, StoreView {
 
     bytes32 key = keccak256("key");
 
+    // using `get` before setting any data should return default empty values
+    DynamicsData memory emptyData;
+    assertEq(abi.encode(Dynamics.get(key)), abi.encode(emptyData));
+
+    // initialize values
     bool[5] memory staticBools = [true, false, true, true, false];
     uint64[] memory u64 = new uint64[](5);
     u64[0] = 0;
@@ -42,7 +47,7 @@ contract TablegenTest is Test, StoreView {
     u64[4] = type(uint64).max;
     string memory str = "Lorem ipsum dolor sit amet, consectetur adipiscing elit,";
     bytes memory b = hex"ff";
-
+    // combine them into a struct
     DynamicsData memory data = DynamicsData(
       [keccak256("value")],
       [int32(-123), 123],
@@ -54,9 +59,11 @@ contract TablegenTest is Test, StoreView {
       b
     );
 
+    // test that the record is set correctly
     Dynamics.set(key, data);
     assertEq(abi.encode(Dynamics.get(key)), abi.encode(data));
 
+    // test setting single fields
     Dynamics.setStaticBools(key, staticBools);
     assertEq(abi.encode(Dynamics.getStaticBools(key)), abi.encode(staticBools));
 

--- a/packages/cli/src/render-solidity/record.ts
+++ b/packages/cli/src/render-solidity/record.ts
@@ -99,16 +99,20 @@ function renderDecodeFunction({ structName, fields, staticFields, dynamicFields 
         ${fieldNamePrefix}${field.name} = ${renderDecodeValueType(field, staticOffsets[index])};
         `
       )}
-      uint256 _start;
-      uint256 _end = ${totalStaticLength + 32};
-      ${renderList(
-        dynamicFields,
-        (field, index) => `
-        _start = _end;
-        _end += _encodedLengths.atIndex(${index});
-        ${fieldNamePrefix}${field.name} = ${renderDecodeDynamicFieldPartial(field)};
-        `
-      )}
+      // Store trims the blob if dynamic fields are all empty
+      if (_blob.length > ${totalStaticLength}) {
+        uint256 _start;
+        // skip static data length + dynamic lengths word
+        uint256 _end = ${totalStaticLength + 32};
+        ${renderList(
+          dynamicFields,
+          (field, index) => `
+          _start = _end;
+          _end += _encodedLengths.atIndex(${index});
+          ${fieldNamePrefix}${field.name} = ${renderDecodeDynamicFieldPartial(field)};
+          `
+        )}
+      }
     }
   `;
   } else {

--- a/packages/store/gas-report.txt
+++ b/packages/store/gas-report.txt
@@ -17,7 +17,7 @@
 (test/Mixed.t.sol) | store Mixed struct in storage (native solidity) [testMixed = mixed]: 92050
 (test/Mixed.t.sol) | register Mixed schema [Mixed.registerSchema()]: 61173
 (test/Mixed.t.sol) | set record in Mixed [Mixed.set({ key: key, u32: 1, u128: 2, a32: a32, s: s })]: 112013
-(test/Mixed.t.sol) | get record from Mixed [MixedData memory mixed = Mixed.get(key)]: 13374
+(test/Mixed.t.sol) | get record from Mixed [MixedData memory mixed = Mixed.get(key)]: 13400
 (test/PackedCounter.t.sol) | get value at index of PackedCounter [packedCounter.atIndex(3)]: 261
 (test/PackedCounter.t.sol) | set value at index of PackedCounter [packedCounter = packedCounter.setAtIndex(2, 5)]: 799
 (test/PackedCounter.t.sol) | pack uint16 array into PackedCounter [PackedCounter packedCounter = PackedCounterLib.pack(counters)]: 2152
@@ -85,7 +85,7 @@
 (test/StoreCore.t.sol) | get static record (2 slots) [bytes memory loadedData = StoreCore.getRecord(table, key, schema)]: 1580
 (test/StoreCore.t.sol) | StoreCore: set table metadata [StoreCore.setMetadata(table, tableName, fieldNames)]: 251710
 (test/StoreMetadata.t.sol) | set record in StoreMetadataTable [StoreMetadata.set({ tableId: tableId, tableName: tableName, abiEncodedFieldNames: abi.encode(fieldNames) })]: 250184
-(test/StoreMetadata.t.sol) | get record from StoreMetadataTable [StoreMetadataData memory metadata = StoreMetadata.get(tableId)]: 12110
+(test/StoreMetadata.t.sol) | get record from StoreMetadataTable [StoreMetadataData memory metadata = StoreMetadata.get(tableId)]: 12133
 (test/StoreSwitch.t.sol) | check if delegatecall [isDelegate = StoreSwitch.isDelegateCall()]: 671
 (test/StoreSwitch.t.sol) | check if delegatecall [isDelegate = StoreSwitch.isDelegateCall()]: 627
 (test/Vector2.t.sol) | register Vector2 schema [Vector2.registerSchema()]: 57971

--- a/packages/store/src/tables/Mixed.sol
+++ b/packages/store/src/tables/Mixed.sol
@@ -303,16 +303,20 @@ library Mixed {
 
     _table.u128 = (uint128(Bytes.slice16(_blob, 4)));
 
-    uint256 _start;
-    uint256 _end = 52;
+    // Store trims the blob if dynamic fields are all empty
+    if (_blob.length > 20) {
+      uint256 _start;
+      // skip static data length + dynamic lengths word
+      uint256 _end = 52;
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(0);
-    _table.a32 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
+      _start = _end;
+      _end += _encodedLengths.atIndex(0);
+      _table.a32 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint32());
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(1);
-    _table.s = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+      _start = _end;
+      _end += _encodedLengths.atIndex(1);
+      _table.s = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+    }
   }
 
   /** Tightly pack full data using this table's schema */

--- a/packages/store/src/tables/StoreMetadata.sol
+++ b/packages/store/src/tables/StoreMetadata.sol
@@ -228,16 +228,20 @@ library StoreMetadata {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
-    uint256 _start;
-    uint256 _end = 32;
+    // Store trims the blob if dynamic fields are all empty
+    if (_blob.length > 0) {
+      uint256 _start;
+      // skip static data length + dynamic lengths word
+      uint256 _end = 32;
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(0);
-    _table.tableName = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+      _start = _end;
+      _end += _encodedLengths.atIndex(0);
+      _table.tableName = (string(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
 
-    _start = _end;
-    _end += _encodedLengths.atIndex(1);
-    _table.abiEncodedFieldNames = (bytes(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+      _start = _end;
+      _end += _encodedLengths.atIndex(1);
+      _table.abiEncodedFieldNames = (bytes(SliceLib.getSubslice(_blob, _start, _end).toBytes()));
+    }
   }
 
   /** Tightly pack full data using this table's schema */


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/560
replaces #564 

the gist of the issue was: in `getRecord` when dynamic fields are empty, Store trims their 32-byte length word, so the blob is only static data.
`tablegen` didn't account for the trimming, and `Slice`'s sanity check detected the invalid subslice [64:64] on a blob of length 32
(an empty subslice is fine, what's invalid is that the indexes exceed the length)