### PR TITLE
fix(common): publish source files for types

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -35,9 +35,6 @@
       ]
     }
   },
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "pnpm run build:js",
     "build:js": "tsup",


### PR DESCRIPTION
I noticed when creating a new project from a template using `pnpm create mud`, I wasn't getting a strongly typed config:

![image](https://github.com/latticexyz/mud/assets/508855/3536dcf7-bf83-4855-a35b-8228b543a6be)

When I dug into the `mudConfig` reference, I noticed there was a broken/missing TS definition for our common package:

![image](https://github.com/latticexyz/mud/assets/508855/a174567c-5de4-48e0-856e-ada409cf6b14)

Building this package locally shows it's missing `src` files that we usually have in our packages and expect with our `typesVersions` definition:

![image](https://github.com/latticexyz/mud/assets/508855/819f8722-2f7f-4e51-8927-5a7a5c49eee6)

I found that this is because the `files` definition here is taking precedence over `.npmignore` in `npm pack` and thus excluding `src`. By removing `files` definition and packing, I can see `src` files in there, so this should fix it.