### PR TITLE
feat: add encodeKey function to tablegen

### DIFF
--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -67,35 +67,27 @@ library CounterTable {
 
   /** Get value */
   function get(bytes32 key) internal view returns (uint32 value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (uint32 value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Set value */
   function set(bytes32 key, uint32 value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
@@ -104,19 +96,21 @@ library CounterTable {
     return abi.encodePacked(value);
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics.sol
@@ -92,664 +92,503 @@ library Dynamics {
 
   /** Get staticB32 */
   function getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get staticB32 (using the specified store) */
   function getStaticB32(IStore _store, bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Set staticB32 */
   function setStaticB32(bytes32 key, bytes32[1] memory staticB32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
 
   /** Set staticB32 (using the specified store) */
   function setStaticB32(IStore _store, bytes32 key, bytes32[1] memory staticB32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
 
   /** Push an element to staticB32 */
   function pushStaticB32(bytes32 key, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to staticB32 (using the specified store) */
   function pushStaticB32(IStore _store, bytes32 key, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from staticB32 */
   function popStaticB32(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 32);
   }
 
   /** Pop an element from staticB32 (using the specified store) */
   function popStaticB32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 0, 32);
   }
 
   /** Update an element of staticB32 at `_index` */
   function updateStaticB32(bytes32 key, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 32, abi.encodePacked((_element)));
   }
 
   /** Update an element of staticB32 (using the specified store) at `_index` */
   function updateStaticB32(IStore _store, bytes32 key, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 32, abi.encodePacked((_element)));
   }
 
   /** Get staticI32 */
   function getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
   /** Get staticI32 (using the specified store) */
   function getStaticI32(IStore _store, bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
   /** Set staticI32 */
   function setStaticI32(bytes32 key, int32[2] memory staticI32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
 
   /** Set staticI32 (using the specified store) */
   function setStaticI32(IStore _store, bytes32 key, int32[2] memory staticI32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
 
   /** Push an element to staticI32 */
   function pushStaticI32(bytes32 key, int32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Push an element to staticI32 (using the specified store) */
   function pushStaticI32(IStore _store, bytes32 key, int32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Pop an element from staticI32 */
   function popStaticI32(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 1, 4);
   }
 
   /** Pop an element from staticI32 (using the specified store) */
   function popStaticI32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 1, 4);
   }
 
   /** Update an element of staticI32 at `_index` */
   function updateStaticI32(bytes32 key, uint256 _index, int32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of staticI32 (using the specified store) at `_index` */
   function updateStaticI32(IStore _store, bytes32 key, uint256 _index, int32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get staticU128 */
   function getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
   /** Get staticU128 (using the specified store) */
   function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
   /** Set staticU128 */
   function setStaticU128(bytes32 key, uint128[3] memory staticU128) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
 
   /** Set staticU128 (using the specified store) */
   function setStaticU128(IStore _store, bytes32 key, uint128[3] memory staticU128) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
 
   /** Push an element to staticU128 */
   function pushStaticU128(bytes32 key, uint128 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Push an element to staticU128 (using the specified store) */
   function pushStaticU128(IStore _store, bytes32 key, uint128 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Pop an element from staticU128 */
   function popStaticU128(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 2, 16);
   }
 
   /** Pop an element from staticU128 (using the specified store) */
   function popStaticU128(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 2, 16);
   }
 
   /** Update an element of staticU128 at `_index` */
   function updateStaticU128(bytes32 key, uint256 _index, uint128 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 2, _index * 16, abi.encodePacked((_element)));
   }
 
   /** Update an element of staticU128 (using the specified store) at `_index` */
   function updateStaticU128(IStore _store, bytes32 key, uint256 _index, uint128 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 2, _index * 16, abi.encodePacked((_element)));
   }
 
   /** Get staticAddrs */
   function getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get staticAddrs (using the specified store) */
   function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Set staticAddrs */
   function setStaticAddrs(bytes32 key, address[4] memory staticAddrs) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
 
   /** Set staticAddrs (using the specified store) */
   function setStaticAddrs(IStore _store, bytes32 key, address[4] memory staticAddrs) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
 
   /** Push an element to staticAddrs */
   function pushStaticAddrs(bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
   /** Push an element to staticAddrs (using the specified store) */
   function pushStaticAddrs(IStore _store, bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
   /** Pop an element from staticAddrs */
   function popStaticAddrs(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 3, 20);
   }
 
   /** Pop an element from staticAddrs (using the specified store) */
   function popStaticAddrs(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 3, 20);
   }
 
   /** Update an element of staticAddrs at `_index` */
   function updateStaticAddrs(bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 3, _index * 20, abi.encodePacked((_element)));
   }
 
   /** Update an element of staticAddrs (using the specified store) at `_index` */
   function updateStaticAddrs(IStore _store, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 3, _index * 20, abi.encodePacked((_element)));
   }
 
   /** Get staticBools */
   function getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
   /** Get staticBools (using the specified store) */
   function getStaticBools(IStore _store, bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
   /** Set staticBools */
   function setStaticBools(bytes32 key, bool[5] memory staticBools) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
 
   /** Set staticBools (using the specified store) */
   function setStaticBools(IStore _store, bytes32 key, bool[5] memory staticBools) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
 
   /** Push an element to staticBools */
   function pushStaticBools(bytes32 key, bool _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 4, abi.encodePacked((_element)));
   }
 
   /** Push an element to staticBools (using the specified store) */
   function pushStaticBools(IStore _store, bytes32 key, bool _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 4, abi.encodePacked((_element)));
   }
 
   /** Pop an element from staticBools */
   function popStaticBools(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 4, 1);
   }
 
   /** Pop an element from staticBools (using the specified store) */
   function popStaticBools(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 4, 1);
   }
 
   /** Update an element of staticBools at `_index` */
   function updateStaticBools(bytes32 key, uint256 _index, bool _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 4, _index * 1, abi.encodePacked((_element)));
   }
 
   /** Update an element of staticBools (using the specified store) at `_index` */
   function updateStaticBools(IStore _store, bytes32 key, uint256 _index, bool _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 4, _index * 1, abi.encodePacked((_element)));
   }
 
   /** Get u64 */
   function getU64(bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 5);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
   /** Get u64 (using the specified store) */
   function getU64(IStore _store, bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 5);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
   /** Set u64 */
   function setU64(bytes32 key, uint64[] memory u64) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 5, EncodeArray.encode((u64)));
   }
 
   /** Set u64 (using the specified store) */
   function setU64(IStore _store, bytes32 key, uint64[] memory u64) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 5, EncodeArray.encode((u64)));
   }
 
   /** Push an element to u64 */
   function pushU64(bytes32 key, uint64 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 5, abi.encodePacked((_element)));
   }
 
   /** Push an element to u64 (using the specified store) */
   function pushU64(IStore _store, bytes32 key, uint64 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 5, abi.encodePacked((_element)));
   }
 
   /** Pop an element from u64 */
   function popU64(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 5, 8);
   }
 
   /** Pop an element from u64 (using the specified store) */
   function popU64(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 5, 8);
   }
 
   /** Update an element of u64 at `_index` */
   function updateU64(bytes32 key, uint256 _index, uint64 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 5, _index * 8, abi.encodePacked((_element)));
   }
 
   /** Update an element of u64 (using the specified store) at `_index` */
   function updateU64(IStore _store, bytes32 key, uint256 _index, uint64 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 5, _index * 8, abi.encodePacked((_element)));
   }
 
   /** Get str */
   function getStr(bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 6);
     return (string(_blob));
   }
 
   /** Get str (using the specified store) */
   function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 6);
     return (string(_blob));
   }
 
   /** Set str */
   function setStr(bytes32 key, string memory str) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 6, bytes((str)));
   }
 
   /** Set str (using the specified store) */
   function setStr(IStore _store, bytes32 key, string memory str) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 6, bytes((str)));
   }
 
   /** Push a slice to str */
   function pushStr(bytes32 key, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 6, bytes((_slice)));
   }
 
   /** Push a slice to str (using the specified store) */
   function pushStr(IStore _store, bytes32 key, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 6, bytes((_slice)));
   }
 
   /** Pop a slice from str */
   function popStr(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 6, 1);
   }
 
   /** Pop a slice from str (using the specified store) */
   function popStr(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 6, 1);
   }
 
   /** Update a slice of str at `_index` */
   function updateStr(bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 6, _index * 1, bytes((_slice)));
   }
 
   /** Update a slice of str (using the specified store) at `_index` */
   function updateStr(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 6, _index * 1, bytes((_slice)));
   }
 
   /** Get b */
   function getB(bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 7);
     return (bytes(_blob));
   }
 
   /** Get b (using the specified store) */
   function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 7);
     return (bytes(_blob));
   }
 
   /** Set b */
   function setB(bytes32 key, bytes memory b) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 7, bytes((b)));
   }
 
   /** Set b (using the specified store) */
   function setB(IStore _store, bytes32 key, bytes memory b) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 7, bytes((b)));
   }
 
   /** Push a slice to b */
   function pushB(bytes32 key, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 7, bytes((_slice)));
   }
 
   /** Push a slice to b (using the specified store) */
   function pushB(IStore _store, bytes32 key, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 7, bytes((_slice)));
   }
 
   /** Pop a slice from b */
   function popB(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 7, 1);
   }
 
   /** Pop a slice from b (using the specified store) */
   function popB(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 7, 1);
   }
 
   /** Update a slice of b at `_index` */
   function updateB(bytes32 key, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 7, _index * 1, bytes((_slice)));
   }
 
   /** Update a slice of b (using the specified store) at `_index` */
   function updateB(IStore _store, bytes32 key, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 7, _index * 1, bytes((_slice)));
   }
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (DynamicsData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -757,8 +596,7 @@ library Dynamics {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (DynamicsData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -777,9 +615,7 @@ library Dynamics {
     bytes memory b
   ) internal {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools, u64, str, b);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -798,9 +634,7 @@ library Dynamics {
     bytes memory b
   ) internal {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools, u64, str, b);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -917,19 +751,21 @@ library Dynamics {
       );
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -72,253 +72,219 @@ library Singleton {
 
   /** Get v1 */
   function getV1() internal view returns (int256 v1) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
   }
 
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
   }
 
   /** Set v1 */
   function setV1(int256 v1) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
   /** Set v1 (using the specified store) */
   function setV1(IStore _store, int256 v1) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
   /** Get v2 */
   function getV2() internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v2 (using the specified store) */
   function getV2(IStore _store) internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Set v2 */
   function setV2(uint32[2] memory v2) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
   /** Set v2 (using the specified store) */
   function setV2(IStore _store, uint32[2] memory v2) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
   /** Push an element to v2 */
   function pushV2(uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Push an element to v2 (using the specified store) */
   function pushV2(IStore _store, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.pushToField(_tableId, _primaryKeys, 1, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v2 */
   function popV2() internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.popFromField(_tableId, _primaryKeys, 1, 4);
   }
 
   /** Pop an element from v2 (using the specified store) */
   function popV2(IStore _store) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.popFromField(_tableId, _primaryKeys, 1, 4);
   }
 
   /** Update an element of v2 at `_index` */
   function updateV2(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.updateInField(_tableId, _primaryKeys, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v2 (using the specified store) at `_index` */
   function updateV2(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.updateInField(_tableId, _primaryKeys, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get v3 */
   function getV3() internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v3 (using the specified store) */
   function getV3(IStore _store) internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Set v3 */
   function setV3(uint32[2] memory v3) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
   /** Set v3 (using the specified store) */
   function setV3(IStore _store, uint32[2] memory v3) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
   /** Push an element to v3 */
   function pushV3(uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Push an element to v3 (using the specified store) */
   function pushV3(IStore _store, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v3 */
   function popV3() internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.popFromField(_tableId, _primaryKeys, 2, 4);
   }
 
   /** Pop an element from v3 (using the specified store) */
   function popV3(IStore _store) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.popFromField(_tableId, _primaryKeys, 2, 4);
   }
 
   /** Update an element of v3 at `_index` */
   function updateV3(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.updateInField(_tableId, _primaryKeys, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v3 (using the specified store) at `_index` */
   function updateV3(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.updateInField(_tableId, _primaryKeys, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get v4 */
   function getV4() internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v4 (using the specified store) */
   function getV4(IStore _store) internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Set v4 */
   function setV4(uint32[1] memory v4) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
   /** Set v4 (using the specified store) */
   function setV4(IStore _store, uint32[1] memory v4) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
   /** Push an element to v4 */
   function pushV4(uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
   /** Push an element to v4 (using the specified store) */
   function pushV4(IStore _store, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.pushToField(_tableId, _primaryKeys, 3, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v4 */
   function popV4() internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.popFromField(_tableId, _primaryKeys, 3, 4);
   }
 
   /** Pop an element from v4 (using the specified store) */
   function popV4(IStore _store) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.popFromField(_tableId, _primaryKeys, 3, 4);
   }
 
   /** Update an element of v4 at `_index` */
   function updateV4(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.updateInField(_tableId, _primaryKeys, 3, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v4 (using the specified store) at `_index` */
   function updateV4(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.updateInField(_tableId, _primaryKeys, 3, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get the full data */
   function get() internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
+    bytes32[] memory _primaryKeys = encodeKey();
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -328,7 +294,7 @@ library Singleton {
   function get(
     IStore _store
   ) internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
+    bytes32[] memory _primaryKeys = encodeKey();
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -337,8 +303,7 @@ library Singleton {
   /** Set the full data using individual values */
   function set(int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) internal {
     bytes memory _data = encode(v1, v2, v3, v4);
-
-    bytes32[] memory _primaryKeys = new bytes32[](0);
+    bytes32[] memory _primaryKeys = encodeKey();
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -346,8 +311,7 @@ library Singleton {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) internal {
     bytes memory _data = encode(v1, v2, v3, v4);
-
-    bytes32[] memory _primaryKeys = new bytes32[](0);
+    bytes32[] memory _primaryKeys = encodeKey();
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -404,17 +368,21 @@ library Singleton {
       );
   }
 
+  function encodeKey() internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](0);
+
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -106,15 +106,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
@@ -130,30 +122,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
   /** Set v1 */
   function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
@@ -169,15 +145,7 @@ library Statics {
     Enum2 k7,
     uint256 v1
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((v1)));
   }
 
@@ -191,15 +159,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
   }
@@ -215,30 +175,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
   }
 
   /** Set v2 */
   function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((v2)));
   }
 
@@ -254,15 +198,7 @@ library Statics {
     Enum2 k7,
     int32 v2
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((v2)));
   }
 
@@ -276,15 +212,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 2);
     return (Bytes.slice16(_blob, 0));
   }
@@ -300,30 +228,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Set v3 */
   function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 2, abi.encodePacked((v3)));
   }
 
@@ -339,15 +251,7 @@ library Statics {
     Enum2 k7,
     bytes16 v3
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 2, abi.encodePacked((v3)));
   }
 
@@ -361,15 +265,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 3);
     return (address(Bytes.slice20(_blob, 0)));
   }
@@ -385,30 +281,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Set v4 */
   function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 3, abi.encodePacked((v4)));
   }
 
@@ -424,15 +304,7 @@ library Statics {
     Enum2 k7,
     address v4
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 3, abi.encodePacked((v4)));
   }
 
@@ -446,15 +318,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 4);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
@@ -470,30 +334,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 4);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Set v5 */
   function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 4, abi.encodePacked((v5)));
   }
 
