### PR TITLE
fix(config): invalidate node js import cache

### DIFF
--- a/packages/config/src/node/loadConfig.ts
+++ b/packages/config/src/node/loadConfig.ts
@@ -15,7 +15,10 @@ export async function loadConfig(configPath?: string): Promise<unknown> {
   try {
     await esbuild.build({ entryPoints: [configPath], format: "esm", outfile: TEMP_CONFIG });
     configPath = await resolveConfigPath(TEMP_CONFIG, true);
-    return (await import(configPath)).default;
+    // Node.js caches dynamic imports, so without appending a cache breaking
+    // param like `?update={Date.now()}` this import always returns the same config
+    // if called multiple times in a single process, like the `dev-contracts` cli
+    return (await import(configPath + `?update=${Date.now()}`)).default;
   } finally {
     rmSync(TEMP_CONFIG, { force: true });
   }


### PR DESCRIPTION
in `loadConfig.ts`:
Node.js caches dynamic imports, so without appending a cache breaking param like `?update={Date.now()}` the import always returns the same config if called multiple times in a single process, like the `dev-contracts` cli