### PR TITLE
fix(cli): clean anvil cache/logs at start of dev-contracts

### DIFF
--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -10,6 +10,8 @@ import { debounce } from "throttle-debounce";
 import { worldgenHandler } from "./worldgen";
 import { WorldConfig } from "@latticexyz/world";
 import { deployHandler, printMUD, worldtypes } from "../utils";
+import { homedir } from "os";
+import { rmSync } from "fs";
 
 type Options = {
   rpc?: string;
@@ -57,6 +59,10 @@ const commandModule: CommandModule<Options, Options> = {
 
     // Start an anvil instance in the background if no RPC url is provided
     if (!args.rpc) {
+      console.log(chalk.gray("Cleaning devnode cache"));
+      const userHomeDir = homedir();
+      rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
+
       const anvilArgs = ["--block-time", "1", "--block-base-fee-per-gas", "0"];
       anvil(anvilArgs);
     }


### PR DESCRIPTION
* Prune the anvil cache before every start of `mud dev-contracts` to avoid issues with large cache files