@@ -509,15 +357,7 @@ library Statics {
     Enum2 k7,
     bool v5
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 4, abi.encodePacked((v5)));
   }
 
@@ -531,15 +371,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 5);
     return Enum1(uint8(Bytes.slice1(_blob, 0)));
   }
@@ -555,30 +387,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 5);
     return Enum1(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Set v6 */
   function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 5, abi.encodePacked(uint8(v6)));
   }
 
@@ -594,15 +410,7 @@ library Statics {
     Enum2 k7,
     Enum1 v6
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 5, abi.encodePacked(uint8(v6)));
   }
 
@@ -616,15 +424,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 6);
     return Enum2(uint8(Bytes.slice1(_blob, 0)));
   }
@@ -640,30 +440,14 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 6);
     return Enum2(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Set v7 */
   function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.setField(_tableId, _primaryKeys, 6, abi.encodePacked(uint8(v7)));
   }
 
@@ -679,15 +463,7 @@ library Statics {
     Enum2 k7,
     Enum2 v7
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.setField(_tableId, _primaryKeys, 6, abi.encodePacked(uint8(v7)));
   }
 
@@ -701,14 +477,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -725,14 +494,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -756,15 +518,7 @@ library Statics {
     Enum2 v7
   ) internal {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
-
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -788,15 +542,7 @@ library Statics {
     Enum2 v7
   ) internal {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
-
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -876,9 +622,16 @@ library Statics {
     return abi.encodePacked(v1, v2, v3, v4, v5, v6, v7);
   }
 
-  /* Delete all data for given keys */
-  function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
+  function encodeKey(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](7);
     _primaryKeys[0] = bytes32(uint256((k1)));
     _primaryKeys[1] = bytes32(uint256(uint32((k2))));
     _primaryKeys[2] = bytes32((k3));
@@ -886,7 +639,12 @@ library Statics {
     _primaryKeys[4] = _boolToBytes32((k5));
     _primaryKeys[5] = bytes32(uint256(uint8(k6)));
     _primaryKeys[6] = bytes32(uint256(uint8(k7)));
+    return _primaryKeys;
+  }
 
+  /* Delete all data for given keys */
+  function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
@@ -901,15 +659,7 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](7);
-    _primaryKeys[0] = bytes32(uint256((k1)));
-    _primaryKeys[1] = bytes32(uint256(uint32((k2))));
-    _primaryKeys[2] = bytes32((k3));
-    _primaryKeys[3] = bytes32(bytes20((k4)));
-    _primaryKeys[4] = _boolToBytes32((k5));
-    _primaryKeys[5] = bytes32(uint256(uint8(k6)));
-    _primaryKeys[6] = bytes32(uint256(uint8(k7)));
-
+    bytes32[] memory _primaryKeys = encodeKey(k1, k2, k3, k4, k5, k6, k7);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -42,20 +42,11 @@ export function renderCommonData({
   const _keyArgs = renderArguments(primaryKeys.map(({ name }) => name));
   const _typedKeyArgs = renderArguments(primaryKeys.map(({ name, typeWithLocation }) => `${typeWithLocation} ${name}`));
 
-  const _primaryKeysDefinition = `
-    bytes32[] memory _primaryKeys = new bytes32[](${primaryKeys.length});
-    ${renderList(
-      primaryKeys,
-      (primaryKey, index) => `_primaryKeys[${index}] = ${renderValueTypeToBytes32(primaryKey.name, primaryKey)};`
-    )}
-  `;
-
   return {
     _tableId,
     _typedTableId,
     _keyArgs,
     _typedKeyArgs,
-    _primaryKeysDefinition,
   };
 }
 
@@ -153,7 +144,7 @@ export function renderTableId(staticResourceData: StaticResourceData) {
   };
 }
 
-function renderValueTypeToBytes32(name: string, { staticByteLength, typeUnwrap, internalTypeId }: RenderType) {
+export function renderValueTypeToBytes32(name: string, { staticByteLength, typeUnwrap, internalTypeId }: RenderType) {
   const bits = staticByteLength * 8;
   const innerText = `${typeUnwrap}(${name})`;
 

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -111,13 +111,13 @@
     "source": "test/Mixed.t.sol",
     "name": "set record in Mixed",
     "functionCall": "Mixed.set({ key: key, u32: 1, u128: 2, a32: a32, s: s })",
-    "gasUsed": 111957
+    "gasUsed": 111997
   },
   {
     "source": "test/Mixed.t.sol",
     "name": "get record from Mixed",
     "functionCall": "MixedData memory mixed = Mixed.get(key)",
-    "gasUsed": 13382
+    "gasUsed": 13403
   },
   {
     "source": "test/PackedCounter.t.sol",
@@ -297,7 +297,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "delete record (complex data, 3 slots)",
     "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 10952
+    "gasUsed": 10975
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -315,61 +315,61 @@
     "source": "test/StoreCore.t.sol",
     "name": "register subscriber",
     "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
-    "gasUsed": 65478
+    "gasUsed": 65530
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "set record on table with subscriber",
     "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 73793
+    "gasUsed": 73839
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "set static field on table with subscriber",
     "functionCall": "StoreCore.setField(table, key, 0, data)",
-    "gasUsed": 31893
+    "gasUsed": 31939
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "delete record on table with subscriber",
     "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 24382
+    "gasUsed": 24428
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "register subscriber",
     "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
-    "gasUsed": 65478
+    "gasUsed": 65530
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "set (dynamic) record on table with subscriber",
     "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 167200
+    "gasUsed": 167246
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "set (dynamic) field on table with subscriber",
     "functionCall": "StoreCore.setField(table, key, 1, arrayDataBytes)",
-    "gasUsed": 34987
+    "gasUsed": 35033
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "delete (dynamic) record on table with subscriber",
     "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 25861
+    "gasUsed": 25907
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "push to field (1 slot, 1 uint32 item)",
     "functionCall": "StoreCore.pushToField(table, key, 1, secondDataToPush)",
-    "gasUsed": 16996
+    "gasUsed": 17019
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "push to field (2 slots, 10 uint32 items)",
     "functionCall": "StoreCore.pushToField(table, key, 2, thirdDataToPush)",
-    "gasUsed": 39718
+    "gasUsed": 39741
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -393,7 +393,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set complex record with dynamic data (4 slots)",
     "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 107567
+    "gasUsed": 107590
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -435,7 +435,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set static field (1 slot)",
     "functionCall": "StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes))",
-    "gasUsed": 38011
+    "gasUsed": 38034
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -447,7 +447,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set static field (overlap 2 slot)",
     "functionCall": "StoreCore.setField(table, key, 1, abi.encodePacked(secondDataBytes))",
-    "gasUsed": 33026
+    "gasUsed": 33049
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -459,7 +459,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set dynamic field (1 slot, first dynamic field)",
     "functionCall": "StoreCore.setField(table, key, 2, thirdDataBytes)",
-    "gasUsed": 55329
+    "gasUsed": 55352
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -471,7 +471,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set dynamic field (1 slot, second dynamic field)",
     "functionCall": "StoreCore.setField(table, key, 3, fourthDataBytes)",
-    "gasUsed": 35469
+    "gasUsed": 35492
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -483,7 +483,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set static record (1 slot)",
     "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 37257
+    "gasUsed": 37280
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -495,7 +495,7 @@
     "source": "test/StoreCore.t.sol",
     "name": "set static record (2 slots)",
     "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 59822
+    "gasUsed": 59845
   },
   {
     "source": "test/StoreCore.t.sol",
@@ -507,55 +507,55 @@
     "source": "test/StoreCore.t.sol",
     "name": "StoreCore: set table metadata",
     "functionCall": "StoreCore.setMetadata(table, tableName, fieldNames)",
-    "gasUsed": 251688
+    "gasUsed": 251734
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "update in field (1 slot, 1 uint32 item)",
     "functionCall": "StoreCore.updateInField(table, key, 1, 4 * 1, secondDataForUpdate)",
-    "gasUsed": 16533
+    "gasUsed": 16556
   },
   {
     "source": "test/StoreCore.t.sol",
     "name": "push to field (2 slots, 6 uint64 items)",
     "functionCall": "StoreCore.updateInField(table, key, 2, 8 * 1, thirdDataForUpdate)",
-    "gasUsed": 17636
+    "gasUsed": 17659
   },
   {
     "source": "test/StoreCoreDynamicUpdate.t.sol",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
     "functionCall": "StoreCore.popFromField(_table, _key, 1, byteLengthToPop)",
-    "gasUsed": 29270
+    "gasUsed": 29293
   },
   {
     "source": "test/StoreCoreDynamicUpdate.t.sol",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
     "functionCall": "StoreCore.popFromField(_table, _key, 1, byteLengthToPop)",
-    "gasUsed": 19348
+    "gasUsed": 19371
   },
   {
     "source": "test/StoreCoreDynamicUpdate.t.sol",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
     "functionCall": "StoreCore.popFromField(_table, _key, 2, byteLengthToPop)",
-    "gasUsed": 31149
+    "gasUsed": 31172
   },
   {
     "source": "test/StoreCoreDynamicUpdate.t.sol",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
     "functionCall": "StoreCore.popFromField(_table, _key, 2, byteLengthToPop)",
-    "gasUsed": 19231
+    "gasUsed": 19254
   },
   {
     "source": "test/StoreMetadata.t.sol",
     "name": "set record in StoreMetadataTable",
     "functionCall": "StoreMetadata.set({ tableId: tableId, tableName: tableName, abiEncodedFieldNames: abi.encode(fieldNames) })",
-    "gasUsed": 250122
+    "gasUsed": 250168
   },
   {
     "source": "test/StoreMetadata.t.sol",
     "name": "get record from StoreMetadataTable",
     "functionCall": "StoreMetadataData memory metadata = StoreMetadata.get(tableId)",
-    "gasUsed": 12106
+    "gasUsed": 12127
   },
   {
     "source": "test/StoreSwitch.t.sol",
@@ -573,37 +573,37 @@
     "source": "test/tables/Callbacks.t.sol",
     "name": "set field in Callbacks",
     "functionCall": "Callbacks.set(key, callbacks)",
-    "gasUsed": 63195
+    "gasUsed": 63241
   },
   {
     "source": "test/tables/Callbacks.t.sol",
     "name": "get field from Callbacks (warm)",
     "functionCall": "bytes24[] memory returnedCallbacks = Callbacks.get(key)",
-    "gasUsed": 5791
+    "gasUsed": 5808
   },
   {
     "source": "test/tables/Callbacks.t.sol",
     "name": "push field to Callbacks",
     "functionCall": "Callbacks.push(key, callbacks[0])",
-    "gasUsed": 40884
+    "gasUsed": 40930
   },
   {
     "source": "test/tables/Hooks.t.sol",
     "name": "set field in Hooks",
     "functionCall": "Hooks.set(key, addresses)",
-    "gasUsed": 63364
+    "gasUsed": 63416
   },
   {
     "source": "test/tables/Hooks.t.sol",
     "name": "get field from Hooks (warm)",
     "functionCall": "address[] memory returnedAddresses = Hooks.get(key)",
-    "gasUsed": 5940
+    "gasUsed": 5963
   },
   {
     "source": "test/tables/Hooks.t.sol",
     "name": "push field to Hooks",
     "functionCall": "Hooks.push(key, addresses[0])",
-    "gasUsed": 40876
+    "gasUsed": 40928
   },
   {
     "source": "test/tightcoder/DecodeSlice.t.sol",
@@ -669,12 +669,12 @@
     "source": "test/Vector2.t.sol",
     "name": "set Vector2 record",
     "functionCall": "Vector2.set({ key: key, x: 1, y: 2 })",
-    "gasUsed": 38494
+    "gasUsed": 38531
   },
   {
     "source": "test/Vector2.t.sol",
     "name": "get Vector2 record",
     "functionCall": "Vector2Data memory vector = Vector2.get(key)",
-    "gasUsed": 5038
+    "gasUsed": 5053
   }
 ]

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -67,83 +67,63 @@ library Callbacks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
   /** Set value */
   function set(bytes32 key, bytes24[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, bytes24[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Push an element to value */
   function push(bytes32 key, bytes24 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, bytes24 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from value */
   function pop(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 24);
   }
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 0, 24);
   }
 
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, bytes24 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 24, abi.encodePacked((_element)));
   }
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, bytes24 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 24, abi.encodePacked((_element)));
   }
 
