### PR TITLE
feat(cli): add local linking to mud set-version

### DIFF
--- a/packages/cli/src/commands/set-version.ts
+++ b/packages/cli/src/commands/set-version.ts
@@ -107,7 +107,11 @@ function updatePackageJson(filePath: string, options: Options): { workspaces?: s
   for (const key in packageJson.dependencies) {
     if (key.startsWith(MUD_PREFIX)) {
       packageJson.dependencies[key] =
-        restore && backupJson ? backupJson.dependencies[key] : mudVersion || packageJson.dependencies[key];
+        restore && backupJson
+          ? backupJson.dependencies[key]
+          : mudVersion
+          ? updateVersion(mudVersion, key, filePath)
+          : packageJson.dependencies[key];
     }
   }
 
@@ -115,7 +119,11 @@ function updatePackageJson(filePath: string, options: Options): { workspaces?: s
   for (const key in packageJson.devDependencies) {
     if (key.startsWith(MUD_PREFIX)) {
       packageJson.devDependencies[key] =
-        restore && backupJson ? backupJson.devDependencies[key] : mudVersion || packageJson.devDependencies[key];
+        restore && backupJson
+          ? backupJson.devDependencies[key]
+          : mudVersion
+          ? updateVersion(mudVersion, key, filePath)
+          : packageJson.devDependencies[key];
     }
   }
 
@@ -167,6 +175,18 @@ function logComparison(prev: Record<string, string>, curr: Record<string, string
       console.log(`${key}: ${chalk.red(prev[key])} -> ${chalk.green(curr[key])}`);
     }
   }
+}
+
+function updateVersion(mudVersion: string, pkg: string, packageJsonPath: string) {
+  // Append the package name if linking to a local MUD clone
+  if (mudVersion.includes("link:")) {
+    const linkPathFromCWD = mudVersion.replace("link:", "");
+    const packagePathToCWD = path.relative(path.dirname(packageJsonPath), process.cwd());
+    const relativeLinkPath = path.join(packagePathToCWD, linkPathFromCWD);
+    const packageLinkPath = path.join(relativeLinkPath, pkg.replace(MUD_PREFIX, ""));
+    return "link:" + packageLinkPath;
+  }
+  return mudVersion;
 }
 
 export default commandModule;

--- a/packages/cli/src/commands/set-version.ts
+++ b/packages/cli/src/commands/set-version.ts
@@ -11,6 +11,7 @@ type Options = {
   force?: boolean;
   restore?: boolean;
   mudVersion?: string;
+  link?: string;
 };
 
 const BACKUP_FILE = ".mudbackup";
@@ -30,13 +31,19 @@ const commandModule: CommandModule<Options, Options> = {
       },
       restore: { type: "boolean", description: `Restore the previous MUD versions from "${BACKUP_FILE}"` },
       mudVersion: { alias: "v", type: "string", description: "The MUD version to install" },
