### PR TITLE
fix(config): use file url to load config on windows

### DIFF
--- a/packages/config/src/node/loadConfig.ts
+++ b/packages/config/src/node/loadConfig.ts
@@ -3,6 +3,8 @@ import path from "path";
 import { NotInsideProjectError } from "../library/errors";
 import esbuild from "esbuild";
 import { rmSync } from "fs";
+import { pathToFileURL } from "url";
+import os from "os";
 
 // In order of preference files are checked
 const configFiles = ["mud.config.js", "mud.config.mjs", "mud.config.ts", "mud.config.mts"];
@@ -28,7 +30,10 @@ async function resolveConfigPath(configPath: string | undefined) {
       configPath = path.normalize(configPath);
     }
   }
-  return configPath;
+
+  // Add `file:///` for Windows support
+  // (see https://github.com/nodejs/node/issues/31710)
+  return os.platform() === "win32" ? pathToFileURL(configPath).href : configPath;
 }
 
 async function getUserConfigPath() {


### PR DESCRIPTION
* Loading the config on windows throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` because the path doesn't begin with `file:///`. Note that appending `file:///` would throw an error on systems other than windows. This PR adds an OS check and appends `file:///` to the url in case it's `win32` (which is the case on all windows systems including 64 bit)