### PR TITLE
feat(templates): make package scripts more windows friendly, add mud:up

### DIFF
--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -8,8 +8,10 @@
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",
     "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
+    "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "initialize": "pnpm recursive run initialize",
     "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -7,7 +7,6 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",
-    "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "initialize": "pnpm recursive run initialize",
     "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
@@ -20,7 +19,6 @@
     "@typescript-eslint/parser": "5.46.1",
     "eslint": "8.29.0",
     "rimraf": "^3.0.2",
-    "run-pty": "^4.0.3",
     "typescript": "^4.9.5"
   },
   "engines": {

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "pnpm recursive run dev",
+    "dev": "pnpm run initialize && pnpm recursive run dev",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -8,6 +8,7 @@
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "pnpm --filter 'contracts' devnode",
     "initialize": "pnpm recursive run initialize",
+    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -3,15 +3,17 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
+    "dev": "pnpm recursive run dev",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
-    "dev:node": "pnpm --filter 'contracts' devnode",
+    "dev:node": "mud devnode",
+    "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
     "initialize": "pnpm recursive run initialize",
     "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {
+    "@latticexyz/cli": "link:../../packages/cli",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
     "eslint": "8.29.0",

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -3,14 +3,17 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
+    "dev": "pnpm recursive run dev",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
-    "dev:node": "pnpm --filter 'contracts' devnode",
+    "dev:node": "mud devnode",
+    "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
     "initialize": "pnpm recursive run initialize",
+    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {
+    "@latticexyz/cli": "link:../../packages/cli",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
     "eslint": "8.29.0",

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -8,8 +8,10 @@
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",
     "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
+    "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "initialize": "pnpm recursive run initialize",
     "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },
   "devDependencies": {

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -7,7 +7,6 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",
-    "dev:pty": "run-pty % pnpm dev:node % pnpm dev:client % pnpm dev:contracts",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "initialize": "pnpm recursive run initialize",
     "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
@@ -20,7 +19,6 @@
     "@typescript-eslint/parser": "5.46.1",
     "eslint": "8.29.0",
     "rimraf": "^3.0.2",
-    "run-pty": "^4.0.3",
     "typescript": "^4.9.5"
   },
   "engines": {

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "pnpm recursive run dev",
+    "dev": "pnpm run initialize && recursive run dev",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "dev:node": "mud devnode",


### PR DESCRIPTION
closes #832
closes #831

- Windows users are reporting issues with `node-pty`. This PR adds a simple `dev` script relying on `pnpm recursive` to remove the need for `run-pty`/`node-pty`
  - I think we should split the `dev:node` command from this dev script because if we have time I'd like to add a simple file watcher that runs codegen and redeploys the contracts when relevant files change, but we don't need to restart anvil for that.
  - ~~we still have the `dev:pty` script which is recommended for everyone who doesn't have issues with `node-pty` because it makes it easier to see when things fail and why they fail~~ removing the `run-pty` dependency because it causes issues for the initial install

- this PR also adds a simple `mud:up` script to update mud to the latest canary
- this PR also adds mud cli as a workspace dependency for templates, so users can run `pnpm mud` anywhere in their project instead of just in the contracts dir