### PR TITLE
fix(world): give World contract access to root namespace

### DIFF
--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -35,6 +35,7 @@ contract CoreModule is IModule, WorldContext {
     ResourceAccess.registerSchema();
     ResourceAccess.setMetadata();
     ResourceAccess.set(ROOT_NAMESPACE, _msgSender(), true);
+    ResourceAccess.set(ROOT_NAMESPACE, address(this), true);
 
     Systems.registerSchema();
     Systems.setMetadata();


### PR DESCRIPTION
- The World didn't have access to the root namespace. This doesn't matter for situations where the World writes to its own storage, but it matters for root systems who want to call other root systems via the World. Since root systems are delegatecalled from the World, `address(this)` in the System is the world address. If these systems try to call a method on the World, it's considered an external call, so access control checks apply, and fail if the World doesn't have access to the root namespace.