+      link: { alias: "l", type: "string", description: "The local MUD clone to link" },
     });
   },
 
   async handler(options) {
     try {
-      if (!options.mudVersion && !options.restore) {
-        throw new MUDError(`Version parameter is required unless --restore is provided.`);
+      if (!options.mudVersion && !options.link && !options.restore) {
+        throw new MUDError("`--mudVersion` or `--link` is required unless --restore is provided.");
+      }
+
+      // `link` and `mudVersion` are mutually exclusive
+      if (options.link && options.mudVersion) {
+        throw new MUDError("Options `--link` and `--mudVersion` are mutually exclusive");
       }
 
       // Resolve the `canary` version number if needed
@@ -63,11 +70,17 @@ const commandModule: CommandModule<Options, Options> = {
 };
 
 function updatePackageJson(filePath: string, options: Options): { workspaces?: string[] } {
-  const { backup, restore, force, mudVersion } = options;
+  const { restore, force, link } = options;
+  let { backup, mudVersion } = options;
+
   const backupFilePath = path.join(path.dirname(filePath), BACKUP_FILE);
+  const backupFileExists = existsSync(backupFilePath);
+
+  // Create a backup file for previous MUD versions by default if linking to local MUD
+  if (link && !backupFileExists) backup = true;
 
   // If `backup` is true and force not set, check if a backup file already exists and throw an error if it does
-  if (backup && !force && existsSync(backupFilePath)) {
+  if (backup && !force && backupFileExists) {
     throw new MUDError(
       `A backup file already exists at ${backupFilePath}.\nUse --force to overwrite it or --restore to restore it.`
     );
@@ -106,24 +119,14 @@ function updatePackageJson(filePath: string, options: Options): { workspaces?: s
   // Update the dependencies
   for (const key in packageJson.dependencies) {
     if (key.startsWith(MUD_PREFIX)) {
-      packageJson.dependencies[key] =
-        restore && backupJson
-          ? backupJson.dependencies[key]
-          : mudVersion
-          ? updateVersion(mudVersion, key, filePath)
-          : packageJson.dependencies[key];
+      packageJson.dependencies[key] = resolveMudVersion(key, "dependencies");
     }
   }
 
   // Update the devDependencies
   for (const key in packageJson.devDependencies) {
     if (key.startsWith(MUD_PREFIX)) {
-      packageJson.devDependencies[key] =
-        restore && backupJson
-          ? backupJson.devDependencies[key]
-          : mudVersion
-          ? updateVersion(mudVersion, key, filePath)
-          : packageJson.devDependencies[key];
+      packageJson.devDependencies[key] = resolveMudVersion(key, "devDependencies");
     }
   }
 
@@ -142,6 +145,13 @@ function updatePackageJson(filePath: string, options: Options): { workspaces?: s
   }
 
   return packageJson;
+
+  function resolveMudVersion(key: string, type: "dependencies" | "devDependencies") {
+    if (restore && backupJson) return backupJson[type][key];
+    if (link) mudVersion = resolveLinkPath(filePath, link, key);
+    if (!mudVersion) return packageJson[type][key];
+    return mudVersion;
+  }
 }
 
 function readPackageJson(path: string): {
@@ -177,16 +187,14 @@ function logComparison(prev: Record<string, string>, curr: Record<string, string
   }
 }
 
-function updateVersion(mudVersion: string, pkg: string, packageJsonPath: string) {
-  // Append the package name if linking to a local MUD clone
-  if (mudVersion.includes("link:")) {
-    const linkPathFromCWD = mudVersion.replace("link:", "");
-    const packagePathToCWD = path.relative(path.dirname(packageJsonPath), process.cwd());
-    const relativeLinkPath = path.join(packagePathToCWD, linkPathFromCWD);
-    const packageLinkPath = path.join(relativeLinkPath, pkg.replace(MUD_PREFIX, ""));
-    return "link:" + packageLinkPath;
-  }
-  return mudVersion;
+/**
+ * Returns path of the package to link, given a path to a local MUD clone and a package
+ */
+function resolveLinkPath(packageJsonPath: string, mudLinkPath: string, pkg: string) {
+  const pkgName = pkg.replace(MUD_PREFIX, "");
+  const packageJsonToRootPath = path.relative(path.dirname(packageJsonPath), process.cwd());
+  const linkPath = path.join(packageJsonToRootPath, mudLinkPath, "packages", pkgName);
+  return "link:" + linkPath;
 }
 
 export default commandModule;

--- a/packages/cli/src/commands/set-version.ts
+++ b/packages/cli/src/commands/set-version.ts
@@ -31,7 +31,7 @@ const commandModule: CommandModule<Options, Options> = {
       },
       restore: { type: "boolean", description: `Restore the previous MUD versions from "${BACKUP_FILE}"` },
       mudVersion: { alias: "v", type: "string", description: "The MUD version to install" },
-      link: { alias: "l", type: "string", description: "The local MUD clone to link" },
+      link: { alias: "l", type: "string", description: "Relative path to the local MUD root directory to link" },
     });
   },
 


### PR DESCRIPTION
* Adds a `--link` param to the `mud set-version` cli script, which takes a relative path from the current project root to the root directory of a local MUD clone, and replaces all MUD dependencies with locally linked versions. It automatically creates a backup file with the previous (non-linked) MUD versions, which can be restored with the `mud set-version --restore`

Usage (from root of any MUD project)

1. Link to local MUD installation
`mud set-version --link <path/to/mud>`

2. Revert to original non-linked versions:
`mud set-version --restore`