### PR TITLE
build: remove git-install helper

### DIFF
--- a/packages/cli/git-install.sh
+++ b/packages/cli/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/cli"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
+    "prepare": "yarn build",
     "codegen": "ts-node --esm --files ./scripts/codegen.ts",
     "lint": "eslint . --ext .ts",
     "dev": "tsup --watch",
@@ -24,7 +24,6 @@
     "link": "yarn link",
     "test": "vitest typecheck --run && yarn test:contracts",
     "test:contracts": "yarn codegen && forge test",
-    "git:install": "bash git-install.sh",
     "release": "npm publish --access=public"
   },
   "devDependencies": {

--- a/packages/noise/git-install.sh
+++ b/packages/noise/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -7,8 +7,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "test:forge": "forge test",
     "test:hardhat": "NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' yarn hardhat test",
     "// Hardhat skipped in GH action until hardhat officially supports TS/ESM": "https://github.com/NomicFoundation/hardhat/pull/3156",

--- a/packages/schema-type/git-install.sh
+++ b/packages/schema-type/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/schema-type/package.json
+++ b/packages/schema-type/package.json
@@ -12,8 +12,7 @@
     "directory": "packages/schema-type"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "test": "yarn test:solidity && yarn test:typescript",
     "test:solidity": "forge test",
     "test:typescript": "tsc --noEmit",

--- a/packages/solecs/git-install.sh
+++ b/packages/solecs/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -10,8 +10,7 @@
     "directory": "packages/solecs"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "test": "forge test",
     "build": "rimraf out && forge build --out out && yarn dist && yarn types",
     "dist": "rimraf abi && mkdir abi && cat exports.txt | cut -d: -f7 | sort -n | uniq | xargs -n 1 sh -c 'cp out/\"$@\".sol/*.json abi/' sh && rimraf abi/*.metadata.json",

--- a/packages/std-contracts/git-install.sh
+++ b/packages/std-contracts/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/std-contracts/package.json
+++ b/packages/std-contracts/package.json
@@ -10,8 +10,7 @@
     "directory": "packages/std-contracts"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "test": "forge test",
     "build": "rimraf out && forge build && yarn dist && yarn types",
     "dist": "rimraf abi && mkdir abi && cat exports.txt | cut -d: -f7 | sort -n | uniq | xargs -n 1 sh -c 'cp out/\"$@\".sol/*.json abi/' sh && rimraf abi/*.metadata.json",

--- a/packages/store/git-install.sh
+++ b/packages/store/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,8 +14,7 @@
     "directory": "packages/store"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "codegen": "ts-node ./scripts/codegen.ts",
     "tablegen": "../cli/dist/mud.js tablegen",
     "test": "yarn codegen && forge test",

--- a/packages/world/git-install.sh
+++ b/packages/world/git-install.sh
@@ -1,5 +1,0 @@
-#! usr/bin/bash
-giturl=https://github.com/$1.git
-head=$(git ls-remote $giturl HEAD | head -n1 | awk '{print $1;}')
-yarn add $giturl#$head
-echo "Installed $giturl#$head"

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -14,8 +14,7 @@
     "directory": "packages/world"
   },
   "scripts": {
-    "prepare": "yarn build && chmod u+x git-install.sh",
-    "git:install": "bash git-install.sh",
+    "prepare": "yarn build",
     "tablegen": "../cli/dist/mud.js tablegen",
     "worldgen": "../cli/dist/mud.js worldgen",
     "test": "forge test",


### PR DESCRIPTION
We don't really use this and you can `yarn add [dep@git-url]` easy enough