### PR TITLE
fix(cli): parse struct function arguments

### DIFF
--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -9,7 +9,7 @@ import { BigNumber, ContractInterface, ethers } from "ethers";
 import { IBaseWorld } from "@latticexyz/world/types/ethers-contracts/IBaseWorld.js";
 import chalk from "chalk";
 import { encodeSchema } from "@latticexyz/schema-type";
-import { defaultAbiCoder as abi, Fragment } from "ethers/lib/utils.js";
+import { defaultAbiCoder as abi, Fragment, ParamType } from "ethers/lib/utils.js";
 
 import WorldData from "@latticexyz/world/abi/World.sol/World.json" assert { type: "json" };
 import IBaseWorldData from "@latticexyz/world/abi/IBaseWorld.sol/IBaseWorld.json" assert { type: "json" };
@@ -388,7 +388,20 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
       .map((item) => {
         if (item.type === "fallback") return { functionName: "", functionArgs: "" };
 
-        return { functionName: item.name, functionArgs: `(${item.inputs.map((arg) => arg.type).join(",")})` };
+        // Helper to recursively parse structs
+        const parseFunctionComponentsRec = (components: ParamType[]): string =>
+          `(${components.map((param) => {
+            const paramType = param.type;
+            if (paramType === "tuple") {
+              return parseFunctionComponentsRec(param.components);
+            }
+            return paramType;
+          })})`;
+
+        return {
+          functionName: item.name,
+          functionArgs: parseFunctionComponentsRec(item.inputs),
+        };
       });
   }
 

--- a/packages/cli/src/utils/deploy-v2.ts
+++ b/packages/cli/src/utils/deploy-v2.ts
@@ -388,21 +388,19 @@ export async function deploy(mudConfig: MUDConfig, deployConfig: DeployConfig): 
       .map((item) => {
         if (item.type === "fallback") return { functionName: "", functionArgs: "" };
 
-        // Helper to recursively parse structs
-        const parseFunctionComponentsRec = (components: ParamType[]): string =>
-          `(${components.map((param) => {
-            const paramType = param.type;
-            if (paramType === "tuple") {
-              return parseFunctionComponentsRec(param.components);
-            }
-            return paramType;
-          })})`;
-
         return {
           functionName: item.name,
-          functionArgs: parseFunctionComponentsRec(item.inputs),
+          functionArgs: parseComponents(item.inputs),
         };
       });
+  }
+
+  /**
+   * Recursively turn (nested) structs in signatures into tuples
+   */
+  function parseComponents(params: ParamType[]): string {
+    const components = params.map((param) => (param.type === "tuple" ? parseComponents(param.components) : param.type));
+    return `(${components})`;
   }
 
   /**


### PR DESCRIPTION
Previously, function arguments that were structs (as opposed to base solidity types) were not parsed correctly by the Mud v2 deploy script. For example, a struct Coord (int32 x, int32 y) would parse as `tuple` instead of `(int32,int32)`.

This change parses structs (& nested structs) in function args