@@ -156,19 +136,21 @@ library Callbacks {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -67,83 +67,63 @@ library Hooks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Set value */
   function set(bytes32 key, address[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Push an element to value */
   function push(bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from value */
   function pop(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 20);
   }
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 0, 20);
   }
 
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 20, abi.encodePacked((_element)));
   }
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 20, abi.encodePacked((_element)));
   }
 
@@ -156,19 +136,21 @@ library Hooks {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -80,240 +80,183 @@ library Mixed {
 
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Set u32 */
   function setU32(bytes32 key, uint32 u32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((u32)));
   }
 
   /** Set u32 (using the specified store) */
   function setU32(IStore _store, bytes32 key, uint32 u32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((u32)));
   }
 
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
   }
 
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
   }
 
   /** Set u128 */
   function setU128(bytes32 key, uint128 u128) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((u128)));
   }
 
   /** Set u128 (using the specified store) */
   function setU128(IStore _store, bytes32 key, uint128 u128) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((u128)));
   }
 
   /** Get a32 */
   function getA32(bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get a32 (using the specified store) */
   function getA32(IStore _store, bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Set a32 */
   function setA32(bytes32 key, uint32[] memory a32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 2, EncodeArray.encode((a32)));
   }
 
   /** Set a32 (using the specified store) */
   function setA32(IStore _store, bytes32 key, uint32[] memory a32) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 2, EncodeArray.encode((a32)));
   }
 
   /** Push an element to a32 */
   function pushA32(bytes32 key, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Push an element to a32 (using the specified store) */
   function pushA32(IStore _store, bytes32 key, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 2, abi.encodePacked((_element)));
   }
 
   /** Pop an element from a32 */
   function popA32(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 2, 4);
   }
 
   /** Pop an element from a32 (using the specified store) */
   function popA32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 2, 4);
   }
 
   /** Update an element of a32 at `_index` */
   function updateA32(bytes32 key, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of a32 (using the specified store) at `_index` */
   function updateA32(IStore _store, bytes32 key, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get s */
   function getS(bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 3);
     return (string(_blob));
   }
 
   /** Get s (using the specified store) */
   function getS(IStore _store, bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 3);
     return (string(_blob));
   }
 
   /** Set s */
   function setS(bytes32 key, string memory s) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 3, bytes((s)));
   }
 
   /** Set s (using the specified store) */
   function setS(IStore _store, bytes32 key, string memory s) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 3, bytes((s)));
   }
 
   /** Push a slice to s */
   function pushS(bytes32 key, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 3, bytes((_slice)));
   }
 
   /** Push a slice to s (using the specified store) */
   function pushS(IStore _store, bytes32 key, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 3, bytes((_slice)));
   }
 
   /** Pop a slice from s */
   function popS(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 3, 1);
   }
 
   /** Pop a slice from s (using the specified store) */
   function popS(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 3, 1);
   }
 
   /** Update a slice of s at `_index` */
   function updateS(bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 3, _index * 1, bytes((_slice)));
   }
 
   /** Update a slice of s (using the specified store) at `_index` */
   function updateS(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 3, _index * 1, bytes((_slice)));
   }
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (MixedData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -321,8 +264,7 @@ library Mixed {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (MixedData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -331,9 +273,7 @@ library Mixed {
   /** Set the full data using individual values */
   function set(bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
     bytes memory _data = encode(u32, u128, a32, s);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -341,9 +281,7 @@ library Mixed {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
     bytes memory _data = encode(u32, u128, a32, s);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -393,19 +331,21 @@ library Mixed {
     return abi.encodePacked(u32, u128, _encodedLengths.unwrap(), EncodeArray.encode((a32)), bytes((s)));
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -74,91 +74,69 @@ library StoreMetadata {
 
   /** Get tableName */
   function getTableName(bytes32 tableId) internal view returns (string memory tableName) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (string(_blob));
   }
 
   /** Get tableName (using the specified store) */
   function getTableName(IStore _store, bytes32 tableId) internal view returns (string memory tableName) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (string(_blob));
   }
 
   /** Set tableName */
   function setTableName(bytes32 tableId, string memory tableName) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, bytes((tableName)));
   }
 
   /** Set tableName (using the specified store) */
   function setTableName(IStore _store, bytes32 tableId, string memory tableName) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.setField(_tableId, _primaryKeys, 0, bytes((tableName)));
   }
 
   /** Push a slice to tableName */
   function pushTableName(bytes32 tableId, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, bytes((_slice)));
   }
 
   /** Push a slice to tableName (using the specified store) */
   function pushTableName(IStore _store, bytes32 tableId, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.pushToField(_tableId, _primaryKeys, 0, bytes((_slice)));
   }
 
   /** Pop a slice from tableName */
   function popTableName(bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 1);
   }
 
   /** Pop a slice from tableName (using the specified store) */
   function popTableName(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.popFromField(_tableId, _primaryKeys, 0, 1);
   }
 
   /** Update a slice of tableName at `_index` */
   function updateTableName(bytes32 tableId, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 1, bytes((_slice)));
   }
 
   /** Update a slice of tableName (using the specified store) at `_index` */
   function updateTableName(IStore _store, bytes32 tableId, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 1, bytes((_slice)));
   }
 
   /** Get abiEncodedFieldNames */
   function getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (bytes(_blob));
   }
