### PR TITLE
build: remove prepare in favor of build script

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,5 +22,9 @@ runs:
 
     - name: Install node dependencies
       shell: bash
-      # We use `--child-concurrency=1` for now because our install step calls `prepare` on each package, which often does a `forge build` and forge has a hard time running these things in parallel (resulting in `Text file busy (os error 26)` errors in CI)
-      run: pnpm install --frozen-lockfile --child-concurrency=1
+      run: pnpm install --frozen-lockfile
+
+    - name: Build
+      shell: bash
+      # We use `--workspace-concurrency=1` for now because forge has a hard time running in parallel (resulting in `Text file busy (os error 26)` errors in CI)
+      run: pnpm recursive --workspace-concurrency=1 run build

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "scripts": {
     "prepare": "husky install && (forge --version || pnpm foundryup)",
+    "build": "pnpm recursive run build",
     "commit": "cz",
     "prettier:check": "prettier --check 'packages/**/*.{ts,css,md,sol}'",
     "prettier": "prettier --write 'packages/**/*.{ts,css,md,sol}'",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,6 @@
     "directory": "packages/cli"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "codegen": "tsx ./scripts/codegen.ts",
     "lint": "eslint . --ext .ts",
     "dev": "tsup --watch",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,6 @@
     "directory": "packages/config"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "test": "vitest typecheck --run",
     "build": "vite build",
     "release": "npm publish --access=public"

--- a/packages/create-mud/package.json
+++ b/packages/create-mud/package.json
@@ -9,7 +9,6 @@
     "dist"
   ],
   "scripts": {
-    "prepare": "pnpm build",
     "build": "tsup src/cli.ts --minify && ./scripts/copy-templates.sh",
     "clean": "rimraf dist",
     "dev": "tsup src/cli.ts --watch",

--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -12,7 +12,6 @@
     "directory": "packages/ecs-browser"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "test": "tsc && echo 'todo: add tests'",
     "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json ",
     "postpack": "mv package.json.bak package.json || echo 'no package.json.bak'",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -14,7 +14,6 @@
     "directory": "packages/network"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "lint": "eslint . --ext .ts",
     "test": "tsc --noEmit && jest --forceExit",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -7,7 +7,6 @@
   "types": "dist/types.d.ts",
   "license": "MIT",
   "scripts": {
-    "prepare": "pnpm build",
     "test:forge": "forge test",
     "test:hardhat": "hardhat test",
     "// Hardhat skipped in GH action until hardhat officially supports TS/ESM": "https://github.com/NomicFoundation/hardhat/pull/3156",

--- a/packages/phaserx/package.json
+++ b/packages/phaserx/package.json
@@ -10,7 +10,6 @@
     "directory": "packages/phaserx"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "lint": "eslint . --ext .ts",
     "test": "tsc && jest --passWithNoTests",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,6 @@
     "directory": "packages/react"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",
     "test": "tsc --noEmit && jest",
     "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json ",

--- a/packages/recs/package.json
+++ b/packages/recs/package.json
@@ -11,7 +11,6 @@
     "directory": "packages/recs"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "lint": "eslint . --ext .ts",
     "test": "tsc && jest",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",

--- a/packages/schema-type/package.json
+++ b/packages/schema-type/package.json
@@ -12,7 +12,6 @@
     "directory": "packages/schema-type"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "test": "pnpm test:solidity && pnpm test:typescript",
     "test:solidity": "forge test",
     "test:typescript": "tsc --noEmit",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/services"
   },
   "scripts": {
-    "prepare": "make build",
+    "build": "make build",
     "docs": "rimraf API && mkdir -p _docs/pkg && find pkg -type f -name '*.go' -exec bash -c 'gomarkdoc {} > \"$(dirname _docs/{})\".md' \\; && mv _docs/pkg API && rimraf _docs",
     "test": "tsc --noEmit && echo 'todo: add tests'",
     "protoc-ts": "make protoc-ts",

--- a/packages/solecs/package.json
+++ b/packages/solecs/package.json
@@ -10,7 +10,6 @@
     "directory": "packages/solecs"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "test": "forge test",
     "build": "rimraf out && forge build --out out && pnpm dist && pnpm types",
     "dist": "rimraf abi && mkdir abi && cat exports.txt | cut -d: -f7 | sort -n | uniq | xargs -n 1 sh -c 'cp out/\"$@\".sol/*.json abi/' sh && rimraf abi/*.metadata.json",

--- a/packages/std-client/package.json
+++ b/packages/std-client/package.json
@@ -11,7 +11,6 @@
     "directory": "packages/std-client"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",
     "codegen": "tsx ./scripts/codegen.mts",
     "test": "pnpm codegen && vitest typecheck --run && echo 'todo: add tests'",

--- a/packages/std-contracts/package.json
+++ b/packages/std-contracts/package.json
@@ -10,7 +10,6 @@
     "directory": "packages/std-contracts"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "test": "forge test",
     "build": "rimraf out && forge build && pnpm dist && pnpm types",
     "dist": "rimraf abi && mkdir abi && cat exports.txt | cut -d: -f7 | sort -n | uniq | xargs -n 1 sh -c 'cp out/\"$@\".sol/*.json abi/' sh && rimraf abi/*.metadata.json",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,7 +14,6 @@
     "directory": "packages/store"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "codegen": "tsx ./scripts/codegen.ts && prettier --write '**/*.sol'",
     "tablegen": "../cli/dist/mud.js tablegen",
     "test": "pnpm codegen && forge test",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,6 @@
     "directory": "packages/utils"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "lint": "eslint . --ext .ts",
     "test": "tsc && jest",
     "docs": "rimraf API && typedoc src && find API -type f -name '*.md' -exec sed -E -i \"\" \"s/(#.*)(<.*>)/\\1/\" {} \\; && echo 'label: API' > API/index.yml",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -14,7 +14,6 @@
     "directory": "packages/world"
   },
   "scripts": {
-    "prepare": "pnpm build",
     "tablegen": "../cli/dist/mud.js tablegen",
     "worldgen": "../cli/dist/mud.js worldgen",
     "test": "forge test",


### PR DESCRIPTION
Speed up installs by removing `prepare`. For now we'll have to run `pnpm build` before using (this happened implicitly after install with `prepare`).

Pulled out of https://github.com/latticexyz/mud/pull/620 to reduce scope of that PR