### PR TITLE
feat(common,world): include errors in worldgen's system interfaces

### DIFF
--- a/packages/world/ts/library/render-solidity/renderSystemInterface.ts
+++ b/packages/world/ts/library/render-solidity/renderSystemInterface.ts
@@ -2,13 +2,15 @@ import { renderArguments, renderList, renderedSolidityHeader, renderImports } fr
 import { RenderSystemInterfaceOptions } from "./types";
 
 export function renderSystemInterface(options: RenderSystemInterfaceOptions) {
-  const { imports, name, functionPrefix, functions } = options;
+  const { imports, name, functionPrefix, functions, errors } = options;
 
   return `${renderedSolidityHeader}
 
 ${renderImports(imports)}
 
 interface ${name} {
+  ${renderList(errors, ({ name, parameters }) => `error ${name}(${renderArguments(parameters)});`)}
+
   ${renderList(
     functions,
     ({ name, parameters, stateMutability, returnParameters }) => `

--- a/packages/world/ts/library/render-solidity/types.ts
+++ b/packages/world/ts/library/render-solidity/types.ts
@@ -1,4 +1,9 @@
-import type { ImportDatum, RelativeImportDatum, ContractInterfaceFunction } from "@latticexyz/common/codegen";
+import type {
+  ImportDatum,
+  RelativeImportDatum,
+  ContractInterfaceFunction,
+  ContractInterfaceError,
+} from "@latticexyz/common/codegen";
 
 export interface RenderSystemInterfaceOptions {
   /** List of symbols to import, and their file paths */
@@ -6,6 +11,7 @@ export interface RenderSystemInterfaceOptions {
   name: string;
   functionPrefix: string;
   functions: ContractInterfaceFunction[];
+  errors: ContractInterfaceError[];
 }
 
 export interface RenderWorldOptions {

--- a/packages/world/ts/library/render-solidity/worldgen.ts
+++ b/packages/world/ts/library/render-solidity/worldgen.ts
@@ -23,7 +23,7 @@ export async function worldgen(
   for (const system of systems) {
     const data = readFileSync(system.path, "utf8");
     // get external funcions from a contract
-    const { functions, symbolImports } = contractToInterface(data, system.basename);
+    const { functions, errors, symbolImports } = contractToInterface(data, system.basename);
     const imports = symbolImports.map((symbolImport) => {
       if (symbolImport.path[0] === ".") {
         // relative import
@@ -47,6 +47,7 @@ export async function worldgen(
       name: systemInterfaceName,
       functionPrefix: config.namespace === "" ? "" : `${config.namespace}_${name}_`,
       functions,
+      errors,
       imports,
     });
     // write to file


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/757
only errors, events are not only an antipattern but wouldn't even work for any non-root system, since those aren't delegatecalled