### PR TITLE
feat: make worldAddress as the caller and address of mud tests

### DIFF
--- a/examples/minimal/packages/contracts/test/CounterTest.t.sol
+++ b/examples/minimal/packages/contracts/test/CounterTest.t.sol
@@ -30,19 +30,19 @@ contract CounterTest is MudV2Test {
   function testCounter() public {
     // Expect the counter to be 1 because it was incremented in the PostDeploy script.
     bytes32 key = SingletonKey;
-    uint32 counter = CounterTable.get(world, key);
+    uint32 counter = CounterTable.get(key);
     assertEq(counter, 1);
 
     // Expect the counter to be 2 after calling increment.
     world.increment();
-    counter = CounterTable.get(world, key);
+    counter = CounterTable.get(key);
     assertEq(counter, 2);
   }
 
   function testKeysWithValue() public {
     bytes32 key = SingletonKey;
-    uint32 counter = CounterTable.get(world, key);
-    bytes32[] memory keysWithValue = getKeysWithValue(world, CounterTableTableId, CounterTable.encode(counter));
+    uint32 counter = CounterTable.get(key);
+    bytes32[] memory keysWithValue = getKeysWithValue(CounterTableTableId, CounterTable.encode(counter));
     assertEq(keysWithValue.length, 1);
   }
 }

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -53,7 +53,7 @@ const commandModule: CommandModule<Options, Options> = {
 
     const userOptions = args.forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
     try {
-      const testResult = await forge(["test", "--fork-url", forkRpc, ...userOptions], {
+      const testResult = await forge(["test", "--fork-url", forkRpc, "--sender", worldAddress, ...userOptions], {
         profile: args.profile,
       });
       console.log(testResult);

--- a/packages/std-contracts/src/test/MudV2Test.t.sol
+++ b/packages/std-contracts/src/test/MudV2Test.t.sol
@@ -8,5 +8,8 @@ contract MudV2Test is Test {
 
   function setUp() public virtual {
     worldAddress = vm.parseAddress(vm.readFile(".mudtest"));
+    // allows passing AccessControl when writing tables directly through libraries
+    // (this should be combined with `--sender` flag when calling `forge test`)
+    vm.startPrank(worldAddress);
   }
 }

--- a/templates/phaser/packages/contracts/test/CounterTest.t.sol
+++ b/templates/phaser/packages/contracts/test/CounterTest.t.sol
@@ -27,12 +27,12 @@ contract CounterTest is MudV2Test {
 
   function testCounter() public {
     // Expect the counter to be 1 because it was incremented in the PostDeploy script.
-    uint32 counter = Counter.get(world);
+    uint32 counter = Counter.get();
     assertEq(counter, 1);
 
     // Expect the counter to be 2 after calling increment.
     world.increment();
-    counter = Counter.get(world);
+    counter = Counter.get();
     assertEq(counter, 2);
   }
 }

--- a/templates/react/packages/contracts/test/CounterTest.t.sol
+++ b/templates/react/packages/contracts/test/CounterTest.t.sol
@@ -27,12 +27,12 @@ contract CounterTest is MudV2Test {
 
   function testCounter() public {
     // Expect the counter to be 1 because it was incremented in the PostDeploy script.
-    uint32 counter = Counter.get(world);
+    uint32 counter = Counter.get();
     assertEq(counter, 1);
 
     // Expect the counter to be 2 after calling increment.
     world.increment();
-    counter = Counter.get(world);
+    counter = Counter.get();
     assertEq(counter, 2);
   }
 }

--- a/templates/vanilla/packages/contracts/test/CounterTest.t.sol
+++ b/templates/vanilla/packages/contracts/test/CounterTest.t.sol
@@ -27,12 +27,12 @@ contract CounterTest is MudV2Test {
 
   function testCounter() public {
     // Expect the counter to be 1 because it was incremented in the PostDeploy script.
-    uint32 counter = Counter.get(world);
+    uint32 counter = Counter.get();
     assertEq(counter, 1);
 
     // Expect the counter to be 2 after calling increment.
     world.increment();
-    counter = Counter.get(world);
+    counter = Counter.get();
     assertEq(counter, 2);
   }
 }


### PR DESCRIPTION
fixes #940
Here I try the 1st solution, as outlined in #940

Note that while this is a slightly breaking change (for tests that use vm.startPrank, since they'd need to call vm.stopPrank 1st),
the changes to examples/templates aren't necessary, the old versions would work fine