### PR TITLE
fix(world): allow world to access own functions via external calls

### DIFF
--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,7 +3,7 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 600410
+    "gasUsed": 591892
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
@@ -21,103 +21,103 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 600410
+    "gasUsed": 591892
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value))",
-    "gasUsed": 169442
+    "gasUsed": 169574
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 600410
+    "gasUsed": 591892
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceFile, keyTuple1, abi.encodePacked(value2))",
-    "gasUsed": 135439
+    "gasUsed": 135571
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "delete a record on a table with KeysWithValueModule installed",
     "functionCall": "world.deleteRecord(namespace, sourceFile, keyTuple1)",
-    "gasUsed": 57935
+    "gasUsed": 58023
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 600410
+    "gasUsed": 591892
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value1))",
-    "gasUsed": 177587
+    "gasUsed": 177719
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceFile, keyTuple1, 0, abi.encodePacked(value2))",
-    "gasUsed": 141933
+    "gasUsed": 142065
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "install unique entity module",
     "functionCall": "world.installModule(uniqueEntityModule, new bytes(0))",
-    "gasUsed": 773726
+    "gasUsed": 773861
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "get a unique entity nonce (non-root module)",
     "functionCall": "uint256 uniqueEntity = uint256(getUniqueEntity(world))",
-    "gasUsed": 65723
+    "gasUsed": 65767
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "installRoot unique entity module",
     "functionCall": "world.installRootModule(uniqueEntityModule, new bytes(0))",
-    "gasUsed": 780192
+    "gasUsed": 767409
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "get a unique entity nonce (root module)",
     "functionCall": "uint256 uniqueEntity = uint256(getUniqueEntity(world))",
-    "gasUsed": 65723
+    "gasUsed": 65767
   },
   {
     "source": "test/World.t.sol",
     "name": "Delete record",
     "functionCall": "world.deleteRecord(namespace, file, singletonKey)",
-    "gasUsed": 16137
+    "gasUsed": 16187
   },
   {
     "source": "test/World.t.sol",
     "name": "Push data to the table",
     "functionCall": "world.pushToField(namespace, file, keyTuple, 0, encodedData)",
-    "gasUsed": 96529
+    "gasUsed": 96573
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a fallback system",
     "functionCall": "bytes4 funcSelector1 = world.registerFunctionSelector(namespace, file, \"\", \"\")",
-    "gasUsed": 81204
+    "gasUsed": 81249
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a root fallback system",
     "functionCall": "bytes4 funcSelector2 = world.registerRootFunctionSelector(namespace, file, worldFunc, 0)",
-    "gasUsed": 72437
+    "gasUsed": 72482
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a function selector",
     "functionCall": "bytes4 functionSelector = world.registerFunctionSelector(namespace, file, \"msgSender\", \"()\")",
-    "gasUsed": 101801
+    "gasUsed": 101846
   },
   {
     "source": "test/World.t.sol",
@@ -129,7 +129,7 @@
     "source": "test/World.t.sol",
     "name": "Register a root function selector",
     "functionCall": "bytes4 functionSelector = world.registerRootFunctionSelector(namespace, file, worldFunc, sysFunc)",
-    "gasUsed": 96343
+    "gasUsed": 88388
   },
   {
     "source": "test/World.t.sol",
@@ -141,18 +141,18 @@
     "source": "test/World.t.sol",
     "name": "Write data to a table field",
     "functionCall": "world.setField(namespace, file, singletonKey, 0, abi.encodePacked(true))",
-    "gasUsed": 44816
+    "gasUsed": 44866
   },
   {
     "source": "test/World.t.sol",
     "name": "Set metadata",
     "functionCall": "world.setMetadata(namespace, file, tableName, fieldNames)",
-    "gasUsed": 277454
+    "gasUsed": 277483
   },
   {
     "source": "test/World.t.sol",
     "name": "Write data to the table",
     "functionCall": "Bool.set(world, tableId, true)",
-    "gasUsed": 42697
+    "gasUsed": 42741
   }
 ]

