### PR TITLE
fix(world): fix config keySchema

### DIFF
--- a/packages/world/mud.config.ts
+++ b/packages/world/mud.config.ts
@@ -69,7 +69,7 @@ export default mudConfig({
     },
     SystemHooks: {
       directory: "modules/core/tables",
-      primaryKeys: {
+      keySchema: {
         resourceSelector: "bytes32",
       },
       schema: "address[]",

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -66,119 +66,119 @@ library SystemHooks {
   }
 
   /** Get value */
-  function get(bytes32 key) internal view returns (address[] memory value) {
+  function get(bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get value (using the specified store) */
-  function get(IStore _store, bytes32 key) internal view returns (address[] memory value) {
+  function get(IStore _store, bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Set value */
-  function set(bytes32 key, address[] memory value) internal {
+  function set(bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
 
   /** Set value (using the specified store) */
-  function set(IStore _store, bytes32 key, address[] memory value) internal {
+  function set(IStore _store, bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
 
   /** Get the length of value */
-  function length(bytes32 key) internal view returns (uint256) {
+  function length(bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
   }
 
   /** Get the length of value (using the specified store) */
-  function length(IStore _store, bytes32 key) internal view returns (uint256) {
+  function length(IStore _store, bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
   }
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
-  function getItem(bytes32 key, uint256 _index) internal view returns (address) {
+  function getItem(bytes32 resourceSelector, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
-  function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
+  function getItem(IStore _store, bytes32 resourceSelector, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Push an element to value */
-  function push(bytes32 key, address _element) internal {
+  function push(bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to value (using the specified store) */
-  function push(IStore _store, bytes32 key, address _element) internal {
+  function push(IStore _store, bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from value */
-  function pop(bytes32 key) internal {
+  function pop(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
 
   /** Pop an element from value (using the specified store) */
-  function pop(IStore _store, bytes32 key) internal {
+  function pop(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
 
   /** Update an element of value at `_index` */
-  function update(bytes32 key, uint256 _index, address _element) internal {
+  function update(bytes32 resourceSelector, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
 
   /** Update an element of value (using the specified store) at `_index` */
-  function update(IStore _store, bytes32 key, uint256 _index, address _element) internal {
+  function update(IStore _store, bytes32 resourceSelector, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -193,23 +193,23 @@ library SystemHooks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
   }
 
   /* Delete all data for given keys */
-  function deleteRecord(bytes32 key) internal {
+  function deleteRecord(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
-  function deleteRecord(IStore _store, bytes32 key) internal {
+  function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = bytes32((resourceSelector));
 
     _store.deleteRecord(_tableId, _keyTuple);
   }


### PR DESCRIPTION
the issue didn't show up in CI because config isn't typechecked in CI, zod silently ignores unknown keys, and keySchema is optional
that config override also doesn't actually change the default key type, just adds a name to it