### PR TITLE
feat(dev-tools): bundle react deps

### DIFF
--- a/packages/dev-tools/src/mount.tsx
+++ b/packages/dev-tools/src/mount.tsx
@@ -5,18 +5,18 @@ export async function mount() {
   }
 
   try {
-    const { StrictMode } = await import("react");
-    const { createRoot } = await import("react-dom/client");
+    const React = await import("react");
+    const ReactDOM = await import("react-dom/client");
     const { App } = await import("./App");
 
     const rootElement = document.createElement("div");
     rootElement.id = "mud-dev-tools";
 
-    const root = createRoot(rootElement);
+    const root = ReactDOM.createRoot(rootElement);
     root.render(
-      <StrictMode>
+      <React.StrictMode>
         <App />
-      </StrictMode>
+      </React.StrictMode>
     );
 
     document.body.appendChild(rootElement);

--- a/packages/dev-tools/tsup.config.ts
+++ b/packages/dev-tools/tsup.config.ts
@@ -9,4 +9,6 @@ export default defineConfig({
   clean: true,
   minify: true,
   injectStyle: true,
+  // bundle react deps so folks can use this in non-react clients
+  noExternal: ["react", "react-dom", "react-router-dom"],
 });


### PR DESCRIPTION
tsup by default [doesn't bundle deps](https://tsup.egoist.dev/#excluding-packages):
> By default tsup bundles all import-ed modules but dependencies and peerDependencies in your packages.json are always excluded

So when we use this package in a non-react project, it will fail to mount because of missing react deps.

We could declare these deps as peer deps, but we've had bad experiences with that, and it feels awkward for non-react projects to have to have react deps to use the dev tools.

We're gonna try bundling react deps, even though it may cause issues if multiple versions of react are detected on the page. We'll address that as it comes up.