--- a/packages/world/src/AccessControl.sol
+++ b/packages/world/src/AccessControl.sol
@@ -15,7 +15,8 @@ library AccessControl {
    */
   function hasAccess(bytes16 namespace, bytes16 file, address caller) internal view returns (bool) {
     return
-      ResourceAccess.get(ResourceSelector.from(namespace, 0), caller) || // First check access based on the namespace
+      address(this) == caller || // First check if the World is calling itself
+      ResourceAccess.get(ResourceSelector.from(namespace, 0), caller) || // Then check access based on the namespace
       ResourceAccess.get(ResourceSelector.from(namespace, file), caller); // If caller has no namespace access, check access on the file
   }
 
@@ -37,14 +38,14 @@ library AccessControl {
     }
   }
 
-  function requireOwner(
+  function requireOwnerOrSelf(
     bytes16 namespace,
     bytes16 file,
     address caller
   ) internal view returns (bytes32 resourceSelector) {
     resourceSelector = ResourceSelector.from(namespace, file);
 
-    if (NamespaceOwner.get(namespace) != caller && caller != address(this)) {
+    if (address(this) != caller && NamespaceOwner.get(namespace) != caller) {
       revert IErrors.AccessDenied(resourceSelector.toString(), caller);
     }
   }

--- a/packages/world/src/AccessControl.sol
+++ b/packages/world/src/AccessControl.sol
@@ -44,7 +44,7 @@ library AccessControl {
   ) internal view returns (bytes32 resourceSelector) {
     resourceSelector = ResourceSelector.from(namespace, file);
 
-    if (NamespaceOwner.get(namespace) != caller) {
+    if (NamespaceOwner.get(namespace) != caller && caller != address(this)) {
       revert IErrors.AccessDenied(resourceSelector.toString(), caller);
     }
   }

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -59,7 +59,7 @@ contract World is Store, IWorldCore {
    * The module is delegatecalled and installed in the root namespace.
    */
   function installRootModule(IModule module, bytes memory args) public {
-    AccessControl.requireOwner(ROOT_NAMESPACE, ROOT_FILE, msg.sender);
+    AccessControl.requireOwnerOrSelf(ROOT_NAMESPACE, ROOT_FILE, msg.sender);
 
     Call.withSender({
       msgSender: msg.sender,
@@ -93,7 +93,7 @@ contract World is Store, IWorldCore {
    */
   function grantAccess(bytes16 namespace, bytes16 file, address grantee) public virtual {
     // Require the caller to own the namespace
-    bytes32 resourceSelector = AccessControl.requireOwner(namespace, file, msg.sender);
+    bytes32 resourceSelector = AccessControl.requireOwnerOrSelf(namespace, file, msg.sender);
 
     // Grant access to the given resource
     ResourceAccess.set(resourceSelector, grantee, true);
@@ -104,7 +104,7 @@ contract World is Store, IWorldCore {
    */
   function retractAccess(bytes16 namespace, bytes16 file, address grantee) public virtual {
     // Require the caller to own the namespace
-    bytes32 resourceSelector = AccessControl.requireOwner(namespace, file, msg.sender);
+    bytes32 resourceSelector = AccessControl.requireOwnerOrSelf(namespace, file, msg.sender);
 
     // Retract access from the given resource
     ResourceAccess.deleteRecord(resourceSelector, grantee);

--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -35,7 +35,6 @@ contract CoreModule is IModule, WorldContext {
     ResourceAccess.registerSchema();
     ResourceAccess.setMetadata();
     ResourceAccess.set(ROOT_NAMESPACE, _msgSender(), true);
-    ResourceAccess.set(ROOT_NAMESPACE, address(this), true);
 
     Systems.registerSchema();
     Systems.setMetadata();

--- a/packages/world/src/modules/registration/RegistrationSystem.sol
+++ b/packages/world/src/modules/registration/RegistrationSystem.sol
@@ -61,7 +61,7 @@ contract RegistrationSystem is System, IErrors {
     // If the namespace doesn't exist yet, register it
     // otherwise require caller to own the namespace
     if (ResourceType.get(namespace) == Resource.NONE) registerNamespace(namespace);
-    else AccessControl.requireOwner(namespace, ROOT_FILE, _msgSender());
+    else AccessControl.requireOwnerOrSelf(namespace, ROOT_FILE, _msgSender());
 
     // Require no resource to exist at this selector yet
     if (ResourceType.get(resourceSelector) != Resource.NONE) {
@@ -86,7 +86,7 @@ contract RegistrationSystem is System, IErrors {
     string[] calldata fieldNames
   ) public virtual {
     // Require caller to own the namespace
-    bytes32 resourceSelector = AccessControl.requireOwner(namespace, file, _msgSender());
+    bytes32 resourceSelector = AccessControl.requireOwnerOrSelf(namespace, file, _msgSender());
 
     // Set the metadata
     StoreCore.setMetadata(resourceSelector.toTableId(), tableName, fieldNames);
@@ -117,7 +117,7 @@ contract RegistrationSystem is System, IErrors {
    */
   function registerTableHook(bytes16 namespace, bytes16 file, IStoreHook hook) public virtual {
     // Require caller to own the namespace
-    bytes32 resourceSelector = AccessControl.requireOwner(namespace, file, _msgSender());
+    bytes32 resourceSelector = AccessControl.requireOwnerOrSelf(namespace, file, _msgSender());
 
     // Register the hook
     StoreCore.registerStoreHook(resourceSelector.toTableId(), hook);
@@ -153,7 +153,7 @@ contract RegistrationSystem is System, IErrors {
     // If the namespace doesn't exist yet, register it
     // otherwise require caller to own the namespace
     if (ResourceType.get(namespace) == Resource.NONE) registerNamespace(namespace);
-    else AccessControl.requireOwner(namespace, ROOT_FILE, _msgSender());
+    else AccessControl.requireOwnerOrSelf(namespace, ROOT_FILE, _msgSender());
 
     // Require no resource to exist at this selector yet
     if (ResourceType.get(resourceSelector) != Resource.NONE) {
@@ -186,7 +186,7 @@ contract RegistrationSystem is System, IErrors {
     string memory systemFunctionArguments
   ) public returns (bytes4 worldFunctionSelector) {
     // Require the caller to own the namespace
-    AccessControl.requireOwner(namespace, file, _msgSender());
+    AccessControl.requireOwnerOrSelf(namespace, file, _msgSender());
 
     // Compute global function selector
     string memory namespaceString = ResourceSelector.toTrimmedString(namespace);
@@ -223,7 +223,7 @@ contract RegistrationSystem is System, IErrors {
     bytes4 systemFunctionSelector
   ) public returns (bytes4) {
     // Require the caller to own the root namespace
-    AccessControl.requireOwner(ROOT_NAMESPACE, ROOT_FILE, _msgSender());
+    AccessControl.requireOwnerOrSelf(ROOT_NAMESPACE, ROOT_FILE, _msgSender());
 
     // Require the function selector to be globally unique
     bytes16 existingNamespace = FunctionSelectors.getNamespace(worldFunctionSelector);


### PR DESCRIPTION
- Calls that require `AccessControl.requireOwner` (eg. `registerRootFunctionSelector` or `registerSystem`) were failing if called externally by the World itself, because the World is not the owner of any `ROOT_FILE`.
- Similarly calls that require `AccessControl.requireAccess` were failing if called externally by the World for the same reason.
- However, the World can always call these methods internally, so it should also be allowed for the World to call them externally (eg. when the World is delegatecalling a `RootModule` to install it, which then tries to install Systems in the World by calling `registerSystem` _as the World_)
- This makes #575 obsolete (since World has access to every namespace now)