### PR TITLE
docs: `yarn create mud` for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ MUD is MIT-licensed, open source and free to use.
 ## Quickstart
 
 ```
-pnpm create mud my-project
+yarn create mud my-project
 ```
 
 ![Scaffolding a new project with the MUD CLI.](./docs/public/mud-create.gif)

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -43,7 +43,7 @@ MUD is MIT-licensed, open source and free to use.
 ## Quickstart
 
 ```
-pnpm create mud my-project
+yarn create mud my-project
 ```
 
 ![Scaffolding a new project with the MUD CLI.](/mud-create.gif)


### PR DESCRIPTION
closes #772 
closes #778 

mud v1 CLI is still using yarn, and I mistakenly updated this in docs during the pnpm migration, which causes the create-mud package to use pnpm during template install (fails due to a yarn/lerna monorepo)

will address in #775 