### PR TITLE
fix(store): `tableId` should be bytes32

### DIFF
--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -34,7 +34,7 @@ library StoreCore {
     registerSchema(
       StoreCoreInternal.SCHEMA_TABLE,
       SchemaLib.encode(SchemaType.BYTES32, SchemaType.BYTES32), // The Schema table's valueSchema is { valueSchema: BYTES32, keySchema: BYTES32 }
-      SchemaLib.encode(SchemaType.UINT256) // The Schema table's keySchema is { tableId: UINT256 }
+      SchemaLib.encode(SchemaType.BYTES32) // The Schema table's keySchema is { tableId: BYTES32 }
     );
 
     // Register other internal tables


### PR DESCRIPTION
found this when digging around for reasons I'm not seeing key schema for `mudstore.schema` records propagate to client

this doesn't fix anything but seems like it was meant to be `bytes32` to match the rest of table IDs?