### PR TITLE
fix: render posix paths for solc

### DIFF
--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -7,6 +7,7 @@ import {
   RenderKeyTuple,
   RenderType,
 } from "./types";
+import { posixPath } from "../utils";
 
 export const renderedSolidityHeader = `// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
@@ -113,7 +114,7 @@ export function renderAbsoluteImports(imports: AbsoluteImportDatum[]) {
   const renderedImports = [];
   for (const [path, symbols] of aggregatedImports) {
     const renderedSymbols = [...symbols].join(", ");
-    renderedImports.push(`import { ${renderedSymbols} } from "${path}";`);
+    renderedImports.push(`import { ${renderedSymbols} } from "${posixPath(path)}";`);
   }
   return renderedImports.join("\n");
 }

--- a/packages/common/src/codegen/utils/index.ts
+++ b/packages/common/src/codegen/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./contractToInterface";
 export * from "./format";
 export * from "./formatAndWrite";
+export * from "./posixPath";

--- a/packages/common/src/codegen/utils/posixPath.ts
+++ b/packages/common/src/codegen/utils/posixPath.ts
@@ -1,0 +1,8 @@
+/**
+ * Explicitly normalize a given path to a posix path (using `/` as separator).
+ * This should be used for generating Solidity files that will be consumed by solc,
+ * because solc expects `/` as path separator, but path.join produces `\` if the user is on windows.
+ */
+export function posixPath(path: string) {
+  return path.replace(/\\/g, "/");
+}

--- a/packages/store/ts/library/render-solidity/renderTableIndex.ts
+++ b/packages/store/ts/library/render-solidity/renderTableIndex.ts
@@ -1,4 +1,4 @@
-import { renderList, renderedSolidityHeader } from "@latticexyz/common/codegen";
+import { posixPath, renderList, renderedSolidityHeader } from "@latticexyz/common/codegen";
 import { TableOptions } from "./tableOptions";
 
 export function renderTableIndex(options: TableOptions[]) {
@@ -9,7 +9,7 @@ ${renderList(options, ({ outputPath, tableName, renderOptions: { structName, sta
   if (structName) imports.push(structName);
   if (staticResourceData) imports.push(`${tableName}TableId`);
 
-  return `import { ${imports.join(", ")} } from "./${outputPath}";`;
+  return `import { ${imports.join(", ")} } from "./${posixPath(outputPath)}";`;
 })}
 `;
 }

--- a/packages/store/ts/library/render-solidity/tableOptions.ts
+++ b/packages/store/ts/library/render-solidity/tableOptions.ts
@@ -85,8 +85,7 @@ export function getTableOptions(config: StoreConfig): TableOptions[] {
     })();
 
     options.push({
-      // solc expects `/` as path separator, but path.join uses `\` if the user is on Windows
-      outputPath: path.join(tableData.directory, `${tableName}.sol`).replace(/\\/g, "/"),
+      outputPath: path.join(tableData.directory, `${tableName}.sol`),
       tableName,
       renderOptions: {
         imports,


### PR DESCRIPTION
fixes https://github.com/latticexyz/emojimon/issues/11

 * Explicitly normalize a paths use a poxis separator (`/`) for when codegenerating solidity files, because `solc` expects posix paths but `path.join` uses the `win32` separator (`\`) if the user is on windows.
 * Followup to #854 (we missed a path, this PR changes the location of normalization to the util rendering imports)