### PR TITLE
fix(dev-tools): various UX improvements

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -32,6 +32,7 @@
     "react-router-dom": "^6.11.0",
     "rxjs": "^7.5.5",
     "tailwind-merge": "^1.12.0",
+    "use-local-storage-state": "^18.3.2",
     "viem": "^0.3.18",
     "zustand": "^4.3.7"
   },

--- a/packages/dev-tools/src/App.tsx
+++ b/packages/dev-tools/src/App.tsx
@@ -4,11 +4,14 @@ import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { router } from "./router";
 import { RouterProvider } from "react-router-dom";
+import useLocalStorageState from "use-local-storage-state";
 
 // TODO: fix tab index so that it's not possible to tab around in the UI when it's hidden
 
 export function App() {
-  const [shown, setShown] = useState(true);
+  const [shown, setShown] = useLocalStorageState("mud-dev-tools-shown", {
+    defaultValue: true,
+  });
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {

--- a/packages/dev-tools/src/App.tsx
+++ b/packages/dev-tools/src/App.tsx
@@ -29,7 +29,7 @@ export function App() {
           shown ? "translate-x-0" : "translate-x-full"
         )}
       >
-        <div className="absolute bottom-0 right-full min-w-max flex flex-col-reverse items-end justify-center m-2">
+        <div className="absolute bottom-0 right-full min-w-max flex flex-col-reverse items-end justify-center m-2 text-gray-500">
           <button
             type="button"
             className="peer text-sm p-2 rounded leading-none transition opacity-60 hover:opacity-100"
@@ -37,9 +37,9 @@ export function App() {
           >
             <span className="whitespace-nowrap font-medium">{shown ? "→" : "←"} MUD Dev Tools</span>
           </button>
-          <span className="transition opacity-0 peer-hover:opacity-40 px-2 text-xs flex items-center justify-center gap-2">
+          <span className="transition opacity-0 peer-hover:opacity-60 px-2 text-xs flex items-center justify-center gap-2">
             Keyboard shortcut
-            <code className="bg-black/10 p-1 rounded text-mono text-xs leading-none">`</code>
+            <code className="bg-gray-500/10 p-1 rounded text-mono text-xs leading-none">`</code>
           </span>
         </div>
         <div

--- a/packages/dev-tools/src/mount.tsx
+++ b/packages/dev-tools/src/mount.tsx
@@ -1,6 +1,14 @@
+const containerId = "mud-dev-tools";
+
+// TODO: rework to always return a unmount function (not a promise or possibly undefined)
 export async function mount() {
   if (typeof window === "undefined") {
     console.warn("MUD dev-tools should only be used in browser bundles");
+    return;
+  }
+
+  if (document.getElementById(containerId)) {
+    console.warn("MUD dev-tools is already mounted");
     return;
   }
 
@@ -10,7 +18,14 @@ export async function mount() {
     const { App } = await import("./App");
 
     const rootElement = document.createElement("div");
-    rootElement.id = "mud-dev-tools";
+    rootElement.id = containerId;
+
+    // We shouldn't need to do this with stacking contexts and this being at
+    // the end of the DOM, but for some reason, any elements on the page with
+    // z-index seem to overlap this.
+    // https://web.dev/learn/css/z-index/#stacking-context
+    rootElement.style.position = "relative";
+    rootElement.style.zIndex = "999999";
 
     const root = ReactDOM.createRoot(rootElement);
     root.render(
@@ -20,9 +35,9 @@ export async function mount() {
     );
 
     document.body.appendChild(rootElement);
+
+    return () => root.unmount();
   } catch (error) {
     console.error("Failed to mount MUD dev-tools", error);
   }
-
-  // TODO: expose an unmount function?
 }

--- a/packages/dev-tools/src/mount.tsx
+++ b/packages/dev-tools/src/mount.tsx
@@ -36,7 +36,10 @@ export async function mount() {
 
     document.body.appendChild(rootElement);
 
-    return () => root.unmount();
+    return () => {
+      root.unmount();
+      rootElement.remove();
+    };
   } catch (error) {
     console.error("Failed to mount MUD dev-tools", error);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       tailwind-merge:
         specifier: ^1.12.0
         version: 1.12.0
+      use-local-storage-state:
+        specifier: ^18.3.2
+        version: 18.3.2(react-dom@18.2.0)(react@18.2.0)
       viem:
         specifier: ^0.3.18
         version: 0.3.18(typescript@5.0.4)
@@ -14411,6 +14414,17 @@ packages:
       querystringify: 2.2.0
       requires-port: 1.0.0
     dev: true
+
+  /use-local-storage-state@18.3.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-JiTuQsJmmKvc0mH0hiSjaTkKFlwtwXTeOlJ+cdg7rRJzZWwv+s/Rr2S2r2NR68O0W5ogwwt1MX1y+P2wQ1lY4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}


### PR DESCRIPTION
related to #777 

- returns `unmount` function from `mount` (inside an optional promise though, which isn't great)
- prevents mounting more than once
- attempts to fix layering (not sure why stacking contexts didn't help here)
- adjusts show/hide button colors to better suit both dark and light backgrounds
- keeps track of open/close state in localStorage (and consistent between browser tabs)
