### PR TITLE
build(noise): always restore package.json after build

### DIFF
--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -20,7 +20,7 @@
     "prepack:cjs": "mv package.json package.json.bak && jq \".main = \\\"dist/cjs/index.cjs\\\"\" package.json.bak > package.json.tmp && jq \".module = \\\"dist/index.js\\\"\" package.json.tmp > package.json.tmp2 && jq \"del(\".type\")\" package.json.tmp2 > package.json",
     "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json",
     "postpack": "(mv package.json.bak package.json || true) && (rm package.json.tmp || true) && (rm package.json.tmp2 || true)",
-    "build": "yarn asbuild:release && (yarn prepack:cjs; yarn parcel build; yarn postpack)",
+    "build": "rimraf dist && yarn asbuild:release && (yarn prepack:cjs; yarn parcel build; yarn postpack)",
     "release": "npm publish --access=public"
   },
   "dependencies": {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -20,7 +20,7 @@
     "prepack:cjs": "mv package.json package.json.bak && jq \".main = \\\"dist/cjs/index.cjs\\\"\" package.json.bak > package.json.tmp && jq \".module = \\\"dist/index.js\\\"\" package.json.tmp > package.json.tmp2 && jq \"del(\".type\")\" package.json.tmp2 > package.json",
     "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json",
     "postpack": "(mv package.json.bak package.json || true) && (rm package.json.tmp || true) && (rm package.json.tmp2 || true)",
-    "build": "rm -rf && yarn asbuild:release && yarn prepack:cjs && yarn parcel build && yarn postpack",
+    "build": "yarn asbuild:release && (yarn prepack:cjs; yarn parcel build; yarn postpack)",
     "release": "npm publish --access=public"
   },
   "dependencies": {

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -20,7 +20,7 @@
     "prepack:cjs": "mv package.json package.json.bak && jq \".main = \\\"dist/cjs/index.cjs\\\"\" package.json.bak > package.json.tmp && jq \".module = \\\"dist/index.js\\\"\" package.json.tmp > package.json.tmp2 && jq \"del(\".type\")\" package.json.tmp2 > package.json",
     "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json",
     "postpack": "(mv package.json.bak package.json || true) && (rm package.json.tmp || true) && (rm package.json.tmp2 || true)",
-    "build": "rimraf dist && yarn asbuild:release && (yarn prepack:cjs; yarn parcel build; yarn postpack)",
+    "build": "rimraf dist && yarn asbuild:release && (yarn prepack:cjs && (yarn parcel build || true) && yarn postpack)",
     "release": "npm publish --access=public"
   },
   "dependencies": {


### PR DESCRIPTION
keep coming across this when adjusting build stuff and noise package fails but leaves a bunch of `package.json.bk` files around