### PR TITLE
ci: add linter for PR title

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
adds linter for PR titles so we can require this workflow step before merging

prerequisite for https://github.com/latticexyz/mud/issues/683

(note that this won't run in this PR with `pull_request_target`, only on PRs from here on out, using `main` as the definition for this workflow, see https://github.com/amannn/action-semantic-pull-request#event-triggers)