@@ -168,81 +146,62 @@ library StoreMetadata {
     IStore _store,
     bytes32 tableId
   ) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (bytes(_blob));
   }
 
   /** Set abiEncodedFieldNames */
   function setAbiEncodedFieldNames(bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, bytes((abiEncodedFieldNames)));
   }
 
   /** Set abiEncodedFieldNames (using the specified store) */
   function setAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.setField(_tableId, _primaryKeys, 1, bytes((abiEncodedFieldNames)));
   }
 
   /** Push a slice to abiEncodedFieldNames */
   function pushAbiEncodedFieldNames(bytes32 tableId, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 1, bytes((_slice)));
   }
 
   /** Push a slice to abiEncodedFieldNames (using the specified store) */
   function pushAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.pushToField(_tableId, _primaryKeys, 1, bytes((_slice)));
   }
 
   /** Pop a slice from abiEncodedFieldNames */
   function popAbiEncodedFieldNames(bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 1, 1);
   }
 
   /** Pop a slice from abiEncodedFieldNames (using the specified store) */
   function popAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.popFromField(_tableId, _primaryKeys, 1, 1);
   }
 
   /** Update a slice of abiEncodedFieldNames at `_index` */
   function updateAbiEncodedFieldNames(bytes32 tableId, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 1, _index * 1, bytes((_slice)));
   }
 
   /** Update a slice of abiEncodedFieldNames (using the specified store) at `_index` */
   function updateAbiEncodedFieldNames(IStore _store, bytes32 tableId, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.updateInField(_tableId, _primaryKeys, 1, _index * 1, bytes((_slice)));
   }
 
   /** Get the full data */
   function get(bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -250,8 +209,7 @@ library StoreMetadata {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -260,9 +218,7 @@ library StoreMetadata {
   /** Set the full data using individual values */
   function set(bytes32 tableId, string memory tableName, bytes memory abiEncodedFieldNames) internal {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -270,9 +226,7 @@ library StoreMetadata {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 tableId, string memory tableName, bytes memory abiEncodedFieldNames) internal {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -318,19 +272,21 @@ library StoreMetadata {
     return abi.encodePacked(_encodedLengths.unwrap(), bytes((tableName)), bytes((abiEncodedFieldNames)));
   }
 
+  function encodeKey(bytes32 tableId) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((tableId));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((tableId));
-
+    bytes32[] memory _primaryKeys = encodeKey(tableId);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -74,76 +74,59 @@ library Vector2 {
 
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Set x */
   function setX(bytes32 key, uint32 x) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((x)));
   }
 
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, uint32 x) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((x)));
   }
 
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
 
   /** Set y */
   function setY(bytes32 key, uint32 y) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((y)));
   }
 
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, uint32 y) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((y)));
   }
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (Vector2Data memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -151,8 +134,7 @@ library Vector2 {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Vector2Data memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -161,9 +143,7 @@ library Vector2 {
   /** Set the full data using individual values */
   function set(bytes32 key, uint32 x, uint32 y) internal {
     bytes memory _data = encode(x, y);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -171,9 +151,7 @@ library Vector2 {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 x, uint32 y) internal {
     bytes memory _data = encode(x, y);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
+    bytes32[] memory _primaryKeys = encodeKey(key);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -200,19 +178,21 @@ library Vector2 {
     return abi.encodePacked(x, y);
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/store/ts/library/render-solidity/field.ts
+++ b/packages/store/ts/library/render-solidity/field.ts
@@ -9,7 +9,7 @@ import { RenderTableOptions } from "./types";
 
 export function renderFieldMethods(options: RenderTableOptions) {
   const storeArgument = options.storeArgument;
-  const { _typedTableId, _typedKeyArgs, _primaryKeysDefinition } = renderCommonData(options);
+  const { _keyArgs, _typedTableId, _typedKeyArgs } = renderCommonData(options);
 
   let result = "";
   for (const [schemaIndex, field] of options.fields.entries()) {
@@ -24,7 +24,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
         _typedTableId,
         _typedKeyArgs,
       ])}) internal view returns (${_typedFieldName}) {
-        ${_primaryKeysDefinition}
+        bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
         bytes memory _blob = ${_store}.getField(_tableId, _primaryKeys, ${schemaIndex});
         return ${renderDecodeFieldSingle(field)};
       }
@@ -41,7 +41,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
         _typedKeyArgs,
         _typedFieldName,
       ])}) internal {
-        ${_primaryKeysDefinition}
+        bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
         ${_store}.setField(_tableId, _primaryKeys, ${schemaIndex}, ${renderEncodeField(field)});
       }
     `
@@ -60,7 +60,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
           _typedKeyArgs,
           `${portionData.typeWithLocation} ${portionData.name}`,
         ])}) internal {
-          ${_primaryKeysDefinition}
+          bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
           ${_store}.pushToField(_tableId, _primaryKeys, ${schemaIndex}, ${portionData.encoded});
         }
       `
