### PR TITLE
chore: sort package.json in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",
-    "*.{ts,tsx,css,md,sol}": "prettier --write"
+    "*.{ts,tsx,css,md,sol}": "prettier --write",
+    "package.json": "pnpm sort-package-json"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.46.1",


### PR DESCRIPTION
I noticed we've all run into this a couple of times where CI complains. This should now be automatic on commit!