### PR TITLE
fix: remove wait-port timeout

### DIFF
--- a/examples/minimal/packages/client-react/package.json
+++ b/examples/minimal/packages/client-react/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port -t 10000 localhost:8545 && vite",
+    "dev": "wait-port localhost:8545 && vite",
     "initialize": "pnpm build",
     "preview": "vite preview"
   },

--- a/examples/minimal/packages/client-vanilla/package.json
+++ b/examples/minimal/packages/client-vanilla/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port -t 10000 localhost:8545 && vite",
+    "dev": "wait-port localhost:8545 && vite",
     "initialize": "pnpm build",
     "preview": "vite preview"
   },

--- a/templates/react/packages/client/package.json
+++ b/templates/react/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port -t 10000 localhost:8545 && vite",
+    "dev": "wait-port localhost:8545 && vite",
     "initialize": "pnpm build",
     "preview": "vite preview",
     "test": "tsc --noEmit"

--- a/templates/vanilla/packages/client/package.json
+++ b/templates/vanilla/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port -t 10000 localhost:8545 && vite",
+    "dev": "wait-port localhost:8545 && vite",
     "initialize": "pnpm build",
     "preview": "vite preview",
     "test": "tsc --noEmit"


### PR DESCRIPTION
followup to #865 

- I expected `wait-port` to move to the next script after the timeout, but turns out it just fails the entire script
- Turns out the initial dev run takes longer than 10s on an entry class Windows laptop, so the timeout breaks it before the script had a chance to complete

- This PR removes the timeout from the `wait-port` command, so the template client's `dev` command also works on slow machines.