### PR TITLE
test(store): fix tests after foundry update, move gas reports to separate tests

### DIFF
--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -276,264 +276,6 @@
     "gasUsed": 1108
   },
   {
-    "source": "test/StoreCore.t.sol",
-    "name": "access non-existing record",
-    "functionCall": "bytes memory data1 = StoreCore.getRecord(table, key)",
-    "gasUsed": 7316
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "access static field of non-existing record",
-    "functionCall": "bytes memory data2 = StoreCore.getField(table, key, 0)",
-    "gasUsed": 2988
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "access dynamic field of non-existing record",
-    "functionCall": "bytes memory data3 = StoreCore.getField(table, key, 1)",
-    "gasUsed": 3599
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "access length of dynamic field of non-existing record",
-    "functionCall": "uint256 data3Length = StoreCore.getFieldLength(table, key, 1, schema)",
-    "gasUsed": 1342
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "access slice of dynamic field of non-existing record",
-    "functionCall": "bytes memory data3Slice = StoreCore.getFieldSlice(table, key, 1, schema, 0, 0)",
-    "gasUsed": 1338
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "delete record (complex data, 3 slots)",
-    "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 10952
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "Check for existence of table (existent)",
-    "functionCall": "StoreCore.hasTable(table)",
-    "gasUsed": 1111
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "check for existence of table (non-existent)",
-    "functionCall": "StoreCore.hasTable(table2)",
-    "gasUsed": 3138
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "register subscriber",
-    "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
-    "gasUsed": 65478
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set record on table with subscriber",
-    "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 73889
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set static field on table with subscriber",
-    "functionCall": "StoreCore.setField(table, key, 0, data)",
-    "gasUsed": 31889
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "delete record on table with subscriber",
-    "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 24405
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "register subscriber",
-    "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
-    "gasUsed": 65478
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set (dynamic) record on table with subscriber",
-    "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 167326
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set (dynamic) field on table with subscriber",
-    "functionCall": "StoreCore.setField(table, key, 1, arrayDataBytes)",
-    "gasUsed": 34983
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "delete (dynamic) record on table with subscriber",
-    "functionCall": "StoreCore.deleteRecord(table, key)",
-    "gasUsed": 25884
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "push to field (1 slot, 1 uint32 item)",
-    "functionCall": "StoreCore.pushToField(table, key, 1, secondDataToPush)",
-    "gasUsed": 16996
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "push to field (2 slots, 10 uint32 items)",
-    "functionCall": "StoreCore.pushToField(table, key, 2, thirdDataToPush)",
-    "gasUsed": 39718
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "StoreCore: register schema",
-    "functionCall": "StoreCore.registerSchema(table, schema, keySchema)",
-    "gasUsed": 54854
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "StoreCore: get schema (warm)",
-    "functionCall": "Schema loadedSchema = StoreCore.getSchema(table)",
-    "gasUsed": 1143
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "StoreCore: get key schema (warm)",
-    "functionCall": "Schema loadedKeySchema = StoreCore.getKeySchema(table)",
-    "gasUsed": 1211
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set complex record with dynamic data (4 slots)",
-    "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 107641
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get complex record with dynamic data (4 slots)",
-    "functionCall": "bytes memory loadedData = StoreCore.getRecord(table, key)",
-    "gasUsed": 6449
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "compare: Set complex record with dynamic data using native solidity",
-    "functionCall": "testStruct = _testStruct",
-    "gasUsed": 116842
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "compare: Set complex record with dynamic data using abi.encode",
-    "functionCall": "testMapping[1234] = abi.encode(_testStruct)",
-    "gasUsed": 267377
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set dynamic length of dynamic index 0",
-    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 10)",
-    "gasUsed": 23600
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set dynamic length of dynamic index 1",
-    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 1, 99)",
-    "gasUsed": 1720
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "reduce dynamic length of dynamic index 0",
-    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 5)",
-    "gasUsed": 1707
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set static field (1 slot)",
-    "functionCall": "StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes))",
-    "gasUsed": 38011
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get static field (1 slot)",
-    "functionCall": "bytes memory loadedData = StoreCore.getField(table, key, 0)",
-    "gasUsed": 2990
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set static field (overlap 2 slot)",
-    "functionCall": "StoreCore.setField(table, key, 1, abi.encodePacked(secondDataBytes))",
-    "gasUsed": 33026
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get static field (overlap 2 slot)",
-    "functionCall": "loadedData = StoreCore.getField(table, key, 1)",
-    "gasUsed": 3882
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set dynamic field (1 slot, first dynamic field)",
-    "functionCall": "StoreCore.setField(table, key, 2, thirdDataBytes)",
-    "gasUsed": 55329
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get dynamic field (1 slot, first dynamic field)",
-    "functionCall": "loadedData = StoreCore.getField(table, key, 2)",
-    "gasUsed": 3831
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set dynamic field (1 slot, second dynamic field)",
-    "functionCall": "StoreCore.setField(table, key, 3, fourthDataBytes)",
-    "gasUsed": 35469
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get dynamic field (1 slot, second dynamic field)",
-    "functionCall": "loadedData = StoreCore.getField(table, key, 3)",
-    "gasUsed": 3850
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set static record (1 slot)",
-    "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 37316
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get static record (1 slot)",
-    "functionCall": "bytes memory loadedData = StoreCore.getRecord(table, key, schema)",
-    "gasUsed": 1335
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "set static record (2 slots)",
-    "functionCall": "StoreCore.setRecord(table, key, data)",
-    "gasUsed": 59881
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "get static record (2 slots)",
-    "functionCall": "bytes memory loadedData = StoreCore.getRecord(table, key, schema)",
-    "gasUsed": 1584
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "StoreCore: set table metadata",
-    "functionCall": "StoreCore.setMetadata(table, tableName, fieldNames)",
-    "gasUsed": 251762
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "update in field (1 slot, 1 uint32 item)",
-    "functionCall": "StoreCore.updateInField(table, key, 1, 4 * 1, secondDataForUpdate)",
-    "gasUsed": 16533
-  },
-  {
-    "source": "test/StoreCore.t.sol",
-    "name": "push to field (2 slots, 6 uint64 items)",
-    "functionCall": "StoreCore.updateInField(table, key, 2, 8 * 1, thirdDataForUpdate)",
-    "gasUsed": 17636
-  },
-  {
     "source": "test/StoreCoreDynamic.t.sol",
     "name": "get field slice (cold, 1 slot)",
     "functionCall": "bytes memory secondFieldSlice = StoreCore.getFieldSlice(_table, _key, 1, schema, 0, 4)",
@@ -604,6 +346,264 @@
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
     "functionCall": "StoreCore.popFromField(_table, _key, 2, byteLengthToPop)",
     "gasUsed": 19231
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "access non-existing record",
+    "functionCall": "StoreCore.getRecord(table, key)",
+    "gasUsed": 7310
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "access static field of non-existing record",
+    "functionCall": "StoreCore.getField(table, key, 0)",
+    "gasUsed": 2982
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "access dynamic field of non-existing record",
+    "functionCall": "StoreCore.getField(table, key, 1)",
+    "gasUsed": 3593
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "access length of dynamic field of non-existing record",
+    "functionCall": "StoreCore.getFieldLength(table, key, 1, schema)",
+    "gasUsed": 1331
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "access slice of dynamic field of non-existing record",
+    "functionCall": "StoreCore.getFieldSlice(table, key, 1, schema, 0, 0)",
+    "gasUsed": 1331
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "delete record (complex data, 3 slots)",
+    "functionCall": "StoreCore.deleteRecord(table, key)",
+    "gasUsed": 11001
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "Check for existence of table (existent)",
+    "functionCall": "StoreCore.hasTable(table)",
+    "gasUsed": 1111
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "check for existence of table (non-existent)",
+    "functionCall": "StoreCore.hasTable(table2)",
+    "gasUsed": 3138
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "register subscriber",
+    "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
+    "gasUsed": 65566
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set record on table with subscriber",
+    "functionCall": "StoreCore.setRecord(table, key, data)",
+    "gasUsed": 73972
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set static field on table with subscriber",
+    "functionCall": "StoreCore.setField(table, key, 0, data)",
+    "gasUsed": 31960
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "delete record on table with subscriber",
+    "functionCall": "StoreCore.deleteRecord(table, key)",
+    "gasUsed": 24545
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "register subscriber",
+    "functionCall": "StoreCore.registerStoreHook(table, subscriber)",
+    "gasUsed": 65566
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set (dynamic) record on table with subscriber",
+    "functionCall": "StoreCore.setRecord(table, key, data)",
+    "gasUsed": 167409
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set (dynamic) field on table with subscriber",
+    "functionCall": "StoreCore.setField(table, key, 1, arrayDataBytes)",
+    "gasUsed": 34919
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "delete (dynamic) record on table with subscriber",
+    "functionCall": "StoreCore.deleteRecord(table, key)",
+    "gasUsed": 26059
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "push to field (1 slot, 1 uint32 item)",
+    "functionCall": "StoreCore.pushToField(table, key, 1, secondDataToPush)",
+    "gasUsed": 17072
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "push to field (2 slots, 10 uint32 items)",
+    "functionCall": "StoreCore.pushToField(table, key, 2, thirdDataToPush)",
+    "gasUsed": 39780
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "StoreCore: register schema",
+    "functionCall": "StoreCore.registerSchema(table, schema, keySchema)",
+    "gasUsed": 54877
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "StoreCore: get schema (warm)",
+    "functionCall": "StoreCore.getSchema(table)",
+    "gasUsed": 1136
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "StoreCore: get key schema (warm)",
+    "functionCall": "StoreCore.getKeySchema(table)",
+    "gasUsed": 1204
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set complex record with dynamic data (4 slots)",
+    "functionCall": "StoreCore.setRecord(table, key, data)",
+    "gasUsed": 107714
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get complex record with dynamic data (4 slots)",
+    "functionCall": "StoreCore.getRecord(table, key)",
+    "gasUsed": 6443
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "compare: Set complex record with dynamic data using native solidity",
+    "functionCall": "testStruct = _testStruct",
+    "gasUsed": 116839
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "compare: Set complex record with dynamic data using abi.encode",
+    "functionCall": "testMapping[1234] = abi.encode(_testStruct)",
+    "gasUsed": 267377
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set dynamic length of dynamic index 0",
+    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 10)",
+    "gasUsed": 23600
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set dynamic length of dynamic index 1",
+    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 1, 99)",
+    "gasUsed": 1719
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "reduce dynamic length of dynamic index 0",
+    "functionCall": "StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 5)",
+    "gasUsed": 1707
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set static field (1 slot)",
+    "functionCall": "StoreCore.setField(table, key, 0, firstDataPacked)",
+    "gasUsed": 37980
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get static field (1 slot)",
+    "functionCall": "StoreCore.getField(table, key, 0)",
+    "gasUsed": 2980
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set static field (overlap 2 slot)",
+    "functionCall": "StoreCore.setField(table, key, 1, secondDataPacked)",
+    "gasUsed": 35009
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get static field (overlap 2 slot)",
+    "functionCall": "StoreCore.getField(table, key, 1)",
+    "gasUsed": 3877
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set dynamic field (1 slot, first dynamic field)",
+    "functionCall": "StoreCore.setField(table, key, 2, thirdDataBytes)",
+    "gasUsed": 57377
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get dynamic field (1 slot, first dynamic field)",
+    "functionCall": "StoreCore.getField(table, key, 2)",
+    "gasUsed": 3812
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set dynamic field (1 slot, second dynamic field)",
+    "functionCall": "StoreCore.setField(table, key, 3, fourthDataBytes)",
+    "gasUsed": 35503
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get dynamic field (1 slot, second dynamic field)",
+    "functionCall": "StoreCore.getField(table, key, 3)",
+    "gasUsed": 3825
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set static record (1 slot)",
+    "functionCall": "StoreCore.setRecord(table, key, data)",
+    "gasUsed": 37369
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get static record (1 slot)",
+    "functionCall": "StoreCore.getRecord(table, key, schema)",
+    "gasUsed": 1329
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "set static record (2 slots)",
+    "functionCall": "StoreCore.setRecord(table, key, data)",
+    "gasUsed": 59940
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "get static record (2 slots)",
+    "functionCall": "StoreCore.getRecord(table, key, schema)",
+    "gasUsed": 1578
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "StoreCore: set table metadata",
+    "functionCall": "StoreCore.setMetadata(table, tableName, fieldNames)",
+    "gasUsed": 251850
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "update in field (1 slot, 1 uint32 item)",
+    "functionCall": "StoreCore.updateInField(table, key, 1, 4 * 1, secondDataForUpdate)",
+    "gasUsed": 16604
+  },
+  {
+    "source": "test/StoreCoreGas.t.sol",
+    "name": "push to field (2 slots, 6 uint64 items)",
+    "functionCall": "StoreCore.updateInField(table, key, 2, 8 * 1, thirdDataForUpdate)",
+    "gasUsed": 17699
   },
   {
     "source": "test/StoreMetadata.t.sol",

--- a/packages/store/test/StoreCoreGas.t.sol
+++ b/packages/store/test/StoreCoreGas.t.sol
@@ -23,7 +23,7 @@ struct TestStruct {
   uint32[] thirdData;
 }
 
-contract StoreCoreTest is Test, StoreMock {
+contract StoreCoreGasTest is Test, StoreMock {
   TestStruct private testStruct;
 
   mapping(uint256 => bytes) private testMapping;
@@ -32,45 +32,29 @@ contract StoreCoreTest is Test, StoreMock {
   function testRegisterAndGetSchema() public {
     Schema schema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16, SchemaType.UINT8, SchemaType.UINT16);
     Schema keySchema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16);
-
     bytes32 table = keccak256("some.table");
 
-    // Expect a StoreSetRecord event to be emitted
-    bytes32[] memory key = new bytes32[](1);
-    key[0] = bytes32(table);
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetRecord(StoreCoreInternal.SCHEMA_TABLE, key, abi.encodePacked(schema.unwrap(), keySchema.unwrap()));
+    // !gasreport StoreCore: register schema
+    StoreCore.registerSchema(table, schema, keySchema);
 
-    IStore(this).registerSchema(table, schema, keySchema);
+    // !gasreport StoreCore: get schema (warm)
+    StoreCore.getSchema(table);
 
-    Schema loadedSchema = IStore(this).getSchema(table);
-
-    assertEq(loadedSchema.unwrap(), schema.unwrap());
-
-    Schema loadedKeySchema = IStore(this).getKeySchema(table);
-    assertEq(loadedKeySchema.unwrap(), keySchema.unwrap());
-  }
-
-  function testFailRegisterInvalidSchema() public {
-    IStore(this).registerSchema(
-      keccak256("table"),
-      Schema.wrap(keccak256("random bytes as schema")),
-      Schema.wrap(keccak256("random bytes as key schema"))
-    );
+    // !gasreport StoreCore: get key schema (warm)
+    StoreCore.getKeySchema(table);
   }
 
   function testHasSchema() public {
     Schema schema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16, SchemaType.UINT8, SchemaType.UINT16);
     bytes32 table = keccak256("some.table");
     bytes32 table2 = keccak256("other.table");
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
+    // !gasreport Check for existence of table (existent)
     StoreCore.hasTable(table);
 
+    // !gasreport check for existence of table (non-existent)
     StoreCore.hasTable(table2);
-
-    assertTrue(StoreCore.hasTable(table));
-    assertFalse(StoreCore.hasTable(table2));
   }
 
   function testSetMetadata() public {
@@ -83,31 +67,10 @@ contract StoreCoreTest is Test, StoreMock {
     fieldNames[1] = "field2";
 
     // Register table
-    IStore(this).registerSchema(table, schema, keySchema);
+    StoreCore.registerSchema(table, schema, keySchema);
 
-    IStore(this).setMetadata(table, tableName, fieldNames);
-
-    // Get metadata for table
-    StoreMetadataData memory metadata = StoreMetadata.get(table);
-
-    assertEq(metadata.tableName, tableName);
-    assertEq(metadata.abiEncodedFieldNames, abi.encode(fieldNames));
-  }
-
-  function testlSetMetadataRevert() public {
-    bytes32 table = keccak256("some.table");
-    Schema schema = SchemaLib.encode(SchemaType.UINT8);
-    Schema keySchema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16, SchemaType.UINT8, SchemaType.UINT16);
-    string memory tableName = "someTable";
-    string[] memory fieldNames = new string[](2);
-    fieldNames[0] = "field1";
-    fieldNames[1] = "field2";
-
-    // Register table
-    IStore(this).registerSchema(table, schema, keySchema);
-
-    vm.expectRevert(abi.encodeWithSelector(IStoreErrors.StoreCore_InvalidFieldNamesLength.selector, 1, 2));
-    IStore(this).setMetadata(table, tableName, fieldNames);
+    // !gasreport StoreCore: set table metadata
+    StoreCore.setMetadata(table, tableName, fieldNames);
   }
 
   function testSetAndGetDynamicDataLength() public {
@@ -122,83 +85,49 @@ contract StoreCoreTest is Test, StoreMock {
     );
 
     // Register schema
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Create some key
     bytes32[] memory key = new bytes32[](1);
     key[0] = bytes32("some key");
 
     // Set dynamic data length of dynamic index 0
+    // !gasreport set dynamic length of dynamic index 0
     StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 10);
 
-    PackedCounter encodedLength = StoreCoreInternal._loadEncodedDynamicDataLength(table, key);
-    assertEq(encodedLength.atIndex(0), 10);
-    assertEq(encodedLength.atIndex(1), 0);
-    assertEq(encodedLength.total(), 10);
-
     // Set dynamic data length of dynamic index 1
+    // !gasreport set dynamic length of dynamic index 1
     StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 1, 99);
 
