### PR TITLE
ci: speed up solc setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,9 +22,10 @@ runs:
 
     # Workaround for parallel building with forge:
     # https://github.com/foundry-rs/foundry/issues/4736
-    - name: Install solc
+    - name: Setup forge
       shell: bash
-      run: cargo install svm-rs && svm install 0.8.13
+      working-directory: packages/schema-type
+      run: forge build
 
     - name: Setup protoc
       uses: arduino/setup-protoc@v1

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,19 +20,19 @@ runs:
       with:
         version: nightly
 
-    # Workaround for parallel building with forge:
-    # https://github.com/foundry-rs/foundry/issues/4736
-    - name: Setup forge
-      shell: bash
-      working-directory: packages/schema-type
-      run: forge build
-
     - name: Setup protoc
       uses: arduino/setup-protoc@v1
 
     - name: Install node dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    # Workaround for parallel building with forge:
+    # https://github.com/foundry-rs/foundry/issues/4736
+    - name: Setup forge
+      shell: bash
+      working-directory: packages/schema-type
+      run: forge build
 
     - name: Cache turbo build
       uses: actions/cache@v3


### PR DESCRIPTION
~3 mins of CI time is spent setting up `solc` with the previous step

trying to see if just using `forge build` helps here

see https://github.com/foundry-rs/foundry/issues/4736