### PR TITLE
build: remove ts-node usages

### DIFF
--- a/packages/create-mud/templates/minimal/packages/contracts/package.json
+++ b/packages/create-mud/templates/minimal/packages/contracts/package.json
@@ -35,7 +35,6 @@
     "rimraf": "^3.0.2",
     "run-pty": "^4.0.3",
     "solhint": "^3.3.7",
-    "ts-node": "^10.7.0",
     "typechain": "^8.1.1",
     "typescript": "^4.9.5",
     "wait-on": "^6.0.1"

--- a/packages/create-mud/templates/react/packages/contracts/package.json
+++ b/packages/create-mud/templates/react/packages/contracts/package.json
@@ -35,7 +35,6 @@
     "rimraf": "^3.0.2",
     "run-pty": "^4.0.3",
     "solhint": "^3.3.7",
-    "ts-node": "^10.7.0",
     "typechain": "^8.1.1",
     "typescript": "^4.9.5",
     "wait-on": "^6.0.1"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -75,7 +75,6 @@
     "rxjs": "^7.5.5",
     "threads": "^1.7.0",
     "ts-jest": "^27.1.3",
-    "ts-node": "^10.7.0",
     "tslib": "^2.3.1",
     "typedoc": "0.23.21",
     "typedoc-plugin-markdown": "^3.13.6",

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "pnpm build",
     "test:forge": "forge test",
-    "test:hardhat": "NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' pnpm hardhat test",
+    "test:hardhat": "hardhat test",
     "// Hardhat skipped in GH action until hardhat officially supports TS/ESM": "https://github.com/NomicFoundation/hardhat/pull/3156",
     "test": "pnpm test:forge",
     "asbuild:debug": "asc assembly/index.ts --target debug",

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -34,7 +34,6 @@
     "solhint": "^3.3.7",
     "solidity-docgen": "^0.6.0-beta.22",
     "solmate": "https://github.com/transmissions11/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c",
-    "ts-node": "10.7",
     "typechain": "^8.1.1",
     "typedoc": "^0.23.10"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "prepare": "pnpm build",
-    "codegen": "ts-node ./scripts/codegen.ts && prettier --write '**/*.sol'",
+    "codegen": "tsx ./scripts/codegen.ts && prettier --write '**/*.sol'",
     "tablegen": "../cli/dist/mud.js tablegen",
     "test": "pnpm codegen && forge test",
     "build": "pnpm codegen && rimraf out && forge build && pnpm dist && pnpm types && tsup",
@@ -42,8 +42,8 @@
     "rimraf": "^3.0.2",
     "solhint": "^3.3.7",
     "solidity-docgen": "^0.6.0-beta.22",
-    "ts-node": "^10.9.1",
     "tsup": "^6.7.0",
+    "tsx": "^3.12.6",
     "typechain": "^8.1.1",
     "typedoc": "^0.23.10"
   },

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -41,7 +41,6 @@
     "rimraf": "^3.0.2",
     "solhint": "^3.3.7",
     "solidity-docgen": "^0.6.0-beta.22",
-    "ts-node": "^10.9.1",
     "tsup": "^6.7.0",
     "typechain": "^8.1.1",
     "typedoc": "^0.23.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,7 +410,7 @@ importers:
         version: 3.21.0
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(ts-node@10.9.1)
+        version: 27.5.1
       mobx:
         specifier: ^6.5.0
         version: 6.5.0
@@ -432,9 +432,6 @@ importers:
       ts-jest:
         specifier: ^27.1.3
         version: 27.1.3(@babel/core@7.21.3)(@types/jest@27.4.1)(jest@27.5.1)(typescript@4.9.5)
-      ts-node:
-        specifier: ^10.7.0
-        version: 10.9.1(@types/node@17.0.34)(typescript@4.9.5)
       tslib:
         specifier: ^2.3.1
         version: 2.5.0
@@ -553,7 +550,7 @@ importers:
         version: 27.4.1
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(ts-node@10.9.1)
+        version: 27.5.1
       mobx:
         specifier: ^6.4.2
         version: 6.5.0
@@ -686,7 +683,7 @@ importers:
         version: 8.3.4
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(ts-node@10.9.1)
+        version: 27.5.1
       mobx:
         specifier: ^6.4.2
         version: 6.5.0
@@ -783,7 +780,7 @@ importers:
         version: github.com/foundry-rs/forge-std/b4f121555729b3afb3c5ffccb62ff4b6e2818fd3
       hardhat:
         specifier: ^2.10.1