-    encodedLength = StoreCoreInternal._loadEncodedDynamicDataLength(table, key);
-    assertEq(encodedLength.atIndex(0), 10);
-    assertEq(encodedLength.atIndex(1), 99);
-    assertEq(encodedLength.total(), 109);
-
     // Reduce dynamic data length of dynamic index 0 again
+    // !gasreport reduce dynamic length of dynamic index 0
     StoreCoreInternal._setDynamicDataLengthAtIndex(table, key, 0, 5);
-
-    encodedLength = StoreCoreInternal._loadEncodedDynamicDataLength(table, key);
-    assertEq(encodedLength.atIndex(0), 5);
-    assertEq(encodedLength.atIndex(1), 99);
-    assertEq(encodedLength.total(), 104);
   }
 
   function testSetAndGetStaticData() public {
     // Register table's schema
     Schema schema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16, SchemaType.UINT8, SchemaType.UINT16);
-
     bytes32 table = keccak256("some.table");
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Set data
     bytes memory data = abi.encodePacked(bytes1(0x01), bytes2(0x0203), bytes1(0x04), bytes2(0x0506));
-
     bytes32[] memory key = new bytes32[](1);
     key[0] = keccak256("some.key");
 
-    // Expect a StoreSetRecord event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetRecord(table, key, data);
-
-    IStore(this).setRecord(table, key, data);
+    // !gasreport set static record (1 slot)
+    StoreCore.setRecord(table, key, data);
 
     // Get data
