### PR TITLE
feat(std-client): disable cache on local chains

### DIFF
--- a/packages/std-client/src/setup/setupMUDV2Network.ts
+++ b/packages/std-client/src/setup/setupMUDV2Network.ts
@@ -164,7 +164,7 @@ export async function setupMUDV2Network<C extends ContractComponents, S extends 
         provider: providerConfig,
         worldContract: contractsConfig.World,
         initialBlockNumber: initialBlockNumber ?? networkConfig.initialBlockNumber,
-        disableCache: networkConfig.disableCache, // Disable cache on local networks (hardhat / anvil)
+        disableCache: networkConfig.disableCache || [31337, 1337].includes(networkConfig.chainId), // Disable cache on local networks (hardhat / anvil)
         fetchSystemCalls,
         initialRecords,
       },


### PR DESCRIPTION
- the cache is indexed by world address, but the world address is often the same locally for different deployments when restarting the local development node. This causes very frequent issues; the current workaround is to append `cache=false` to the url
- this PR disables the local cache for development chains like anvil/hardhat (chainids 31337, 1337)