### PR TITLE
fix(store): always use posix separator in tablegen

### DIFF
--- a/packages/store/ts/library/render-solidity/tablegen.ts
+++ b/packages/store/ts/library/render-solidity/tablegen.ts
@@ -29,7 +29,8 @@ export async function tablegen(config: StoreConfig, outputBaseDirectory: string)
     await formatAndWriteSolidity(output, fullOutputPath, "Generated types file");
   }
 
-  const fullOutputPath = path.join(outputBaseDirectory, `Tables.sol`);
+  // solc expects `/` as path separator, but path.join uses `\` if the user is on Windows
+  const fullOutputPath = path.join(outputBaseDirectory, `Tables.sol`).replace(/\\/g, "/");
   const output = renderTableIndex(allTableOptions);
   await formatAndWriteSolidity(output, fullOutputPath, "Generated table index");
 }


### PR DESCRIPTION
* tablegen used `path.join` to create import paths that are put in solidity files and read by `solc`, which expects `posix` paths independent of the operating system it's running on. This little regex replaces all windows separators (`\`) with posix separators (`/`)