-        version: 2.10.2(ts-node@10.7.0)(typescript@4.9.5)
+        version: 2.10.2(ts-node@10.9.1)(typescript@4.9.5)
       memmove:
         specifier: https://github.com/dk1a/memmove.git#ffd71cd77b1708574ef46a667b23ca3a5cc9fa27
         version: github.com/dk1a/memmove/ffd71cd77b1708574ef46a667b23ca3a5cc9fa27
@@ -799,9 +796,6 @@ importers:
       solmate:
         specifier: https://github.com/transmissions11/solmate.git#9cf1428245074e39090dceacb0c28b1f684f584c
         version: github.com/transmissions11/solmate/9cf1428245074e39090dceacb0c28b1f684f584c
-      ts-node:
-        specifier: '10.7'
-        version: 10.7.0(@types/node@17.0.34)(typescript@4.9.5)
       typechain:
         specifier: ^8.1.1
         version: 8.1.1(typescript@4.9.5)
@@ -939,7 +933,7 @@ importers:
         version: github.com/foundry-rs/forge-std/b4f121555729b3afb3c5ffccb62ff4b6e2818fd3
       hardhat:
         specifier: ^2.10.1
-        version: 2.10.2(ts-node@10.7.0)(typescript@4.9.5)
+        version: 2.10.2(ts-node@10.9.1)(typescript@4.9.5)
       memmove:
         specifier: https://github.com/dk1a/memmove.git#ffd71cd77b1708574ef46a667b23ca3a5cc9fa27
         version: github.com/dk1a/memmove/ffd71cd77b1708574ef46a667b23ca3a5cc9fa27
@@ -1009,12 +1003,12 @@ importers:
       solidity-docgen:
         specifier: ^0.6.0-beta.22
         version: 0.6.0-beta.22(hardhat@2.10.2)
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@17.0.34)(typescript@4.9.5)
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@4.9.5)
+        version: 6.7.0(typescript@4.9.5)
+      tsx:
+        specifier: ^3.12.6
+        version: 3.12.6
       typechain:
         specifier: ^8.1.1
         version: 8.1.1(typescript@4.9.5)
@@ -1045,7 +1039,7 @@ importers:
         version: 5.7.2
       jest:
         specifier: ^27.5.1
-        version: 27.5.1(ts-node@10.9.1)
+        version: 27.5.1
       mobx:
         specifier: ^6.5.0
         version: 6.5.0
@@ -1127,12 +1121,9 @@ importers:
       solidity-docgen:
         specifier: ^0.6.0-beta.22
         version: 0.6.0-beta.22(hardhat@2.10.2)
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@17.0.34)(typescript@4.9.5)
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@4.9.5)
+        version: 6.7.0(typescript@4.9.5)
       typechain:
         specifier: ^8.1.1
         version: 8.1.1(typescript@4.9.5)
@@ -1709,18 +1700,6 @@ packages:
       chalk: 4.1.2
     dev: true
     optional: true
