### PR TITLE
feat(cli): allow passing world address and src dir

### DIFF
--- a/packages/cli/src/commands/deploy-v2.ts
+++ b/packages/cli/src/commands/deploy-v2.ts
@@ -19,6 +19,8 @@ export type DeployOptions = {
   debug?: boolean;
   saveDeployment?: boolean;
   rpc?: string;
+  worldAddress?: string;
+  srcDir?: string;
 };
 
 export const yDeployOptions = {
@@ -34,6 +36,8 @@ export const yDeployOptions = {
   },
   saveDeployment: { type: "boolean", desc: "Save the deployment info to a file", default: true },
   rpc: { type: "string", desc: "The RPC URL to use. Defaults to the RPC url from the local foundry.toml" },
+  worldAddress: { type: "string", desc: "Deploy to an existing World at the given address" },
+  srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
 } satisfies Record<keyof DeployOptions, Options>;
 
 export async function deployHandler(args: Parameters<(typeof commandModule)["handler"]>[0]) {
@@ -53,7 +57,7 @@ export async function deployHandler(args: Parameters<(typeof commandModule)["han
   await forge(["build"], { profile });
 
   // Get a list of all contract names
-  const srcDir = await getSrcDirectory();
+  const srcDir = args?.srcDir ?? (await getSrcDirectory());
   const existingContracts = glob
     .sync(`${srcDir}/**/*.sol`)
     // Get the basename of the file

--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -22,6 +22,7 @@ export interface DeployConfig {
   privateKey: string;
   priorityFeeMultiplier: number;
   debug?: boolean;
+  worldAddress?: string;
 }
 
 export interface DeploymentInfo {
@@ -32,7 +33,7 @@ export interface DeploymentInfo {
 export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): Promise<DeploymentInfo> {
   const startTime = Date.now();
   const { worldContractName, namespace, postDeployScript } = mudConfig;
-  const { profile, rpc, privateKey, priorityFeeMultiplier, debug } = deployConfig;
+  const { profile, rpc, privateKey, priorityFeeMultiplier, debug, worldAddress } = deployConfig;
   const forgeOutDirectory = await getOutDirectory(profile);
 
   // Set up signer for deployment
@@ -57,7 +58,9 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
 
   // Deploy World
   const worldPromise = {
-    World: worldContractName
+    World: worldAddress
+      ? Promise.resolve(worldAddress)
+      : worldContractName
       ? deployContractByName(worldContractName)
       : deployContract(IBaseWorldData.abi, WorldData.bytecode, "World"),
   };
@@ -99,10 +102,12 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
   const WorldContract = new ethers.Contract(await contractPromises.World, IBaseWorldData.abi, signer) as IBaseWorld;
 
   // Install core Modules
-  console.log(chalk.blue("Installing core World modules"));
-  await fastTxExecute(WorldContract, "installRootModule", [await modulePromises.CoreModule, "0x"]);
-  await fastTxExecute(WorldContract, "installRootModule", [await modulePromises.RegistrationModule, "0x"]);
-  console.log(chalk.green("Installed core World modules"));
+  if (!worldAddress) {
+    console.log(chalk.blue("Installing core World modules"));
+    await fastTxExecute(WorldContract, "installRootModule", [await modulePromises.CoreModule, "0x"]);
+    await fastTxExecute(WorldContract, "installRootModule", [await modulePromises.RegistrationModule, "0x"]);
+    console.log(chalk.green("Installed core World modules"));
+  }
 
   // Register namespace
   if (namespace) await fastTxExecute(WorldContract, "registerNamespace", [toBytes16(namespace)]);


### PR DESCRIPTION
* Allow passing a `worldAddress` argument to the `deploy-v2` cli to deploy to an existing World
* Allow passing an explicit `srcDir` argument to the `deploy-v2` cli to override the default foundry config's src dir