-    bytes memory loadedData = IStore(this).getRecord(table, key, schema);
-
-    assertTrue(Bytes.equals(data, loadedData));
-  }
-
-  function testFailSetAndGetStaticData() public {
-    // Register table's schema
-    Schema schema = SchemaLib.encode(SchemaType.UINT8, SchemaType.UINT16, SchemaType.UINT8, SchemaType.UINT16);
-    bytes32 table = keccak256("some.table");
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
-
-    // Set data
-    bytes memory data = abi.encodePacked(bytes1(0x01), bytes2(0x0203), bytes1(0x04));
-
-    bytes32[] memory key = new bytes32[](1);
-    key[0] = keccak256("some.key");
-
-    // This should fail because the data is not 6 bytes long
-    IStore(this).setRecord(table, key, data);
+    // !gasreport get static record (1 slot)
+    StoreCore.getRecord(table, key, schema);
   }
 
   function testSetAndGetStaticDataSpanningWords() public {
     // Register table's schema
     Schema schema = SchemaLib.encode(SchemaType.UINT128, SchemaType.UINT256);
     bytes32 table = keccak256("some.table");
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Set data
     bytes memory data = abi.encodePacked(
@@ -209,16 +138,12 @@ contract StoreCoreTest is Test, StoreMock {
     bytes32[] memory key = new bytes32[](1);
     key[0] = keccak256("some.key");
 
-    // Expect a StoreSetRecord event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetRecord(table, key, data);
-
-    IStore(this).setRecord(table, key, data);
+    // !gasreport set static record (2 slots)
+    StoreCore.setRecord(table, key, data);
 
     // Get data
-    bytes memory loadedData = IStore(this).getRecord(table, key, schema);
-
-    assertTrue(Bytes.equals(data, loadedData));
+    // !gasreport get static record (2 slots)
+    StoreCore.getRecord(table, key, schema);
   }
 
   function testSetAndGetDynamicData() public {
@@ -227,7 +152,7 @@ contract StoreCoreTest is Test, StoreMock {
     {
       // Register table's schema
       Schema schema = SchemaLib.encode(SchemaType.UINT128, SchemaType.UINT32_ARRAY, SchemaType.UINT32_ARRAY);
-      IStore(this).registerSchema(table, schema, defaultKeySchema);
+      StoreCore.registerSchema(table, schema, defaultKeySchema);
     }
 
     bytes16 firstDataBytes = bytes16(0x0102030405060708090a0b0c0d0e0f10);
@@ -269,18 +194,13 @@ contract StoreCoreTest is Test, StoreMock {
     bytes32[] memory key = new bytes32[](1);
     key[0] = bytes32("some.key");
 
-    // Expect a StoreSetRecord event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetRecord(table, key, data);
-
     // Set data
-    IStore(this).setRecord(table, key, data);
+    // !gasreport set complex record with dynamic data (4 slots)
+    StoreCore.setRecord(table, key, data);
 
     // Get data
-    bytes memory loadedData = IStore(this).getRecord(table, key);
-
-    assertEq(loadedData.length, data.length);
-    assertEq(keccak256(loadedData), keccak256(data));
+    // !gasreport get complex record with dynamic data (4 slots)
+    StoreCore.getRecord(table, key);
 
     // Compare gas - setting the data as raw struct
     TestStruct memory _testStruct = TestStruct(0, new uint32[](2), new uint32[](3));
@@ -291,8 +211,10 @@ contract StoreCoreTest is Test, StoreMock {
     _testStruct.thirdData[1] = 0x1d1e1f20;
     _testStruct.thirdData[2] = 0x21222324;
 
+    // !gasreport compare: Set complex record with dynamic data using native solidity
     testStruct = _testStruct;
 
+    // !gasreport compare: Set complex record with dynamic data using abi.encode
     testMapping[1234] = abi.encode(_testStruct);
   }
 
@@ -307,7 +229,7 @@ contract StoreCoreTest is Test, StoreMock {
         SchemaType.UINT32_ARRAY,
         SchemaType.UINT32_ARRAY
       );
-      IStore(this).registerSchema(table, schema, defaultKeySchema);
+      StoreCore.registerSchema(table, schema, defaultKeySchema);
     }
 
     bytes16 firstDataBytes = bytes16(0x0102030405060708090a0b0c0d0e0f10);
@@ -318,56 +240,28 @@ contract StoreCoreTest is Test, StoreMock {
 
     bytes memory firstDataPacked = abi.encodePacked(firstDataBytes);
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 0, firstDataPacked);
-
     // Set first field
-    IStore(this).setField(table, key, 0, firstDataPacked);
+    // !gasreport set static field (1 slot)
+    StoreCore.setField(table, key, 0, firstDataPacked);
 
     ////////////////
     // Static data
     ////////////////
 
     // Get first field
-    bytes memory loadedData = IStore(this).getField(table, key, 0);
-
-    // Verify loaded data is correct
-    assertEq(loadedData.length, 16);
-    assertEq(bytes16(loadedData), bytes16(firstDataBytes));
-
-    // Verify the second index is not set yet
-    assertEq(uint256(bytes32(IStore(this).getField(table, key, 1))), 0);
+    // !gasreport get static field (1 slot)
+    StoreCore.getField(table, key, 0);
 
     // Set second field
     bytes32 secondDataBytes = keccak256("some data");
-
     bytes memory secondDataPacked = abi.encodePacked(secondDataBytes);
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 1, secondDataPacked);
-
-    IStore(this).setField(table, key, 1, secondDataPacked);
+    // !gasreport set static field (overlap 2 slot)
+    StoreCore.setField(table, key, 1, secondDataPacked);
 
     // Get second field
-    loadedData = IStore(this).getField(table, key, 1);
-
-    // Verify loaded data is correct
-    assertEq(loadedData.length, 32);
-    assertEq(bytes32(loadedData), secondDataBytes);
-
-    // Verify the first field didn't change
-    assertEq(bytes16(IStore(this).getField(table, key, 0)), bytes16(firstDataBytes));
-
-    // Verify the full static data is correct
-    assertEq(IStore(this).getSchema(table).staticDataLength(), 48);
-    assertEq(Bytes.slice16(IStore(this).getRecord(table, key), 0), firstDataBytes);
-    assertEq(Bytes.slice32(IStore(this).getRecord(table, key), 16), secondDataBytes);
-    assertEq(
-      keccak256(SliceLib.getSubslice(IStore(this).getRecord(table, key), 0, 48).toBytes()),
-      keccak256(abi.encodePacked(firstDataBytes, secondDataBytes))
-    );
+    // !gasreport get static field (overlap 2 slot)
+    StoreCore.getField(table, key, 1);
 
     ////////////////
     // Dynamic data
@@ -390,50 +284,21 @@ contract StoreCoreTest is Test, StoreMock {
       fourthDataBytes = EncodeArray.encode(fourthData);
     }
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 2, thirdDataBytes);
-
     // Set third field
-    IStore(this).setField(table, key, 2, thirdDataBytes);
+    // !gasreport set dynamic field (1 slot, first dynamic field)
+    StoreCore.setField(table, key, 2, thirdDataBytes);
 
     // Get third field
-    loadedData = IStore(this).getField(table, key, 2);
-
-    // Verify loaded data is correct
-    assertEq(SliceLib.fromBytes(loadedData).decodeArray_uint32().length, 2);
-    assertEq(loadedData.length, thirdDataBytes.length);
-    assertEq(keccak256(loadedData), keccak256(thirdDataBytes));
-
-    // Verify the fourth field is not set yet
-    assertEq(IStore(this).getField(table, key, 3).length, 0);
-
-    // Verify none of the previous fields were impacted
-    assertEq(bytes16(IStore(this).getField(table, key, 0)), bytes16(firstDataBytes));
-    assertEq(bytes32(IStore(this).getField(table, key, 1)), bytes32(secondDataBytes));
-
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 3, fourthDataBytes);
+    // !gasreport get dynamic field (1 slot, first dynamic field)
+    StoreCore.getField(table, key, 2);
 
     // Set fourth field
-    IStore(this).setField(table, key, 3, fourthDataBytes);
+    // !gasreport set dynamic field (1 slot, second dynamic field)
+    StoreCore.setField(table, key, 3, fourthDataBytes);
 
     // Get fourth field
-    loadedData = IStore(this).getField(table, key, 3);
-
-    // Verify loaded data is correct
-    assertEq(loadedData.length, fourthDataBytes.length);
-    assertEq(keccak256(loadedData), keccak256(fourthDataBytes));
-
-    // Verify all fields are correct
-    PackedCounter encodedLengths = PackedCounterLib.pack(uint16(thirdDataBytes.length), uint16(fourthDataBytes.length));
-    assertEq(
-      keccak256(IStore(this).getRecord(table, key)),
-      keccak256(
-        abi.encodePacked(firstDataBytes, secondDataBytes, encodedLengths.unwrap(), thirdDataBytes, fourthDataBytes)
-      )
-    );
+    // !gasreport get dynamic field (1 slot, second dynamic field)
+    StoreCore.getField(table, key, 3);
   }
 
   function testDeleteData() public {
@@ -441,7 +306,7 @@ contract StoreCoreTest is Test, StoreMock {
 
     // Register table's schema
     Schema schema = SchemaLib.encode(SchemaType.UINT128, SchemaType.UINT32_ARRAY, SchemaType.UINT32_ARRAY);
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     bytes16 firstDataBytes = bytes16(0x0102030405060708090a0b0c0d0e0f10);
 
@@ -483,24 +348,11 @@ contract StoreCoreTest is Test, StoreMock {
     key[0] = bytes32("some.key");
 
     // Set data
-    IStore(this).setRecord(table, key, data);
-
-    // Get data
-    bytes memory loadedData = IStore(this).getRecord(table, key);
-
-    assertEq(loadedData.length, data.length);
-    assertEq(keccak256(loadedData), keccak256(data));
-
-    // Expect a StoreDeleteRecord event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreDeleteRecord(table, key);
+    StoreCore.setRecord(table, key, data);
 
     // Delete data
-    IStore(this).deleteRecord(table, key);
-
-    // Verify data is deleted
-    loadedData = IStore(this).getRecord(table, key);
-    assertEq(keccak256(loadedData), keccak256(new bytes(schema.staticDataLength())));
+    // !gasreport delete record (complex data, 3 slots)
+    StoreCore.deleteRecord(table, key);
   }
 
   function testPushToField() public {
@@ -509,7 +361,7 @@ contract StoreCoreTest is Test, StoreMock {
     {
       // Register table's schema
       Schema schema = SchemaLib.encode(SchemaType.UINT256, SchemaType.UINT32_ARRAY, SchemaType.UINT32_ARRAY);
-      IStore(this).registerSchema(table, schema, defaultKeySchema);
+      StoreCore.registerSchema(table, schema, defaultKeySchema);
     }
 
     // Create key
@@ -535,10 +387,10 @@ contract StoreCoreTest is Test, StoreMock {
     }
 
     // Set fields
-    IStore(this).setField(table, key, 0, abi.encodePacked(firstDataBytes));
-    IStore(this).setField(table, key, 1, secondDataBytes);
+    StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes));
+    StoreCore.setField(table, key, 1, secondDataBytes);
     // Initialize a field with push
-    IStore(this).pushToField(table, key, 2, thirdDataBytes);
+    StoreCore.pushToField(table, key, 2, thirdDataBytes);
 
     // Create data to push
     bytes memory secondDataToPush;
@@ -549,24 +401,9 @@ contract StoreCoreTest is Test, StoreMock {
     }
     bytes memory newSecondDataBytes = abi.encodePacked(secondDataBytes, secondDataToPush);
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 1, newSecondDataBytes);
-
     // Push to second field
-    IStore(this).pushToField(table, key, 1, secondDataToPush);
-
-    // Get second field
-    bytes memory loadedData = IStore(this).getField(table, key, 1);
-
-    // Verify loaded data is correct
-    assertEq(SliceLib.fromBytes(loadedData).decodeArray_uint32().length, 2 + 1);
-    assertEq(loadedData.length, newSecondDataBytes.length);
-    assertEq(loadedData, newSecondDataBytes);
-
-    // Verify none of the other fields were impacted
-    assertEq(bytes32(IStore(this).getField(table, key, 0)), firstDataBytes);
-    assertEq(IStore(this).getField(table, key, 2), thirdDataBytes);
+    // !gasreport push to field (1 slot, 1 uint32 item)
+    StoreCore.pushToField(table, key, 1, secondDataToPush);
 
     // Create data to push
     bytes memory thirdDataToPush;
@@ -584,26 +421,10 @@ contract StoreCoreTest is Test, StoreMock {
       thirdData[9] = 0x9abcdef0;
       thirdDataToPush = EncodeArray.encode(thirdData);
     }
-    bytes memory newThirdDataBytes = abi.encodePacked(thirdDataBytes, thirdDataToPush);
-
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 2, newThirdDataBytes);
 
     // Push to third field