@@ -75,7 +75,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
           _typedTableId,
           _typedKeyArgs,
         ])}) internal {
-          ${_primaryKeysDefinition}
+          bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
           ${_store}.popFromField(_tableId, _primaryKeys, ${schemaIndex}, ${portionData.elementLength});
         }
       `
@@ -92,7 +92,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
           "uint256 _index",
           `${portionData.typeWithLocation} ${portionData.name}`,
         ])}) internal {
-          ${_primaryKeysDefinition}
+          bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
           ${_store}.updateInField(
             _tableId,
             _primaryKeys,

--- a/packages/store/ts/library/render-solidity/record.ts
+++ b/packages/store/ts/library/render-solidity/record.ts
@@ -10,7 +10,7 @@ import { RenderTableOptions } from "./types";
 
 export function renderRecordMethods(options: RenderTableOptions) {
   const { structName, storeArgument } = options;
-  const { _tableId, _typedTableId, _keyArgs, _typedKeyArgs, _primaryKeysDefinition } = renderCommonData(options);
+  const { _tableId, _typedTableId, _keyArgs, _typedKeyArgs } = renderCommonData(options);
 
   let result = renderWithStore(
     storeArgument,
@@ -21,7 +21,8 @@ export function renderRecordMethods(options: RenderTableOptions) {
       _typedTableId,
       _typedKeyArgs,
     ])}) internal view returns (${renderDecodedRecord(options)}) {
-      ${_primaryKeysDefinition}
+      bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
+
       bytes memory _blob = ${_store}.getRecord(_tableId, _primaryKeys, getSchema());
       return decode(_blob);
     }
@@ -39,8 +40,7 @@ export function renderRecordMethods(options: RenderTableOptions) {
       renderArguments(options.fields.map(({ name, typeWithLocation }) => `${typeWithLocation} ${name}`)),
     ])}) internal {
       bytes memory _data = encode(${renderArguments(options.fields.map(({ name }) => name))});
-
-      ${_primaryKeysDefinition}
+      bytes32[] memory _primaryKeys = encodeKey(${renderArguments([_keyArgs])});
 
       ${_store}.setRecord(_tableId, _primaryKeys, _data);
     }

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,13 +3,13 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 609117
+    "gasUsed": 609721
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "Get list of keys with a given value",
     "functionCall": "bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1))",
-    "gasUsed": 7658
+    "gasUsed": 7696
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
@@ -21,162 +21,162 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 609117
+    "gasUsed": 609721
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value))",
-    "gasUsed": 169255
+    "gasUsed": 169569
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 609117
+    "gasUsed": 609721
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value2))",
-    "gasUsed": 135252
+    "gasUsed": 135566
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "delete a record on a table with KeysWithValueModule installed",
     "functionCall": "world.deleteRecord(namespace, sourceName, keyTuple1)",
-    "gasUsed": 57919
+    "gasUsed": 58117
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "install keys with value module",
     "functionCall": "world.installRootModule(keysWithValueModule, abi.encode(sourceTableId))",
-    "gasUsed": 609117
+    "gasUsed": 609721
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceName, keyTuple1, 0, abi.encodePacked(value1))",
-    "gasUsed": 177359
+    "gasUsed": 177673
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceName, keyTuple1, 0, abi.encodePacked(value2))",
-    "gasUsed": 141705
+    "gasUsed": 142019
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "install unique entity module",
     "functionCall": "world.installModule(uniqueEntityModule, new bytes(0))",
-    "gasUsed": 790997
+    "gasUsed": 791986
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "get a unique entity nonce (non-root module)",
     "functionCall": "uint256 uniqueEntity = uint256(getUniqueEntity(world))",
-    "gasUsed": 65641
+    "gasUsed": 65755
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "installRoot unique entity module",
     "functionCall": "world.installRootModule(uniqueEntityModule, new bytes(0))",
-    "gasUsed": 766798
+    "gasUsed": 767689
   },
   {
     "source": "test/UniqueEntityModule.t.sol",
     "name": "get a unique entity nonce (root module)",
     "functionCall": "uint256 uniqueEntity = uint256(getUniqueEntity(world))",
-    "gasUsed": 65641
+    "gasUsed": 65755
   },
   {
     "source": "test/World.t.sol",
     "name": "Delete record",
     "functionCall": "world.deleteRecord(namespace, name, singletonKey)",
-    "gasUsed": 16147
+    "gasUsed": 16192
   },
   {
     "source": "test/World.t.sol",
     "name": "Push data to the table",
     "functionCall": "world.pushToField(namespace, name, keyTuple, 0, encodedData)",
-    "gasUsed": 96512
+    "gasUsed": 96557
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a fallback system",
     "functionCall": "bytes4 funcSelector1 = world.registerFunctionSelector(namespace, name, \"\", \"\")",
-    "gasUsed": 81175
+    "gasUsed": 81333
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a root fallback system",
     "functionCall": "bytes4 funcSelector2 = world.registerRootFunctionSelector(namespace, name, worldFunc, 0)",
-    "gasUsed": 72426
+    "gasUsed": 72584
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a function selector",
     "functionCall": "bytes4 functionSelector = world.registerFunctionSelector(namespace, name, \"msgSender\", \"()\")",
-    "gasUsed": 101772
+    "gasUsed": 101930
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a new namespace",
     "functionCall": "world.registerNamespace(\"test\")",
-    "gasUsed": 151950
+    "gasUsed": 152165
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a root function selector",
     "functionCall": "bytes4 functionSelector = world.registerRootFunctionSelector(namespace, name, worldFunc, sysFunc)",
-    "gasUsed": 88332
+    "gasUsed": 88490
   },
   {
     "source": "test/World.t.sol",
     "name": "Register a new table in the namespace",
     "functionCall": "bytes32 tableSelector = world.registerTable(namespace, table, schema, defaultKeySchema)",
-    "gasUsed": 252654
+    "gasUsed": 252967
   },
   {
     "source": "test/World.t.sol",
     "name": "Write data to a table field",
     "functionCall": "world.setField(namespace, name, singletonKey, 0, abi.encodePacked(true))",
-    "gasUsed": 44820
+    "gasUsed": 44865
   },
   {
     "source": "test/World.t.sol",
     "name": "Set metadata",
     "functionCall": "world.setMetadata(namespace, name, tableName, fieldNames)",
-    "gasUsed": 277520
+    "gasUsed": 277626
   },
   {
     "source": "test/World.t.sol",
     "name": "Write data to the table",
     "functionCall": "Bool.set(world, tableId, true)",
-    "gasUsed": 42687
+    "gasUsed": 42732
   },
   {
     "source": "test/WorldDynamicUpdate.t.sol",
     "name": "pop 1 address (cold)",
     "functionCall": "world.popFromField(namespace, name, keyTuple, 0, byteLengthToPop)",
-    "gasUsed": 37995
+    "gasUsed": 38040
   },
   {
     "source": "test/WorldDynamicUpdate.t.sol",
     "name": "pop 1 address (warm)",
     "functionCall": "world.popFromField(namespace, name, keyTuple, 0, byteLengthToPop)",
-    "gasUsed": 22789
+    "gasUsed": 22834
   },
   {
     "source": "test/WorldDynamicUpdate.t.sol",
     "name": "updateInField 1 item (cold)",
     "functionCall": "world.updateInField(namespace, name, keyTuple, 0, 0, EncodeArray.encode(dataForUpdate))",
-    "gasUsed": 40375
+    "gasUsed": 40420
   },
   {
     "source": "test/WorldDynamicUpdate.t.sol",
     "name": "updateInField 1 item (warm)",
     "functionCall": "world.updateInField(namespace, name, keyTuple, 0, 0, EncodeArray.encode(dataForUpdate))",
-    "gasUsed": 25573
+    "gasUsed": 25618
   }
 ]

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -71,77 +71,59 @@ library FunctionSelectors {
 
   /** Get namespace */
   function getNamespace(bytes4 functionSelector) internal view returns (bytes16 namespace) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Get namespace (using the specified store) */
   function getNamespace(IStore _store, bytes4 functionSelector) internal view returns (bytes16 namespace) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Set namespace */
   function setNamespace(bytes4 functionSelector, bytes16 namespace) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((namespace)));
   }
 
   /** Set namespace (using the specified store) */
   function setNamespace(IStore _store, bytes4 functionSelector, bytes16 namespace) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((namespace)));
   }
 
   /** Get name */
   function getName(bytes4 functionSelector) internal view returns (bytes16 name) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Get name (using the specified store) */
   function getName(IStore _store, bytes4 functionSelector) internal view returns (bytes16 name) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Set name */
   function setName(bytes4 functionSelector, bytes16 name) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((name)));
   }
 
   /** Set name (using the specified store) */
   function setName(IStore _store, bytes4 functionSelector, bytes16 name) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((name)));
   }
 
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 2);
     return (Bytes.slice4(_blob, 0));
   }
@@ -151,26 +133,20 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 2);
     return (Bytes.slice4(_blob, 0));
   }
 
   /** Set systemFunctionSelector */
   function setSystemFunctionSelector(bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 2, abi.encodePacked((systemFunctionSelector)));
   }
 
   /** Set systemFunctionSelector (using the specified store) */
   function setSystemFunctionSelector(IStore _store, bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     _store.setField(_tableId, _primaryKeys, 2, abi.encodePacked((systemFunctionSelector)));
   }
 
@@ -178,8 +154,7 @@ library FunctionSelectors {
   function get(
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -190,8 +165,7 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -200,9 +174,7 @@ library FunctionSelectors {
   /** Set the full data using individual values */
   function set(bytes4 functionSelector, bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) internal {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -216,9 +188,7 @@ library FunctionSelectors {
     bytes4 systemFunctionSelector
   ) internal {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -239,19 +209,21 @@ library FunctionSelectors {
     return abi.encodePacked(namespace, name, systemFunctionSelector);
   }
 
+  function encodeKey(bytes4 functionSelector) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((functionSelector));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes4 functionSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes4 functionSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((functionSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(functionSelector);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -70,35 +70,27 @@ library ResourceType {
 
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Set resourceType */
   function set(bytes32 resourceSelector, Resource resourceType) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked(uint8(resourceType)));
   }
 
   /** Set resourceType (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, Resource resourceType) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked(uint8(resourceType)));
   }
 
@@ -107,19 +99,21 @@ library ResourceType {
     return abi.encodePacked(resourceType);
   }
 
+  function encodeKey(bytes32 resourceSelector) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((resourceSelector));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -67,35 +67,27 @@ library SystemRegistry {
 
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (Bytes.slice32(_blob, 0));
   }
 
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (Bytes.slice32(_blob, 0));
   }
 
   /** Set resourceSelector */
   function set(address system, bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((resourceSelector)));
   }
 
   /** Set resourceSelector (using the specified store) */
   function set(IStore _store, address system, bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((resourceSelector)));
   }
 
@@ -104,19 +96,21 @@ library SystemRegistry {
     return abi.encodePacked(resourceSelector);
   }
 
+  function encodeKey(address system) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32(bytes20((system)));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(address system) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, address system) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32(bytes20((system)));
-
+    bytes32[] memory _primaryKeys = encodeKey(system);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -69,76 +69,59 @@ library Systems {
 
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Set system */
   function setSystem(bytes32 resourceSelector, address system) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((system)));
   }
 
   /** Set system (using the specified store) */
   function setSystem(IStore _store, bytes32 resourceSelector, address system) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((system)));
   }
 
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Set publicAccess */
   function setPublicAccess(bytes32 resourceSelector, bool publicAccess) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     StoreSwitch.setField(_tableId, _primaryKeys, 1, abi.encodePacked((publicAccess)));
   }
 
   /** Set publicAccess (using the specified store) */
   function setPublicAccess(IStore _store, bytes32 resourceSelector, bool publicAccess) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     _store.setField(_tableId, _primaryKeys, 1, abi.encodePacked((publicAccess)));
   }
 
   /** Get the full data */
   function get(bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -146,8 +129,7 @@ library Systems {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -156,9 +138,7 @@ library Systems {
   /** Set the full data using individual values */
   function set(bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -166,9 +146,7 @@ library Systems {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
-
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -185,19 +163,21 @@ library Systems {
     return abi.encodePacked(system, publicAccess);
   }
 
+  function encodeKey(bytes32 resourceSelector) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((resourceSelector));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((resourceSelector));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -64,9 +64,7 @@ library KeysWithValue {
 
   /** Get keysWithValue */
   function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
@@ -77,74 +75,56 @@ library KeysWithValue {
     bytes32 _tableId,
     bytes32 valueHash
   ) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Set keysWithValue */
   function set(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((keysWithValue)));
   }
 
   /** Set keysWithValue (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((keysWithValue)));
   }
 
   /** Push an element to keysWithValue */
   function push(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to keysWithValue (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from keysWithValue */
   function pop(bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 32);
   }
 
   /** Pop an element from keysWithValue (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     _store.popFromField(_tableId, _primaryKeys, 0, 32);
   }
 
   /** Update an element of keysWithValue at `_index` */
   function update(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 32, abi.encodePacked((_element)));
   }
 
   /** Update an element of keysWithValue (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 32, abi.encodePacked((_element)));
   }
 
@@ -157,19 +137,21 @@ library KeysWithValue {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((keysWithValue)));
   }
 
+  function encodeKey(bytes32 valueHash) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((valueHash));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((valueHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(valueHash);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -63,31 +63,27 @@ library UniqueEntity {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
   /** Set value */
   function set(bytes32 _tableId, uint256 value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
@@ -96,17 +92,21 @@ library UniqueEntity {
     return abi.encodePacked(value);
   }
 
+  function encodeKey() internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](0);
+
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -72,10 +72,7 @@ library InstalledModules {
 
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
@@ -86,37 +83,26 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Set moduleAddress */
   function setModuleAddress(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((moduleAddress)));
   }
 
   /** Set moduleAddress (using the specified store) */
   function setModuleAddress(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((moduleAddress)));
   }
 
   /** Get the full data */
   function get(bytes16 moduleName, bytes32 argumentsHash) internal view returns (InstalledModulesData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -128,9 +114,7 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (InstalledModulesData memory _table) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
 
     bytes memory _blob = _store.getRecord(_tableId, _primaryKeys, getSchema());
     return decode(_blob);
@@ -139,10 +123,7 @@ library InstalledModules {
   /** Set the full data using individual values */
   function set(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
-
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
 
     StoreSwitch.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -150,10 +131,7 @@ library InstalledModules {
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
-
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
 
     _store.setRecord(_tableId, _primaryKeys, _data);
   }
@@ -178,21 +156,22 @@ library InstalledModules {
     return abi.encodePacked(moduleAddress);
   }
 
-  /* Delete all data for given keys */
-  function deleteRecord(bytes16 moduleName, bytes32 argumentsHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
+  function encodeKey(bytes16 moduleName, bytes32 argumentsHash) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](2);
     _primaryKeys[0] = bytes32((moduleName));
     _primaryKeys[1] = bytes32((argumentsHash));
+    return _primaryKeys;
+  }
 
+  /* Delete all data for given keys */
+  function deleteRecord(bytes16 moduleName, bytes32 argumentsHash) internal {
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 moduleName, bytes32 argumentsHash) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((moduleName));
-    _primaryKeys[1] = bytes32((argumentsHash));
-
+    bytes32[] memory _primaryKeys = encodeKey(moduleName, argumentsHash);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -67,35 +67,27 @@ library NamespaceOwner {
 
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Set owner */
   function set(bytes16 namespace, address owner) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((owner)));
   }
 
   /** Set owner (using the specified store) */
   function set(IStore _store, bytes16 namespace, address owner) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((owner)));
   }
 
@@ -104,19 +96,21 @@ library NamespaceOwner {
     return abi.encodePacked(owner);
   }
 
+  function encodeKey(bytes16 namespace) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((namespace));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes16 namespace) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 namespace) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((namespace));
-
+    bytes32[] memory _primaryKeys = encodeKey(namespace);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -68,39 +68,27 @@ library ResourceAccess {
 
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((resourceSelector));
-    _primaryKeys[1] = bytes32(bytes20((caller)));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((resourceSelector));
-    _primaryKeys[1] = bytes32(bytes20((caller)));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Set access */
   function set(bytes32 resourceSelector, address caller, bool access) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((resourceSelector));
-    _primaryKeys[1] = bytes32(bytes20((caller)));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((access)));
   }
 
   /** Set access (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address caller, bool access) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((resourceSelector));
-    _primaryKeys[1] = bytes32(bytes20((caller)));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((access)));
   }
 
@@ -109,21 +97,22 @@ library ResourceAccess {
     return abi.encodePacked(access);
   }
 
-  /* Delete all data for given keys */
-  function deleteRecord(bytes32 resourceSelector, address caller) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
+  function encodeKey(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](2);
     _primaryKeys[0] = bytes32((resourceSelector));
     _primaryKeys[1] = bytes32(bytes20((caller)));
+    return _primaryKeys;
+  }
 
+  /* Delete all data for given keys */
+  function deleteRecord(bytes32 resourceSelector, address caller) internal {
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector, address caller) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](2);
-    _primaryKeys[0] = bytes32((resourceSelector));
-    _primaryKeys[1] = bytes32(bytes20((caller)));
-
+    bytes32[] memory _primaryKeys = encodeKey(resourceSelector, caller);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -64,83 +64,63 @@ library AddressArray {
 
   /** Get value */
   function get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Set value */
   function set(bytes32 _tableId, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.setField(_tableId, _primaryKeys, 0, EncodeArray.encode((value)));
   }
 
   /** Push an element to value */
   function push(bytes32 _tableId, bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 key, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.pushToField(_tableId, _primaryKeys, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from value */
   function pop(bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.popFromField(_tableId, _primaryKeys, 0, 20);
   }
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.popFromField(_tableId, _primaryKeys, 0, 20);
   }
 
   /** Update an element of value at `_index` */
   function update(bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.updateInField(_tableId, _primaryKeys, 0, _index * 20, abi.encodePacked((_element)));
   }
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.updateInField(_tableId, _primaryKeys, 0, _index * 20, abi.encodePacked((_element)));
   }
 
@@ -153,19 +133,21 @@ library AddressArray {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));
   }
 
+  function encodeKey(bytes32 key) internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](1);
+    _primaryKeys[0] = bytes32((key));
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](1);
-    _primaryKeys[0] = bytes32((key));
-
+    bytes32[] memory _primaryKeys = encodeKey(key);
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -63,31 +63,27 @@ library Bool {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = StoreSwitch.getField(_tableId, _primaryKeys, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     bytes memory _blob = _store.getField(_tableId, _primaryKeys, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Set value */
   function set(bytes32 _tableId, bool value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bool value) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.setField(_tableId, _primaryKeys, 0, abi.encodePacked((value)));
   }
 
@@ -96,17 +92,21 @@ library Bool {
     return abi.encodePacked(value);
   }
 
+  function encodeKey() internal pure returns (bytes32[] memory _primaryKeys) {
+    _primaryKeys = new bytes32[](0);
+
+    return _primaryKeys;
+  }
+
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     StoreSwitch.deleteRecord(_tableId, _primaryKeys);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId) internal {
-    bytes32[] memory _primaryKeys = new bytes32[](0);
-
+    bytes32[] memory _primaryKeys = encodeKey();
     _store.deleteRecord(_tableId, _primaryKeys);
   }
 }


### PR DESCRIPTION
Addresses #751.

This simplifies the Table contracts, but replacing the inlined code with an internal function increases gas use :(

It also causes `stack too deep` error on worlds with too many keys + fields.