### PR TITLE
feat(mode): abi decode keys instead of custom mud decoding

### DIFF
--- a/packages/services/pkg/mode/ingress/handlers.go
+++ b/packages/services/pkg/mode/ingress/handlers.go
@@ -137,8 +137,7 @@ func (il *IngressLayer) handleSetFieldEventInsertRow(event *storecore.StorecoreS
 	// Decode the row field data (value).
 	decodedFieldData := storecore.DecodeDataField__DecodedData(event.Data, *tableSchema.StoreCoreSchemaTypeKV.Value, event.SchemaIndex)
 	// Decode the row key.
-	aggregateKey := mode.AggregateKey(event.Key)
-	decodedKeyData := storecore.DecodeData(aggregateKey, *tableSchema.StoreCoreSchemaTypeKV.Key)
+	decodedKeyData := storecore.DecodeKeyData(event.Key, *tableSchema.StoreCoreSchemaTypeKV.Key)
 
 	// Create a row for the table from the decoded data.
 	row := write.RowFromDecodedData(decodedKeyData, decodedFieldData, tableSchema)
@@ -500,8 +499,7 @@ func (il *IngressLayer) handleGenericTableEvent(event *storecore.StorecoreStoreS
 	decodedFieldData := storecore.DecodeData(event.Data, *tableSchema.StoreCoreSchemaTypeKV.Value)
 
 	// Decode the row key.
-	aggregateKey := mode.AggregateKey(event.Key)
-	decodedKeyData := storecore.DecodeData(aggregateKey, *tableSchema.StoreCoreSchemaTypeKV.Key)
+	decodedKeyData := storecore.DecodeKeyData(event.Key, *tableSchema.StoreCoreSchemaTypeKV.Key)
 
 	// Create a row for the table from the decoded data.
 	row := write.RowFromDecodedData(decodedKeyData, decodedFieldData, tableSchema)

--- a/packages/services/pkg/mode/keys.go
+++ b/packages/services/pkg/mode/keys.go
@@ -61,8 +61,7 @@ func KeyToString(keys [][32]byte) []string {
 //   - (map[string]interface{}): A map of filter objects.
 func KeyToFilter(tableSchema *TableSchema, key [][32]byte) map[string]interface{} {
 	// First decode the key data so that it's easier to work with.
-	aggregateKey := AggregateKey(key)
-	decodedKeyData := storecore.DecodeData(aggregateKey, *tableSchema.StoreCoreSchemaTypeKV.Key)
+	decodedKeyData := storecore.DecodeKeyData(key, *tableSchema.StoreCoreSchemaTypeKV.Key)
 
 	filter := make(map[string]interface{})
 

--- a/packages/services/pkg/mode/storecore/encoding.go
+++ b/packages/services/pkg/mode/storecore/encoding.go
@@ -7,8 +7,10 @@ import (
 	"math/big"
 	"strings"
 
+	abi_geth "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"go.uber.org/zap"
 )
 
@@ -451,6 +453,94 @@ func DecodeDataField__DecodedData(encoding []byte, schemaTypePair SchemaTypePair
 	logger.GetLogger().Fatal("could not decode data field at index", zap.Uint8("index", index))
 	return nil
 
+}
+
+// MapDecodedParameterBytes takes in a value that is a byte slice and maps it to a format that is
+// compatible with MODE / Postgres backend by calling handleBytes() after parsing the interface{}
+// into the correct fixed-size byte slice (e.g. [32]byte for BYTES32]) using a switch. This is
+// needed since data comes in as fixed size byte slices from the ABI Decoder.
+func MapDecodedParameterBytes(value interface{}, schemaType SchemaType) interface{} {
+	// TODO: finish
+	switch schemaType {
+	case BYTES4:
+		v := value.([4]byte)
+		return handleBytes(v[:])
+	case BYTES8:
+		v := value.([8]byte)
+		return handleBytes(v[:])
+	case BYTES16:
+		v := value.([16]byte)
+		return handleBytes(v[:])
+	case BYTES32:
+		v := value.([32]byte)
+		return handleBytes(v[:])
+	default:
+		return value
+	}
+}
+
+// MapDecodedParameterAddress takes in a value that is a common.Address and maps it to a format
+// that is compatible with MODE / Postgres (string).
+func MapDecodedParameterAddress(value interface{}, schemaType SchemaType) interface{} {
+	v := value.(common.Address)
+	return handleAddress(v[:])
+}
+
+// MapDecodedParameter takes in a value that is an interface{} and maps it to a format that is
+// compatible with MODE / Postgres.
+func MapDecodedParameter(value interface{}, schemaType SchemaType) interface{} {
+	// Only address and bytes types need to be mapped.
+	if schemaType >= BYTES1 && schemaType <= BYTES32 {
+		return MapDecodedParameterBytes(value, schemaType)
+	} else if schemaType == ADDRESS {
+		return MapDecodedParameterAddress(value, schemaType)
+	} else {
+		return value
+	}
+}
+
+// DecodeParameter ABI decodes the given an array of byte slices `data` into an interface{} using the
+// provided schema type `schemaType`.
+func ABIDecodeParameter(schemaType SchemaType, data [32]byte) (interface{}, error) {
+	args := make(abi_geth.Arguments, 0)
+
+	arg := abi_geth.Argument{}
+	var err error
+	arg.Type, err = abi_geth.NewType(strings.ToLower(schemaType.String()), "", nil)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, arg)
+
+	values, err := args.UnpackValues(data[:])
+	return MapDecodedParameter(values[0], schemaType), err
+}
+
+// DecodeKeyData decodes the given an array of byte slices `encodedKey` into a `DecodedData` object
+// using the provided schema type pair `schemaTypePair`.
+//
+// Parameters:
+// - encodedKey ([32]byte) - The byte slices of a key to be decoded.
+// - schemaTypePair (SchemaTypePair) - The schema type pair used to decode the byte slices.
+//
+// Returns:
+// - (*DecodedData) - A pointer to the `DecodedData` object.
+func DecodeKeyData(encodedKey [][32]byte, schemaTypePair SchemaTypePair) *DecodedData {
+	// Where the decoded data is stored.
+	data := NewDecodedDataFromSchemaTypePair(schemaTypePair)
+
+	for idx, fieldType := range schemaTypePair.Static {
+		decodedKeyData, err := ABIDecodeParameter(fieldType, encodedKey[idx])
+		if err != nil {
+			panic(err)
+		}
+		data.Add(&DataSchemaType__Struct{
+			Data:       decodedKeyData,
+			SchemaType: fieldType,
+		})
+	}
+
+	return data
 }
 
 // DecodeData decodes the given byte slice `encoding` into a `DecodedData` object

--- a/packages/services/pkg/mode/storecore/encoding_test.go
+++ b/packages/services/pkg/mode/storecore/encoding_test.go
@@ -48,3 +48,54 @@ func TestDecodeData(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeKeyData(t *testing.T) {
+	encoding := "0x000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000001"
+	encodingBytes := hexutil.MustDecode(encoding)
+	var key [][32]byte
+	for i := 0; i < len(encodingBytes); i += 32 {
+		var temp [32]byte
+		copy(temp[:], encodingBytes[i:i+32])
+		key = append(key, temp)
+	}
+
+	schemaTypePair := SchemaTypePair{
+		Static: []SchemaType{
+			UINT32,
+			UINT32,
+		},
+		Dynamic:          []SchemaType{},
+		StaticDataLength: 8,
+	}
+	expectedTypes := []SchemaType{
+		UINT32,
+		UINT32,
+	}
+	expectedValues := []DataSchemaType__Struct{
+		{
+			Data:       uint32(12),
+			SchemaType: UINT32,
+		},
+		{
+			Data:       uint32(1),
+			SchemaType: UINT32,
+		},
+	}
+
+	decodedData := DecodeKeyData(key, schemaTypePair)
+
+	if decodedData.Length() != schemaTypePair.Length() {
+		t.Errorf("Expected length to be %d, got %d", schemaTypePair.Length(), decodedData.Length())
+	}
+	for i := 0; i < decodedData.Length(); i++ {
+		if decodedData.types[i] != expectedTypes[i] {
+			t.Errorf("Expected type to be %s, got %s", expectedTypes[i], decodedData.types[i])
+		}
+		if decodedData.values[i].Data.(uint32) != expectedValues[i].Data.(uint32) {
+			t.Errorf("Expected value to be %d, got %d", expectedValues[i].Data.(uint32), decodedData.values[i].Data.(uint32))
+		}
+		if decodedData.values[i].SchemaType != expectedValues[i].SchemaType {
+			t.Errorf("Expected schema type to be %s, got %s", expectedValues[i].SchemaType, decodedData.values[i].SchemaType)
+		}
+	}
+}


### PR DESCRIPTION
One TODO is figuring out how to best handle the mapping of fixed-size byte arrays that ABI decoding returns. Postgres really doesn't like these inserted like this, so we hex encode. But them being fixed sized means that the conversion from interface{} -> []byte doesn't work