### PR TITLE
build: include src directory in npm release

### DIFF
--- a/packages/ecs-browser/.npmignore
+++ b/packages/ecs-browser/.npmignore
@@ -1,6 +1,7 @@
 *
 
 !dist/**
+!src/**
 !package.json
 !README.md
 !CHANGELOG.md

--- a/packages/phaserx/.npmignore
+++ b/packages/phaserx/.npmignore
@@ -1,6 +1,7 @@
 *
 
 !dist/**
+!src/**
 !package.json
 !README.md
 !CHANGELOG.md

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -1,6 +1,7 @@
 *
 
 !dist/**
+!src/**
 !package.json
 !README.md
 !CHANGELOG.md

--- a/packages/recs/.npmignore
+++ b/packages/recs/.npmignore
@@ -1,6 +1,7 @@
 *
 
 !dist/**
+!src/**
 !package.json
 !README.md
 !CHANGELOG.md

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -1,6 +1,7 @@
 *
 
 !dist/**
+!src/**
 !package.json
 !README.md
 !CHANGELOG.md


### PR DESCRIPTION
We changed the `types` entry in `package.json` to point to the ts source files, but forgot to release the source files to npm 