### PR TITLE
test(create-mud): add threejs template to create-mud tests

### DIFF
--- a/packages/create-mud/package.json
+++ b/packages/create-mud/package.json
@@ -15,9 +15,10 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "pnpm run test:vanilla && pnpm run test:react && pnpm run test:phaser",
+    "test": "pnpm run test:vanilla && pnpm run test:react && pnpm run test:phaser && pnpm run test:threejs",
     "test:phaser": "dist/cli.js test-project --template phaser && rimraf test-project",
     "test:react": "dist/cli.js test-project --template react && rimraf test-project",
+    "test:threejs": "dist/cli.js test-project --template threejs && rimraf test-project",
     "test:vanilla": "dist/cli.js test-project --template vanilla && rimraf test-project"
   },
   "dependencies": {

--- a/templates/threejs/packages/client/src/App.tsx
+++ b/templates/threejs/packages/client/src/App.tsx
@@ -70,9 +70,11 @@ const Scene = () => {
   );
 };
 
+const styles = { height: "100vh" };
+
 export const App = () => {
   return (
-    <Canvas style={{ height: "100vh" }}>
+    <Canvas style={styles}>
       <Scene />
     </Canvas>
   );


### PR DESCRIPTION

Fixes this issue: <img width="212" alt="CleanShot 2023-05-19 at 20 10 12@2x" src="https://github.com/latticexyz/mud/assets/89248902/770c5ebc-3c25-4a8c-a5ac-8a060a72ed4c">

It seems like `create-create-app` / `handlebars` is interpreting the `{{ height: 100vh }}` as an unknown handlebars option, this is a quick fix to resolve that