### PR TITLE
fix(dev-tools): change async import approach

### DIFF
--- a/packages/dev-tools/src/mount.tsx
+++ b/packages/dev-tools/src/mount.tsx
@@ -5,18 +5,18 @@ export async function mount() {
   }
 
   try {
-    const React = await import("react");
-    const ReactDOM = await import("react-dom/client");
+    const { StrictMode } = await import("react");
+    const { createRoot } = await import("react-dom/client");
     const { App } = await import("./App");
 
     const rootElement = document.createElement("div");
     rootElement.id = "mud-dev-tools";
 
-    const root = ReactDOM.createRoot(rootElement);
+    const root = createRoot(rootElement);
     root.render(
-      <React.StrictMode>
+      <StrictMode>
         <App />
-      </React.StrictMode>
+      </StrictMode>
     );
 
     document.body.appendChild(rootElement);


### PR DESCRIPTION
Attempting to resolve this issue:

<img width="560" alt="image" src="https://github.com/latticexyz/mud/assets/508855/5d38c723-1310-4fb4-bb12-0911cf883ca2">

I think I could have changed these lines to something like
```ts
const ReactDOM = (await import('react-dom/client')).default;
```

But I wasn't as confident in that approach. TS tells me both the current approach and these alternatives would work, so I'm not sure what's up. I don't use these style imports often, so I'm not sure of the edge cases.

It might also mean that we need to force these deps to be bundled? 