### PR TITLE
feat(world): emit event on deploy

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./examples/${{ matrix.example }}
         run: pnpm run initialize && pnpm run build
 
-      - name: Outdated files, run `pnpm gas-report` and commit them
+      - name: Outdated files, run `pnpm run initialize && pnpm run build` in `examples/${{ matrix.example }}` and commit them
         uses: ./.github/actions/require-empty-diff
 
       - name: Run tests

--- a/examples/minimal/packages/contracts/types/ethers-contracts/IWorld.ts
+++ b/examples/minimal/packages/contracts/types/ethers-contracts/IWorld.ts
@@ -502,15 +502,22 @@ export interface IWorldInterface extends utils.Interface {
   ): Result;
 
   events: {
+    "HelloWorld()": EventFragment;
     "StoreDeleteRecord(bytes32,bytes32[])": EventFragment;
     "StoreSetField(bytes32,bytes32[],uint8,bytes)": EventFragment;
     "StoreSetRecord(bytes32,bytes32[],bytes)": EventFragment;
   };
 
+  getEvent(nameOrSignatureOrTopic: "HelloWorld"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "StoreDeleteRecord"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "StoreSetField"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "StoreSetRecord"): EventFragment;
 }
+
+export interface HelloWorldEventObject {}
+export type HelloWorldEvent = TypedEvent<[], HelloWorldEventObject>;
+
+export type HelloWorldEventFilter = TypedEventFilter<HelloWorldEvent>;
 
 export interface StoreDeleteRecordEventObject {
   table: string;
@@ -1337,6 +1344,9 @@ export interface IWorld extends BaseContract {
   };
 
   filters: {
+    "HelloWorld()"(): HelloWorldEventFilter;
+    HelloWorld(): HelloWorldEventFilter;
+
     "StoreDeleteRecord(bytes32,bytes32[])"(
       table?: null,
       key?: null

--- a/examples/minimal/packages/contracts/types/ethers-contracts/factories/IWorld__factory.ts
+++ b/examples/minimal/packages/contracts/types/ethers-contracts/factories/IWorld__factory.ts
@@ -102,6 +102,12 @@ const _abi = [
   },
   {
     anonymous: false,
+    inputs: [],
+    name: "HelloWorld",
+    type: "event",
+  },
+  {
+    anonymous: false,
     inputs: [
       {
         indexed: false,

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -32,6 +32,8 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     NamespaceOwner.set(ROOT_NAMESPACE, msg.sender);
 
     // Other internal tables are registered by the CoreModule to reduce World's bytecode size.
+
+    emit HelloWorld();
   }
 
   /**

--- a/packages/world/src/interfaces/IWorldKernel.sol
+++ b/packages/world/src/interfaces/IWorldKernel.sol
@@ -101,5 +101,5 @@ interface IWorldCall {
  * registered functions selectors from the `CoreModule`.
  */
 interface IWorldKernel is IWorldData, IWorldModuleInstallation, IWorldCall, IErrors {
-
+  event HelloWorld();
 }

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -119,6 +119,7 @@ contract WorldTestTableHook is IStoreHook {
 contract WorldTest is Test {
   using ResourceSelector for bytes32;
 
+  event HelloWorld();
   event HookCalled(bytes data);
   event WorldTestSystemLog(string log);
 
@@ -148,6 +149,12 @@ contract WorldTest is Test {
   }
 
   function testConstructor() public {
+    vm.expectEmit(true, true, true, true);
+    emit HelloWorld();
+    new World();
+  }
+
+  function testRootNamespace() public {
     // Owner of root route should be the creator of the World
     address rootOwner = NamespaceOwner.get(world, ROOT_NAMESPACE);
     assertEq(rootOwner, address(this));


### PR DESCRIPTION
Adds an event to world deploy so we don't need to keep track of deploy block number, we can just grab it from the RPC by looking for this event.

see #680