-    IStore(this).pushToField(table, key, 2, thirdDataToPush);
-
-    // Get third field
-    loadedData = IStore(this).getField(table, key, 2);
-
-    // Verify loaded data is correct
-    assertEq(SliceLib.fromBytes(loadedData).decodeArray_uint32().length, 3 + 10);
-    assertEq(loadedData.length, newThirdDataBytes.length);
-    assertEq(loadedData, newThirdDataBytes);
-
-    // Verify none of the other fields were impacted
-    assertEq(bytes32(IStore(this).getField(table, key, 0)), firstDataBytes);
-    assertEq(IStore(this).getField(table, key, 1), newSecondDataBytes);
+    // !gasreport push to field (2 slots, 10 uint32 items)
+    StoreCore.pushToField(table, key, 2, thirdDataToPush);
   }
 
   function testUpdateInField() public {
@@ -612,7 +433,7 @@ contract StoreCoreTest is Test, StoreMock {
     {
       // Register table's schema
       Schema schema = SchemaLib.encode(SchemaType.UINT256, SchemaType.UINT32_ARRAY, SchemaType.UINT64_ARRAY);
-      IStore(this).registerSchema(table, schema, defaultKeySchema);
+      StoreCore.registerSchema(table, schema, defaultKeySchema);
     }
 
     // Create key
@@ -636,9 +457,9 @@ contract StoreCoreTest is Test, StoreMock {
     bytes memory thirdDataBytes = EncodeArray.encode(thirdData);
 
     // Set fields
-    IStore(this).setField(table, key, 0, abi.encodePacked(firstDataBytes));
-    IStore(this).setField(table, key, 1, secondDataBytes);
-    IStore(this).setField(table, key, 2, thirdDataBytes);
+    StoreCore.setField(table, key, 0, abi.encodePacked(firstDataBytes));
+    StoreCore.setField(table, key, 1, secondDataBytes);
+    StoreCore.setField(table, key, 2, thirdDataBytes);
 
     // Create data to use for the update
     bytes memory secondDataForUpdate;
@@ -651,24 +472,9 @@ contract StoreCoreTest is Test, StoreMock {
       newSecondDataBytes = abi.encodePacked(secondData[0], _secondDataForUpdate[0]);
     }
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 1, newSecondDataBytes);
-
     // Update index 1 in second field (4 = byte length of uint32)
-    IStore(this).updateInField(table, key, 1, 4 * 1, secondDataForUpdate);
-
-    // Get second field
-    bytes memory loadedData = IStore(this).getField(table, key, 1);
-
-    // Verify loaded data is correct
-    assertEq(SliceLib.fromBytes(loadedData).decodeArray_uint32().length, secondData.length);
-    assertEq(loadedData.length, newSecondDataBytes.length);
-    assertEq(loadedData, newSecondDataBytes);
-
-    // Verify none of the other fields were impacted
-    assertEq(bytes32(IStore(this).getField(table, key, 0)), firstDataBytes);
-    assertEq(IStore(this).getField(table, key, 2), thirdDataBytes);
+    // !gasreport update in field (1 slot, 1 uint32 item)
+    StoreCore.updateInField(table, key, 1, 4 * 1, secondDataForUpdate);
 
     // Create data for update
     bytes memory thirdDataForUpdate;
@@ -691,56 +497,35 @@ contract StoreCoreTest is Test, StoreMock {
       );
     }
 
-    // Expect a StoreSetField event to be emitted
-    vm.expectEmit(true, true, true, true);
-    emit StoreSetField(table, key, 2, newThirdDataBytes);
-
     // Update indexes 1,2,3,4 in third field (8 = byte length of uint64)
-    IStore(this).updateInField(table, key, 2, 8 * 1, thirdDataForUpdate);
-
-    // Get third field
-    loadedData = IStore(this).getField(table, key, 2);
-
-    // Verify loaded data is correct
-    assertEq(SliceLib.fromBytes(loadedData).decodeArray_uint64().length, thirdData.length);
-    assertEq(loadedData.length, newThirdDataBytes.length);
-    assertEq(loadedData, newThirdDataBytes);
-
-    // Verify none of the other fields were impacted
-    assertEq(bytes32(IStore(this).getField(table, key, 0)), firstDataBytes);
-    assertEq(IStore(this).getField(table, key, 1), newSecondDataBytes);
-
-    // startByteIndex must not overflow
-    vm.expectRevert(
-      abi.encodeWithSelector(IStoreErrors.StoreCore_DataIndexOverflow.selector, type(uint16).max, type(uint32).max)
-    );
-    IStore(this).updateInField(table, key, 2, type(uint32).max, thirdDataForUpdate);
+    // !gasreport push to field (2 slots, 6 uint64 items)
+    StoreCore.updateInField(table, key, 2, 8 * 1, thirdDataForUpdate);
   }
 
   function testAccessEmptyData() public {
     bytes32 table = keccak256("some.table");
     Schema schema = SchemaLib.encode(SchemaType.UINT32, SchemaType.UINT32_ARRAY);
 
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Create key
     bytes32[] memory key = new bytes32[](1);
     key[0] = bytes32("some.key");
 
-    bytes memory data1 = IStore(this).getRecord(table, key);
-    assertEq(data1.length, schema.staticDataLength());
+    // !gasreport access non-existing record
+    StoreCore.getRecord(table, key);
 
-    bytes memory data2 = IStore(this).getField(table, key, 0);
-    assertEq(data2.length, schema.staticDataLength());
+    // !gasreport access static field of non-existing record
+    StoreCore.getField(table, key, 0);
 
-    bytes memory data3 = IStore(this).getField(table, key, 1);
-    assertEq(data3.length, 0);
+    // !gasreport access dynamic field of non-existing record
+    StoreCore.getField(table, key, 1);
 
-    uint256 data3Length = IStore(this).getFieldLength(table, key, 1, schema);
-    assertEq(data3Length, 0);
+    // !gasreport access length of dynamic field of non-existing record
+    StoreCore.getFieldLength(table, key, 1, schema);
 
-    bytes memory data3Slice = IStore(this).getFieldSlice(table, key, 1, schema, 0, 0);
-    assertEq(data3Slice.length, 0);
+    // !gasreport access slice of dynamic field of non-existing record
+    StoreCore.getFieldSlice(table, key, 1, schema, 0, 0);
   }
 
   function testHooks() public {
@@ -750,34 +535,26 @@ contract StoreCoreTest is Test, StoreMock {
 
     // Register table's schema
     Schema schema = SchemaLib.encode(SchemaType.UINT128);
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Create subscriber
     MirrorSubscriber subscriber = new MirrorSubscriber(table, schema, defaultKeySchema);
 
-    IStore(this).registerStoreHook(table, subscriber);
+    // !gasreport register subscriber
+    StoreCore.registerStoreHook(table, subscriber);
 
     bytes memory data = abi.encodePacked(bytes16(0x0102030405060708090a0b0c0d0e0f10));
 
-    IStore(this).setRecord(table, key, data);
-
-    // Get data from indexed table - the indexer should have mirrored the data there
-    bytes memory indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(data), keccak256(indexedData));
+    // !gasreport set record on table with subscriber
+    StoreCore.setRecord(table, key, data);
 
     data = abi.encodePacked(bytes16(0x1112131415161718191a1b1c1d1e1f20));
 
-    IStore(this).setField(table, key, 0, data);
+    // !gasreport set static field on table with subscriber
+    StoreCore.setField(table, key, 0, data);
 
-    // Get data from indexed table - the indexer should have mirrored the data there
-    indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(data), keccak256(indexedData));
-
-    IStore(this).deleteRecord(table, key);
-
-    // Get data from indexed table - the indexer should have mirrored the data there
-    indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(indexedData), keccak256(abi.encodePacked(bytes16(0))));
+    // !gasreport delete record on table with subscriber
+    StoreCore.deleteRecord(table, key);
   }
 
   function testHooksDynamicData() public {
@@ -787,12 +564,13 @@ contract StoreCoreTest is Test, StoreMock {
 
     // Register table's schema
     Schema schema = SchemaLib.encode(SchemaType.UINT128, SchemaType.UINT32_ARRAY);
-    IStore(this).registerSchema(table, schema, defaultKeySchema);
+    StoreCore.registerSchema(table, schema, defaultKeySchema);
 
     // Create subscriber
     MirrorSubscriber subscriber = new MirrorSubscriber(table, schema, defaultKeySchema);
 
-    IStore(this).registerStoreHook(table, subscriber);
+    // !gasreport register subscriber
+    StoreCore.registerStoreHook(table, subscriber);
 
     uint32[] memory arrayData = new uint32[](1);
     arrayData[0] = 0x01020304;
@@ -802,11 +580,8 @@ contract StoreCoreTest is Test, StoreMock {
     bytes memory staticData = abi.encodePacked(bytes16(0x0102030405060708090a0b0c0d0e0f10));
     bytes memory data = abi.encodePacked(staticData, dynamicData);
 
-    IStore(this).setRecord(table, key, data);
-
-    // Get data from indexed table - the indexer should have mirrored the data there
-    bytes memory indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(data), keccak256(indexedData));
+    // !gasreport set (dynamic) record on table with subscriber
+    StoreCore.setRecord(table, key, data);
 
     // Update dynamic data
     arrayData[0] = 0x11121314;
@@ -814,17 +589,11 @@ contract StoreCoreTest is Test, StoreMock {
     dynamicData = abi.encodePacked(encodedArrayDataLength.unwrap(), arrayDataBytes);
     data = abi.encodePacked(staticData, dynamicData);
 
-    IStore(this).setField(table, key, 1, arrayDataBytes);
+    // !gasreport set (dynamic) field on table with subscriber
+    StoreCore.setField(table, key, 1, arrayDataBytes);
 
-    // Get data from indexed table - the indexer should have mirrored the data there
-    indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(data), keccak256(indexedData));
-
-    IStore(this).deleteRecord(table, key);
-
-    // Get data from indexed table - the indexer should have mirrored the data there
-    indexedData = IStore(this).getRecord(indexerTableId, key);
-    assertEq(keccak256(indexedData), keccak256(abi.encodePacked(bytes16(0))));
+    // !gasreport delete (dynamic) record on table with subscriber
+    StoreCore.deleteRecord(table, key);
   }
 }
 

