### PR TITLE
feat(world): delete record for empty keysWithValue array

### DIFF
--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -57,7 +57,7 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value))",
-    "gasUsed": 169314
+    "gasUsed": 165686
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
@@ -69,13 +69,13 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a record on a table with KeysWithValueModule installed",
     "functionCall": "world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value2))",
-    "gasUsed": 135311
+    "gasUsed": 135337
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "delete a record on a table with KeysWithValueModule installed",
     "functionCall": "world.deleteRecord(namespace, sourceName, keyTuple1)",
-    "gasUsed": 57919
+    "gasUsed": 54294
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
@@ -87,13 +87,13 @@
     "source": "test/KeysWithValueModule.t.sol",
     "name": "set a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceName, keyTuple1, 0, abi.encodePacked(value1))",
-    "gasUsed": 177359
+    "gasUsed": 173722
   },
   {
     "source": "test/KeysWithValueModule.t.sol",
     "name": "change a field on a table with KeysWithValueModule installed",
     "functionCall": "world.setField(namespace, sourceName, keyTuple1, 0, abi.encodePacked(value2))",
-    "gasUsed": 141705
+    "gasUsed": 138080
   },
   {
     "source": "test/UniqueEntityModule.t.sol",

--- a/packages/world/src/modules/keyswithvalue/KeysWithValueHook.sol
+++ b/packages/world/src/modules/keyswithvalue/KeysWithValueHook.sol
@@ -65,7 +65,12 @@ contract KeysWithValueHook is IStoreHook {
     // Get the keys with the previous value excluding the current key
     bytes32[] memory keysWithPreviousValue = KeysWithValue.get(targetTableId, valueHash).filter(key);
 
-    // Set the keys with the previous value
-    KeysWithValue.set(targetTableId, valueHash, keysWithPreviousValue);
+    if (keysWithPreviousValue.length == 0) {
+      // Delete the list of keys in this table
+      KeysWithValue.deleteRecord(targetTableId, valueHash);
+    } else {
+      // Set the keys with the previous value
+      KeysWithValue.set(targetTableId, valueHash, keysWithPreviousValue);
+    }
   }
 }


### PR DESCRIPTION
@holic this will tidy the dev UI by removing redundant records.

We could also take this chance to refactor the internals of `KeysWithValue` to be like `KeysInTable` (ie. no `tableIdArgument`, removing unbounded array filter). But I don't think it is worth the time investment with MUD2 still in flux.