### PR TITLE
build: update canary preid

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write '**/*.{ts,css,md,sol}'",
     "prettier:check": "prettier --check '**/*.{ts,css,md,sol}'",
     "release": "pnpm install && lerna publish --no-private --force-publish && pnpm retype:updateversion",
-    "release:canary": "lerna publish prepatch --canary --no-private --force-publish",
+    "release:canary": "lerna publish premajor --preid alpha.1 --canary --no-private --force-publish",
     "release:ci": "lerna publish --no-private --force-publish --yes",
     "release:manual": "pnpm --recursive --no-bail run release",
     "release:yalc": "(pnpm entry:dist && lerna exec npx yalc push); pnpm entry:src",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "prettier --write '**/*.{ts,css,md,sol}'",
     "prettier:check": "prettier --check '**/*.{ts,css,md,sol}'",
     "release": "pnpm install && lerna publish --no-private --force-publish && pnpm retype:updateversion",
-    "release:canary": "lerna publish premajor --canary --no-private --force-publish",
+    "release:canary": "lerna publish prepatch --canary --no-private --force-publish",
     "release:ci": "lerna publish --no-private --force-publish --yes",
     "release:manual": "pnpm --recursive --no-bail run release",
     "release:yalc": "(pnpm entry:dist && lerna exec npx yalc push); pnpm entry:src",


### PR DESCRIPTION
Our canary release pipeline assumed the next release would be a major version, so when we did a manual minor release, the alpha counter reset:

![image](https://user-images.githubusercontent.com/508855/232602430-1144da7f-f5d0-4c92-b65e-e1b5db04e156.png)

In ~30 main commits, this will conflict with previously released alphas.

We'll have probably lots of minor/patch releases until 2.0 (and after), so let's switch canary/alpha releases to use prepatch. It won't exactly follow semver but at least we won't have to fight this issue every manual release.