### PR TITLE
refactor: normalize vite configs, use tsx for store/world scripts

### DIFF
--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
-    minify: false,
+    minify: true,
     sourcemap: true,
     target: "esnext",
   },

--- a/packages/common/vite.config.ts
+++ b/packages/common/vite.config.ts
@@ -16,8 +16,9 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
-    minify: false,
+    minify: true,
     sourcemap: true,
+    target: "esnext",
   },
   ssr: {
     noExternal: ["execa", "is-stream", "npm-run-path"],

--- a/packages/common/vite.config.ts
+++ b/packages/common/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     target: "esnext",
   },
   ssr: {
-    noExternal: ["execa", "is-stream", "npm-run-path"],
+    noExternal: ["execa", "is-stream", "npm-run-path", "@latticexyz/solidity-parser"],
   },
   /**
    * @see https://vitest.dev/config/

--- a/packages/config/vite.config.ts
+++ b/packages/config/vite.config.ts
@@ -13,8 +13,9 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
-    minify: false,
+    minify: true,
     sourcemap: true,
+    target: "esnext",
   },
   /**
    * @see https://vitest.dev/config/

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -16,9 +16,9 @@
   },
   "types": "ts/index.ts",
   "scripts": {
-    "build": "pnpm run build:js && pnpm run build:tightcoder && pnpm run build:codegen && pnpm run build:abi && pnpm run build:typechain",
+    "build": "pnpm run build:tightcoder && pnpm run build:codegen && pnpm run build:abi && pnpm run build:typechain && pnpm run build:js",
     "build:abi": "forge build --out abi --skip test script",
-    "build:codegen": "node ./dist/tablegen.js",
+    "build:codegen": "tsx ./ts/scripts/tablegen.ts",
     "build:js": "vite build",
     "build:tightcoder": "tsx ./ts/scripts/codegenTightcoder.ts && prettier --write '**/*.sol'",
     "build:typechain": "typechain --target ethers-v5 'abi/**/*.sol/!(*.abi).json'",

--- a/packages/store/vite.config.ts
+++ b/packages/store/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   build: {
     ssr: true,
     lib: {
-      entry: ["mud.config.ts", "ts/scripts/tablegen.ts", "ts/index.ts"],
+      entry: ["mud.config.ts", "ts/index.ts"],
       formats: ["es"],
     },
     outDir: "dist",

--- a/packages/store/vite.config.ts
+++ b/packages/store/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
-    minify: false,
+    minify: true,
     sourcemap: true,
     target: "esnext",
   },

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -16,9 +16,9 @@
   },
   "types": "ts/index.ts",
   "scripts": {
-    "build": "pnpm run build:js && pnpm run build:codegen && pnpm run build:abi && pnpm run build:typechain",
+    "build": "pnpm run build:codegen && pnpm run build:abi && pnpm run build:typechain && pnpm run build:js",
     "build:abi": "forge build --out abi --skip test script",
-    "build:codegen": "node ./dist/tablegen.js && node ./dist/worldgen.js",
+    "build:codegen": "tsx ./ts/scripts/tablegen.ts && tsx ./ts/scripts/worldgen.ts",
     "build:js": "vite build",
     "build:typechain": "typechain --target ethers-v5 'abi/**/*.sol/!(*.abi).json'",
     "clean": "pnpm run clean:abi && pnpm run clean:typechain && pnpm run clean:js",

--- a/packages/world/vite.config.ts
+++ b/packages/world/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   build: {
     ssr: true,
     lib: {
-      entry: ["ts/scripts/worldgen.ts", "ts/scripts/tablegen.ts", "ts/index.ts", "mud.config.ts"],
+      entry: ["ts/index.ts", "mud.config.ts"],
       formats: ["es"],
     },
     outDir: "dist",

--- a/packages/world/vite.config.ts
+++ b/packages/world/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
-    minify: false,
+    minify: true,
     sourcemap: true,
     target: "esnext",
   },


### PR DESCRIPTION
- vite config changes are about minify from https://github.com/latticexyz/mud/pull/640#discussion_r1172766764 and some minor normalization
- tsx requires to also bundle solidity parser, which ups `common`'s bundle size from ~50kB to ~1000kB. Probably not much of an issue since it's nodeside. Also moved `build:js` back to the end.
- Tried to remove `modules.d.ts` with prettier plugin stuff, but they're still required in the downstream packages unfortunately