-
-  /@cspotcode/source-map-consumer@0.8.0:
-    resolution: {integrity: sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==}
-    engines: {node: '>= 12'}
-    dev: true
-
-  /@cspotcode/source-map-support@0.7.0:
-    resolution: {integrity: sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@cspotcode/source-map-consumer': 0.8.0
-    dev: true
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2643,7 +2622,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core@27.5.1(ts-node@10.9.1):
+  /@jest/core@27.5.1:
     resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -2664,7 +2643,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 27.5.1
-      jest-config: 27.5.1(ts-node@10.9.1)
+      jest-config: 27.5.1
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
@@ -10051,75 +10030,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /hardhat@2.10.2(ts-node@10.7.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-L/KvDDT/MA6332uAtYTqdcHoSABljw4pPjHQe5SHdIJ+xKfaSc6vDKw03CmrQ5Xup0gHs8XnVSBpZo1AbbIW7g==}
-    engines: {node: ^14.0.0 || ^16.0.0 || ^18.0.0}
-    hasBin: true
-    peerDependencies:
-      ts-node: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@ethereumjs/block': 3.6.3
-      '@ethereumjs/blockchain': 5.5.3
-      '@ethereumjs/common': 2.6.5
-      '@ethereumjs/tx': 3.5.2
-      '@ethereumjs/vm': 5.9.3
-      '@ethersproject/abi': 5.7.0
-      '@metamask/eth-sig-util': 4.0.1
-      '@sentry/node': 5.30.0
-      '@solidity-parser/parser': 0.14.5
-      '@types/bn.js': 5.1.1
-      '@types/lru-cache': 5.1.1
-      abort-controller: 3.0.0
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      chalk: 2.4.2
-      chokidar: 3.5.3
-      ci-info: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
-      enquirer: 2.3.6
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      ethereumjs-abi: 0.6.8
-      ethereumjs-util: 7.1.5
-      find-up: 2.1.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      glob: 7.2.0
-      immutable: 4.3.0
-      io-ts: 1.10.4
-      lodash: 4.17.21
-      merkle-patricia-tree: 4.2.4
-      mnemonist: 0.38.5
-      mocha: 10.0.0
-      p-map: 4.0.0
-      qs: 6.11.0
-      raw-body: 2.5.2
-      resolve: 1.17.0
-      semver: 6.3.0
-      slash: 3.0.0
-      solc: 0.7.3(debug@4.3.4)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.10
-      true-case-path: 2.2.1
-      ts-node: 10.7.0(@types/node@17.0.34)(typescript@4.9.5)
-      tsort: 0.0.1
-      typescript: 4.9.5
-      undici: 5.21.0
-      uuid: 8.3.2
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /hardhat@2.10.2(ts-node@10.9.1)(typescript@4.9.5):
     resolution: {integrity: sha512-L/KvDDT/MA6332uAtYTqdcHoSABljw4pPjHQe5SHdIJ+xKfaSc6vDKw03CmrQ5Xup0gHs8XnVSBpZo1AbbIW7g==}
     engines: {node: ^14.0.0 || ^16.0.0 || ^18.0.0}
@@ -11280,7 +11190,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@27.5.1(ts-node@10.9.1):
+  /jest-cli@27.5.1:
     resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -11290,14 +11200,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.5.1(ts-node@10.9.1)
+      '@jest/core': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 27.5.1(ts-node@10.9.1)
+      jest-config: 27.5.1
       jest-util: 27.5.1
       jest-validate: 27.5.1
       prompts: 2.4.2
@@ -11366,7 +11276,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@27.5.1(ts-node@10.9.1):
+  /jest-config@27.5.1:
     resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     peerDependencies:
@@ -11399,7 +11309,6 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@17.0.34)(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -12395,7 +12304,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest@27.5.1(ts-node@10.9.1):
+  /jest@27.5.1:
     resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -12405,9 +12314,9 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 27.5.1(ts-node@10.9.1)
+      '@jest/core': 27.5.1
       import-local: 3.1.0
-      jest-cli: 27.5.1(ts-node@10.9.1)
+      jest-cli: 27.5.1
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -15088,7 +14997,7 @@ packages:
       find-up: 3.0.0
     dev: false
 
-  /postcss-load-config@3.1.4(ts-node@10.9.1):
+  /postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -15101,7 +15010,6 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.5
-      ts-node: 10.9.1(@types/node@17.0.34)(typescript@4.9.5)
       yaml: 1.10.2
     dev: true
 
@@ -16375,7 +16283,7 @@ packages:
       hardhat: ^2.8.0
     dependencies:
       handlebars: 4.7.7
-      hardhat: 2.10.2(ts-node@10.7.0)(typescript@4.9.5)
+      hardhat: 2.10.2(ts-node@10.9.1)(typescript@4.9.5)
       solidity-ast: 0.4.46
     dev: true
 
@@ -17242,7 +17150,7 @@ packages:
       '@types/jest': 27.4.1
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(ts-node@10.9.1)
+      jest: 27.5.1
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -17318,37 +17226,6 @@ packages:
       semver: 7.3.8
       typescript: 4.9.5
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-node@10.7.0(@types/node@17.0.34)(typescript@4.9.5):
-    resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.7.0
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 17.0.34
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
     dev: true
 
   /ts-node@10.9.1(@types/node@17.0.34)(typescript@4.9.5):
@@ -17448,7 +17325,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 2.79.1
       source-map: 0.7.4
@@ -17485,7 +17362,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.20.2
       source-map: 0.8.0-beta.0
@@ -17497,7 +17374,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@6.7.0(ts-node@10.9.1)(typescript@4.9.5):
+  /tsup@6.7.0(typescript@4.9.5):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -17521,7 +17398,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.20.2
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
We no longer need ts-node at runtime like we did before (this was either a cli thing or a config thing), we can remove ts-node from most packages.

That leaves only a couple that actually used it:
- store for codegen, but this was easy to swap with tsx (used elsewhere)
- noise for `test:hardhat` but the command wasn't working or in use anyway, so I just reduced it to what it _should_ be assuming hardhat adds TS support
  - we could also just migrate the test cases over to foundry

Helps a bit with #612 