### PR TITLE
refactor(std-client): deprecate devMode, add disableCache flag instead

### DIFF
--- a/packages/std-client/src/setup/setupMUDNetwork.ts
+++ b/packages/std-client/src/setup/setupMUDNetwork.ts
@@ -155,7 +155,8 @@ export async function setupMUDNetwork<C extends ContractComponents, SystemTypes 
         provider: providerConfig,
         worldContract: contractsConfig.World,
         initialBlockNumber: networkConfig.initialBlockNumber ?? 0,
-        disableCache: networkConfig.devMode, // Disable cache on local networks (hardhat / anvil)
+        // TODO: `networkConfig.devMode` is deprecated, only use `networkConfig.disableCache`
+        disableCache: networkConfig.devMode || networkConfig.disableCache,
         fetchSystemCalls: options?.fetchSystemCalls,
       },
     });

--- a/packages/std-client/src/setup/setupMUDV2Network.ts
+++ b/packages/std-client/src/setup/setupMUDV2Network.ts
@@ -121,7 +121,7 @@ export async function setupMUDV2Network<C extends ContractComponents>({
     initialGasPrice || Math.ceil((await signerOrProvider.get().getGasPrice()).toNumber() * 1.3)
   );
 
-  // TODO: make this v2 compatible
+  // TODO: replace this with `fastTxExecutor`
   const { txQueue, dispose: disposeTxQueue } = createTxQueue(contracts, network, gasPriceInput$, {
     devMode: networkConfig.devMode,
   });
@@ -151,7 +151,7 @@ export async function setupMUDV2Network<C extends ContractComponents>({
         provider: providerConfig,
         worldContract: contractsConfig.World,
         initialBlockNumber: networkConfig.initialBlockNumber ?? 0,
-        disableCache: networkConfig.devMode, // Disable cache on local networks (hardhat / anvil)
+        disableCache: networkConfig.disableCache, // Disable cache on local networks (hardhat / anvil)
         fetchSystemCalls,
       },
     });

--- a/packages/std-client/src/setup/types.ts
+++ b/packages/std-client/src/setup/types.ts
@@ -5,7 +5,11 @@ import { Contract } from "ethers";
 export type SetupContractConfig = NetworkConfig &
   Omit<SyncWorkerConfig, "worldContract" | "mappings"> & {
     worldAddress: string;
+    /**
+     * @deprecated: use `disableCache` to disable the cache, use `fastTxExecutor` to send tx with 0 gas on dev chains
+     */
     devMode?: boolean;
+    disableCache?: boolean;
   };
 
 export type DecodedNetworkComponentUpdate = Omit<Omit<NetworkComponentUpdate, "entity">, "component"> & {


### PR DESCRIPTION
* `devMode` was used to both set gas price to 0 (to use dev chains with 0 gas) and to disable the cache
* Therefore using the `devMode` flag to disable the cache in a production deployment didn't work, because in this situation the side effect of setting gas price to 0 was unintended.
* This PR deprecates the `devMode` flag and adds a new `disableCache` flag to be used to disable the cache. (We don't remove the `devMode` flag yet to avoid a breaking change in MUD v1, since the config is shared by both v1 and v2 network setup functions)
* To send transactions with gas price 0 during development, the `fastTxExecute` function should be used instead of `txQueue` (it's much leaner and has logic to not set a gas price / priority fee if the chain's base fee is 0) 