--- a/packages/store/test/StoreMock.sol
+++ b/packages/store/test/StoreMock.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { IStore, IStoreHook } from "../src/IStore.sol";
+import { StoreCore } from "../src/StoreCore.sol";
+import { Schema } from "../src/Schema.sol";
+import { StoreRead } from "../src/StoreRead.sol";
+
+/**
+ * StoreMock is a contract wrapper around the StoreCore library for testing purposes.
+ */
+contract StoreMock is IStore, StoreRead {
+  // Set full record (including full dynamic data)
+  function setRecord(bytes32 table, bytes32[] calldata key, bytes calldata data) public {
+    StoreCore.setRecord(table, key, data);
+  }
+
+  // Set partial data at schema index
+  function setField(bytes32 table, bytes32[] calldata key, uint8 schemaIndex, bytes calldata data) public {
+    StoreCore.setField(table, key, schemaIndex, data);
+  }
+
+  // Push encoded items to the dynamic field at schema index
+  function pushToField(bytes32 table, bytes32[] calldata key, uint8 schemaIndex, bytes calldata dataToPush) public {
+    StoreCore.pushToField(table, key, schemaIndex, dataToPush);
+  }
+
+  // Pop byte length from the dynamic field at schema index
+  function popFromField(bytes32 table, bytes32[] calldata key, uint8 schemaIndex, uint256 byteLengthToPop) public {
+    StoreCore.popFromField(table, key, schemaIndex, byteLengthToPop);
+  }
+
+  // Change encoded items within the dynamic field at schema index
+  function updateInField(
+    bytes32 table,
+    bytes32[] calldata key,
+    uint8 schemaIndex,
+    uint256 startByteIndex,
+    bytes calldata dataToSet
+  ) public {
+    StoreCore.updateInField(table, key, schemaIndex, startByteIndex, dataToSet);
+  }
+
+  // Set full record (including full dynamic data)
+  function deleteRecord(bytes32 table, bytes32[] memory key) public {
+    StoreCore.deleteRecord(table, key);
+  }
+
+  // Emit the ephemeral event without modifying storage
+  function emitEphemeralRecord(bytes32 table, bytes32[] calldata key, bytes calldata data) public {
+    StoreCore.emitEphemeralRecord(table, key, data);
+  }
+
+  function registerSchema(bytes32 table, Schema schema, Schema keySchema) public {
+    StoreCore.registerSchema(table, schema, keySchema);
+  }
+
+  function setMetadata(bytes32 table, string calldata tableName, string[] calldata fieldNames) public {
+    StoreCore.setMetadata(table, tableName, fieldNames);
+  }
+
+  // Register hook to be called when a record or field is set or deleted
+  function registerStoreHook(bytes32 table, IStoreHook hook) public {
+    StoreCore.registerStoreHook(table, hook);
+  }
+}


### PR DESCRIPTION
Fixes #814 

* Integrates the new `expectEmit` behavior introduced in https://github.com/foundry-rs/foundry/pull/4920 by calling functions on a wrapper contract (`IStore(this)`) instead of the library directly (`StoreCore`) to trigger a `CALL`.

* Moves the gas reports to a separate test which still uses `StoreCore`, since calling the methods on a wrapper contract increases gas cost (but for the Store library gas reports we're interested in the library cost, not the contract call cost)