### PR TITLE
Allows components, systems, and initializers to be placed in subdirectories and specified in deploy.json

### DIFF
--- a/packages/cli/src/contracts/LibDeploy.ejs
+++ b/packages/cli/src/contracts/LibDeploy.ejs
@@ -60,9 +60,9 @@ library LibDeploy {
     if (!_reuseComponents) {
       IComponent comp;
 <% components.forEach(component => { -%>
-
-      console.log("Deploying <%= component %>");
-      comp = new <%= component %>(address(result.world));
+      <% const componentName=component.split("/").pop(); %>
+      console.log("Deploying <%= componentName %>");
+      comp = new <%= componentName %>(address(result.world));
       console.log(address(comp));
 <% });-%>
     } 
@@ -76,7 +76,8 @@ library LibDeploy {
       SystemStorage.init(result.world, result.world.components());
 
 <% initializers.forEach((name) => { -%>
-      <%= name -%>.init(result.world);
+      <% const initializerName=name.split("/").pop(); %>
+      <%= initializerName -%>.init(result.world);
 <% }); -%>
     }
   }
@@ -102,17 +103,19 @@ library LibDeploy {
     ISystem system; 
     IUint256Component components = world.components();
 <% systems.forEach(system => { -%>
-
-    console.log("Deploying <%= system.name %>");
-    system = new <%= system.name %>(world, address(components));
-    world.registerSystem(address(system), <%= system.name %>ID);
+    <% const systemName=system.name.split("/").pop(); %>
+    console.log("Deploying <%= systemName %>");
+    system = new <%= systemName %>(world, address(components));
+    world.registerSystem(address(system), <%= systemName %>ID);
 <% system.writeAccess?.forEach(component => { -%>
-<% if (component === "*") { -%>
+<% const componentName=component.split("/").pop(); %>
+<% if (componentName === "*") { -%>
 <% components.forEach(comp=> { -%>
-    authorizeWriter(components, <%= comp %>ID, address(system));
+    <% const compName=comp.split("/").pop(); %>
+    authorizeWriter(components, <%= compName %>ID, address(system));
 <% });-%>
 <% } else { -%>
-    authorizeWriter(components, <%= component %>ID, address(system));
+    authorizeWriter(components, <%= componentName %>ID, address(system));
 <% } -%>
 <% });-%>
 <% if (system.initialize) { -%>

--- a/packages/cli/src/contracts/LibDeploy.ejs
+++ b/packages/cli/src/contracts/LibDeploy.ejs
@@ -17,18 +17,21 @@ import { SystemStorage } from "solecs/SystemStorage.sol";
 
 // Components (requires 'components=...' remapping in project's remappings.txt)
 <% components.forEach(component => { -%>
-import { <%= component %>, ID as <%= component %>ID } from "components/<%- component %>.sol";
+<% const componentName = component.split("/").pop(); %>
+import { <%= componentName %>, ID as <%= componentName %>ID } from "components/<%- component %>.sol";
 <% }); -%>
 
 // Systems (requires 'systems=...' remapping in project's remappings.txt)
 <% systems.forEach(system => { -%>
-import { <%= system.name %>, ID as <%= system.name %>ID } from "systems/<%- system.name %>.sol";
+<% const systemName=system.name.split("/").pop(); %>
+import { <%= systemName %>, ID as <%= systemName %>ID } from "systems/<%- system.name %>.sol";
 <% }); -%>
 
 <% if (initializers.length > 0) { -%>
 // Initializer libraries (requires 'libraries=...' remapping in project's remappings.txt)
 <% initializers.forEach((initializer) => { -%>
-import { <%= initializer %> } from "libraries/<%- initializer %>.sol";
+<% const initializerName=initializer.name.split("/").pop(); %>
+import { <%= initializerName %> } from "libraries/<%- initializer %>.sol";
 <% }); -%>
 <% } -%>
 


### PR DESCRIPTION
Allows components, systems, and initializers to be placed in subdirectories. This helps with organizing components if there is a lot of them.

For example, "components/base/PositionComponent.sol" in the components directory will be imported as `import { PositionComponent, ID as PositionComponentID } from "components/base/PositionComponent.sol";` in `LibDeploy.sol`.

Sample deploy.json:

```
  "components": [
    "debug/CounterComponent",
    "base/GameConfigComponent",
    "base/PositionComponent",
    "base/TileComponent",
    "base/OwnedByComponent",
    "resource/IronComponent",
    "resource/CopperComponent",
    "resource/IridiumComponent",
    "crafted/BulletComponent",
    "crafted/FastMinerComponent"
  ]
```