### PR TITLE
fix(network): decode negative keys

### DIFF
--- a/packages/network/src/v2/schemas/decodeKeyTuple.ts
+++ b/packages/network/src/v2/schemas/decodeKeyTuple.ts
@@ -1,11 +1,17 @@
-import { SchemaTypeToAbiType } from "@latticexyz/schema-type";
+import { StaticSchemaType, getStaticByteLength } from "@latticexyz/schema-type";
+
 import { Schema } from "../common";
-import { decodeAbiParameters } from "viem";
+import { decodeStaticField } from "./decodeStaticField";
+import { hexToArray } from "@latticexyz/utils";
 
 export function decodeKeyTuple(keySchema: Schema, keyTuple: unknown[]) {
-  const abiTypes = keySchema.staticFields.map((schemaType) => SchemaTypeToAbiType[schemaType]);
-  const decodedKeys = keyTuple.map(
-    (key, index) => decodeAbiParameters([{ type: abiTypes[index] }], key as `0x${string}`)[0]
-  );
+  const decodedKeys = keyTuple.map((key, index) => {
+    const schemaType = keySchema.staticFields[index] as StaticSchemaType;
+    const byteLength = getStaticByteLength(schemaType);
+    const bytes = hexToArray(key as string);
+    // Key data is padded, so need offset
+    const offset = bytes.length - byteLength;
+    return decodeStaticField(keySchema.staticFields[index] as StaticSchemaType, bytes, offset);
+  });
   return decodedKeys.reduce<Record<number, unknown>>((acc, curr, i) => ({ ...acc, [i]: curr }), {});
 }


### PR DESCRIPTION
- viem's decodeAbiParameters doesn't expect 0 padding for negatives, but expects f padding
- this causes negative keys to be decoded as large positive numbers in decodeKeyTuple
- fix is to use decodeStaticField instead of viem
- see conversation here: https://discord.com/channels/865335009915961364/1111501157077094533/1111503609058828319