### PR TITLE
fix(create-mud): rename system execute args

### DIFF
--- a/templates/minimal/packages/contracts/src/systems/IncrementSystem.sol
+++ b/templates/minimal/packages/contracts/src/systems/IncrementSystem.sol
@@ -10,8 +10,8 @@ uint256 constant ID = uint256(keccak256("system.Increment"));
 contract IncrementSystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
-  function execute(bytes memory arguments) public returns (bytes memory) {
-    uint256 entity = abi.decode(arguments, (uint256));
+  function execute(bytes memory args) public returns (bytes memory) {
+    uint256 entity = abi.decode(args, (uint256));
     CounterComponent c = CounterComponent(getAddressById(components, CounterComponentID));
     LibMath.increment(c, entity);
   }

--- a/templates/react/packages/contracts/src/systems/IncrementSystem.sol
+++ b/templates/react/packages/contracts/src/systems/IncrementSystem.sol
@@ -10,8 +10,8 @@ uint256 constant ID = uint256(keccak256("system.Increment"));
 contract IncrementSystem is System {
   constructor(IWorld _world, address _components) System(_world, _components) {}
 
-  function execute(bytes memory arguments) public returns (bytes memory) {
-    uint256 entity = abi.decode(arguments, (uint256));
+  function execute(bytes memory args) public returns (bytes memory) {
+    uint256 entity = abi.decode(args, (uint256));
     CounterComponent c = CounterComponent(getAddressById(components, CounterComponentID));
     LibMath.increment(c, entity);
   }


### PR DESCRIPTION
`arguments` is a reserved word in TS strict mode, so this causes downstream issues with generated types from typechain
