### PR TITLE
fix(world): regenerate SystemHooks table after PackedCounter change

### DIFF
--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -185,8 +185,8 @@ library SystemHooks {
 
   /** Tightly pack full data using this table's schema */
   function encode(address[] memory value) internal view returns (bytes memory) {
-    uint16[] memory _counters = new uint16[](1);
-    _counters[0] = uint16(value.length * 20);
+    uint40[] memory _counters = new uint40[](1);
+    _counters[0] = uint40(value.length * 20);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);
 
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));


### PR DESCRIPTION
* #804 introduced a change in the size of `PackedCounter`, in #834 we added a new table and merged without accounting for the `PackedCounter` change merged shortly before it.
* This PR regenerates the `SystemHooks` table to account for the updated `PackedCounter` size