### PR TITLE
fix(create-mud): replace linked deps

### DIFF
--- a/packages/create-mud/scripts/copy-templates.sh
+++ b/packages/create-mud/scripts/copy-templates.sh
@@ -7,6 +7,17 @@ git ls-files ../../templates | rsync --files-from=- ../../ dist
 # Replace all MUD package links with mustache placeholder used by create-create-app
 # that will be replaced with the latest MUD version number when the template is used
 find ./dist/templates/* -name "package.json" -type f | while read -r file; do
+  echo "Before replacement in $file:"
+  cat "$file"
   # GPT-4 recommended perl to edit-in-place rather than sed, because sed wasn't working on CI
-  perl -pi -e 's/"\(@latticexyz\/.*\)": "link:.*"/"\1": "{{mud-version}}"/g' "$file"
+  perl -pi -e 's|"(?=@latticexyz)([^"]+)":\s*"link:[^"]+"|"\1": "{{mud-version}}"|g' "$file"
+  echo "After replacement in $file:"
+  cat "$file"
+  echo
 done
+
+# Check if any files still have "link:" dependencies
+if grep -r -E 'link:' ./dist/templates; then
+  echo "Linked dependencies found in dist/templates"
+  exit 1
+fi


### PR DESCRIPTION
Thanks GPT-4 for helping with the original code and fixing this bug.

The script now will 1) output more information so we can debug this easier in the future and 2) exit with a non-zero code if any linked dependencies are found after running the replacement logic.

Fixes #647 
