### PR TITLE
build(ecs-browser): clean up deps

### DIFF
--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -30,8 +30,8 @@
     "lodash": "^4.17.21",
     "mobx": "^6.7.0",
     "mobx-react-lite": "^3.4.0",
-    "shiki": "^0.11.1",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "shiki": "^0.11.1"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",

--- a/packages/ecs-browser/package.json
+++ b/packages/ecs-browser/package.json
@@ -9,58 +9,34 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "src/index.ts",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "types": "src/index.ts",
   "scripts": {
     "build": "pnpm run build:js",
     "build:js": "tsup",
     "clean": "pnpm run clean:js",
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
-    "prepack": "mv package.json package.json.bak && jq \".main = \\\"dist/index.js\\\"\" package.json.bak > package.json ",
-    "postpack": "mv package.json.bak package.json || echo 'no package.json.bak'",
     "release": "npm publish --access=public",
-    "test": "tsc --noEmit && echo 'todo: add tests'"
+    "test": "tsc --noEmit"
   },
   "dependencies": {
-    "goober": "^2.1.11",
-    "shiki": "^0.11.1"
-  },
-  "devDependencies": {
     "@latticexyz/recs": "workspace:*",
     "@latticexyz/std-client": "workspace:*",
     "@latticexyz/utils": "workspace:*",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-typescript": "^11.1.0",
-    "@types/jest": "^27.4.1",
+    "goober": "^2.1.11",
+    "lodash": "^4.17.21",
+    "mobx": "^6.7.0",
+    "mobx-react-lite": "^3.4.0",
+    "shiki": "^0.11.1",
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
     "@types/lodash": "^4.14.182",
     "@types/react": "^18.2.6",
-    "@types/react-collapse": "^5.0.1",
-    "@types/uuid": "^8.3.4",
-    "lodash": "^4.17.21",
-    "mobx": "^6.7.0",
-    "mobx-react-lite": "^3.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rimraf": "^3.0.2",
-    "rollup": "^2.70.0",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4",
-    "rxjs": "^7.5.5",
-    "tslib": "^2.5.0",
-    "tsup": "^6.7.0",
-    "typescript": "^4.9.5"
-  },
-  "peerDependencies": {
-    "@latticexyz/recs": "*",
-    "@latticexyz/std-client": "*",
-    "@latticexyz/utils": "*",
-    "lodash": "^4.17.21",
-    "mobx": "^6.7.0",
-    "mobx-react-lite": "^3.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rxjs": "^7.5.5"
+    "tsup": "^6.7.0"
   },
   "gitHead": "914a1e0ae4a573d685841ca2ea921435057deb8f"
 }

--- a/packages/ecs-browser/tsconfig.json
+++ b/packages/ecs-browser/tsconfig.json
@@ -1,102 +1,17 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Enable incremental compilation */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react-jsx" /* Specify what JSX code is generated. */,
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
-    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
-    /* Modules */
-    "module": "esnext" /* Specify what module code is generated. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    "types": ["jest"] /* Specify type package names to be included without being referenced in a source file. */,
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    "resolveJsonModule": true /* Enable importing .json files */,
-    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-
-    /* Emit */
-    "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true /* Only output d.ts files and not JavaScript files. */,
-    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "dist" /* Specify an output folder for all emitted files. */,
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  },
-  "exclude": ["dist", "**/*.spec.ts", "packages"]
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
+  }
 }

--- a/packages/ecs-browser/tsup.config.js
+++ b/packages/ecs-browser/tsup.config.js
@@ -4,8 +4,8 @@ export default defineConfig({
   entry: ["src/index.ts"],
   outDir: "dist",
   format: ["esm"],
+  dts: false,
   sourcemap: true,
   clean: true,
-  dts: true,
-  noExternal: ["goober", "shiki"],
+  minify: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,13 +330,6 @@ importers:
 
   packages/ecs-browser:
     dependencies:
-      goober:
-        specifier: ^2.1.11
-        version: 2.1.11(csstype@3.1.2)
-      shiki:
-        specifier: ^0.11.1
-        version: 0.11.1
-    devDependencies:
       '@latticexyz/recs':
         specifier: workspace:*
         version: link:../recs
@@ -346,27 +339,9 @@ importers:
       '@latticexyz/utils':
         specifier: workspace:*
         version: link:../utils
-      '@rollup/plugin-node-resolve':
-        specifier: ^13.1.3
-        version: 13.3.0(rollup@2.79.1)
-      '@rollup/plugin-typescript':
-        specifier: ^11.1.0
-        version: 11.1.0(rollup@2.79.1)(tslib@2.5.0)(typescript@4.9.5)
-      '@types/jest':
-        specifier: ^27.4.1
-        version: 27.4.1
-      '@types/lodash':
-        specifier: ^4.14.182
-        version: 4.14.182
-      '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.6
-      '@types/react-collapse':
-        specifier: ^5.0.1
-        version: 5.0.1
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
+      goober:
+        specifier: ^2.1.11
+        version: 2.1.11(csstype@3.1.2)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -375,37 +350,23 @@ importers:
         version: 6.9.0
       mobx-react-lite:
         specifier: ^3.4.0
-        version: 3.4.0(mobx@6.9.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 3.4.0(mobx@6.9.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
-      rollup:
-        specifier: ^2.70.0
-        version: 2.79.1
-      rollup-plugin-commonjs:
-        specifier: ^10.1.0
-        version: 10.1.0(rollup@2.79.1)
-      rollup-plugin-peer-deps-external:
-        specifier: ^2.2.4
-        version: 2.2.4(rollup@2.79.1)
-      rxjs:
-        specifier: ^7.5.5
-        version: 7.5.6
-      tslib:
-        specifier: ^2.5.0
-        version: 2.5.0
+      shiki:
+        specifier: ^0.11.1
+        version: 0.11.1
+    devDependencies:
+      '@types/lodash':
+        specifier: ^4.14.182
+        version: 4.14.182
+      '@types/react':
+        specifier: ^18.2.6
+        version: 18.2.6
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.23)(typescript@5.0.4)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
 
   packages/network:
     dependencies:
@@ -11542,7 +11503,7 @@ packages:
       obliterator: 2.0.4
     dev: true
 
-  /mobx-react-lite@3.4.0(mobx@6.9.0)(react-dom@18.2.0)(react@18.2.0):
+  /mobx-react-lite@3.4.0(mobx@6.9.0)(react@18.2.0):
     resolution: {integrity: sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==}
     peerDependencies:
       mobx: ^6.1.0
@@ -11557,12 +11518,10 @@ packages:
     dependencies:
       mobx: 6.9.0
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /mobx@6.9.0:
     resolution: {integrity: sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ==}
-    dev: true
 
   /mocha@10.0.0:
     resolution: {integrity: sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==}


### PR DESCRIPTION
related to https://github.com/latticexyz/mud/issues/411

I did this by going through each dep, looking at import usages, and deciding if it should be a regular dep (if used within the app bundle) or dev dep (if only used in tests, type checking, etc.). I also removed a couple extraneous deps.