### PR TITLE
fix(std-client): skip non-existent record keys in nameKeys

### DIFF
--- a/packages/std-client/src/setup/utils.ts
+++ b/packages/std-client/src/setup/utils.ts
@@ -224,7 +224,9 @@ export function applyNetworkUpdates<C extends Components, S extends StoreConfig>
 function nameKeys(indexedRecord: Record<number, unknown>, keyNames: string[]) {
   const namedRecord: Record<string, unknown> = {};
   keyNames.forEach((key, index) => {
-    namedRecord[key] = indexedRecord[index];
+    if (index in indexedRecord) {
+      namedRecord[key] = indexedRecord[index];
+    }
   });
   return namedRecord;
 }


### PR DESCRIPTION
- we were applying `nameKeys` to partial updates but still naming all keys, including those that weren't present in the partial update (their value was set to `undefined`, but the key was still created in the object). This caused the partial update logic in `storeCache` to fail, because now all keys were overridden, including those not present in the original partial update.
- this PR makes `nameKeys` only name keys present in the original object and skip non-existent ones