### PR TITLE
fix(dev-tools): simulate result at last block

### DIFF
--- a/packages/dev-tools/src/actions/getTransactionResult.ts
+++ b/packages/dev-tools/src/actions/getTransactionResult.ts
@@ -25,9 +25,9 @@ export const getTransactionResult = (publicClient: PublicClient & { chain: Chain
         abi: worldAbi,
         functionName,
         args,
-        // value: tx.value,
-        blockNumber: receipt.blockNumber,
-        // TODO: do we need to include nonce, gas price, etc. to properly simulate?
+        // simulation happens at the end of the block, so we need to use the previous block number
+        blockNumber: receipt.blockNumber - 1n,
+        // TODO: do we need to include value, nonce, gas price, etc. to properly simulate?
       });
     });
   }


### PR DESCRIPTION
By using the block number of the confirmed tx, a simulation for `increment` would show the value incrementing again (one more than what it should be) because the simulation happens at the end of the block (after the tx we're simulating)

![image](https://github.com/latticexyz/mud/assets/508855/a4585d33-1dff-4cd1-9ae1-2eead15b6e1e)
![image](https://github.com/latticexyz/mud/assets/508855/13456ce7-6a39-4502-bf18-196f358a6329)
