### PR TITLE
feat(dev-tools): various improvements

### DIFF
--- a/packages/dev-tools/src/actions/TransactionSummary.tsx
+++ b/packages/dev-tools/src/actions/TransactionSummary.tsx
@@ -60,6 +60,8 @@ export function TransactionSummary({ hash }: Props) {
           .filter(isDefined)
       : null;
 
+  const blockExplorer = publicClient?.chain.blockExplorers?.default.url;
+
   return (
     <details
       onToggle={(event) => {
@@ -80,11 +82,31 @@ export function TransactionSummary({ hash }: Props) {
           {functionData?.functionName}({functionData?.args?.map((value) => serialize(value)).join(", ")})
         </div>
         {transactionReceipt.status === "fulfilled" ? (
-          <div className="flex-none font-mono text-xs text-white/40">
+          <a
+            href={
+              blockExplorer ? `${blockExplorer}/block/${transactionReceipt.value.blockNumber.toString()}` : undefined
+            }
+            target="_blank"
+            className={twMerge(
+              "flex-none font-mono text-xs text-white/40",
+              blockExplorer ? "hover:text-white/60 hover:underline" : null
+            )}
+            title={transactionReceipt.value.blockNumber.toString()}
+          >
             block {transactionReceipt.value.blockNumber.toString()}
-          </div>
+          </a>
         ) : null}
-        <div className="flex-none font-mono text-xs text-white/40">tx {truncateHex(hash)}</div>
+        <a
+          href={blockExplorer ? `${blockExplorer}/tx/${hash}` : undefined}
+          target="_blank"
+          className={twMerge(
+            "flex-none font-mono text-xs text-white/40",
+            blockExplorer ? "hover:text-white/60 hover:underline" : null
+          )}
+          title={hash}
+        >
+          tx {truncateHex(hash)}
+        </a>
         <div className="flex-none inline-flex w-4 h-4 justify-center items-center font-bold">
           {isPending ? <PendingIcon /> : isRevert ? <>⚠</> : <>✓</>}
         </div>

--- a/packages/dev-tools/src/summary/AccountSummary.tsx
+++ b/packages/dev-tools/src/summary/AccountSummary.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useStore } from "../useStore";
+import { formatUnits } from "viem";
 
-export function BurnerWalletSummary() {
+export function AccountSummary() {
   const publicClient = useStore((state) => state.publicClient);
   const walletClient = useStore((state) => state.walletClient);
 
@@ -27,8 +28,13 @@ export function BurnerWalletSummary() {
       <dt className="text-amber-200/80">Address</dt>
       <dd className="text-sm">{walletClient?.account?.address}</dd>
       <dt className="text-amber-200/80">Balance</dt>
-      <dd className="text-sm">
-        {balance?.toString()} {publicClient?.chain?.nativeCurrency.symbol}
+      <dd className="text-sm" title={balance ? balance.toString() : undefined}>
+        {publicClient && balance ? (
+          <>
+            {formatUnits(balance, publicClient.chain.nativeCurrency.decimals).replace(/(\.\d{4})\d+$/, "$1")}{" "}
+            {publicClient.chain.nativeCurrency.symbol}
+          </>
+        ) : null}
       </dd>
     </dl>
   );

--- a/packages/dev-tools/src/summary/SummaryPage.tsx
+++ b/packages/dev-tools/src/summary/SummaryPage.tsx
@@ -3,11 +3,16 @@ import { AccountSummary } from "./AccountSummary";
 import { EventsSummary } from "./EventsSummary";
 import { ActionsSummary } from "./ActionsSummary";
 import { TablesSummary } from "./TablesSummary";
+import packageJson from "../../package.json";
+
+const isLinked = Object.entries(packageJson.dependencies).some(
+  ([name, version]) => name.startsWith("@latticexyz/") && version.startsWith("link:")
+);
 
 export function SummaryPage() {
   return (
-    <>
-      <div className="p-6 space-y-8">
+    <div className="h-full flex flex-col">
+      <div className="flex-grow p-6 space-y-8 relative">
         <div className="space-y-2">
           <h1 className="font-bold text-white/40 uppercase text-xs">Network</h1>
           <NetworkSummary />
@@ -29,6 +34,9 @@ export function SummaryPage() {
           <TablesSummary />
         </div>
       </div>
-    </>
+      <div className="p-2 text-right font-mono text-xs leading-none text-white/20">
+        MUD {isLinked ? <>v{packageJson.version}</> : <>linked</>}
+      </div>
+    </div>
   );
 }

--- a/packages/dev-tools/src/summary/SummaryPage.tsx
+++ b/packages/dev-tools/src/summary/SummaryPage.tsx
@@ -1,5 +1,5 @@
 import { NetworkSummary } from "./NetworkSummary";
-import { BurnerWalletSummary } from "./BurnerWalletSummary";
+import { AccountSummary } from "./AccountSummary";
 import { EventsSummary } from "./EventsSummary";
 import { ActionsSummary } from "./ActionsSummary";
 import { TablesSummary } from "./TablesSummary";
@@ -13,8 +13,8 @@ export function SummaryPage() {
           <NetworkSummary />
         </div>
         <div className="space-y-2">
-          <h1 className="font-bold text-white/40 uppercase text-xs">Burner wallet</h1>
-          <BurnerWalletSummary />
+          <h1 className="font-bold text-white/40 uppercase text-xs">Account</h1>
+          <AccountSummary />
         </div>
         <div className="space-y-2">
           <h1 className="font-bold text-white/40 uppercase text-xs">Recent actions</h1>


### PR DESCRIPTION
see #777

- link to tx and block if block explorer is available (this has been handy while trying to debug optimistic rendering issues in testnet)
- rename "burner wallet" to "account" (since its not always gonna be a burner wallet)
- properly format balance (truncated to 4 decimals)
- shows mud version in bottom right of summary page

<img width="648" alt="image" src="https://github.com/latticexyz/mud/assets/508855/d14c127b-42ea-4dcb-b882-1985993102fd">

<img width="476" alt="image" src="https://github.com/latticexyz/mud/assets/508855/f6899371-542c-4a9a-938b-9900449b8d9b">

<img width="672" alt="image" src="https://github.com/latticexyz/mud/assets/508855/5015b080-ca85-4966-97bb-da2966bdf9e8">
