### PR TITLE
fix(dev-tools): publish dist

### DIFF
--- a/packages/dev-tools/.npmignore
+++ b/packages/dev-tools/.npmignore
@@ -1,0 +1,5 @@
+*
+
+!dist/**
+!src/**
+!package.json


### PR DESCRIPTION
whoops, forgot an `.npmignore` file and so `dist` wasn't getting published