### PR TITLE
fix: usage of hasEntity

### DIFF
--- a/packages/std-client/src/systems/ActionSystem/createActionSystem.ts
+++ b/packages/std-client/src/systems/ActionSystem/createActionSystem.ts
@@ -67,7 +67,7 @@ export function createActionSystem<M = undefined>(world: World, txReduced$: Obse
   function add<C extends Components, T>(actionRequest: ActionRequest<C, T, M>): Entity {
     // Prevent the same actions from being scheduled multiple times
     const existingAction = world.hasEntity(actionRequest.id as Entity);
-    if (existingAction != null) {
+    if (existingAction) {
       console.warn(`Action with id ${actionRequest.id} is already requested.`);
       return actionRequest.id as Entity;
     }


### PR DESCRIPTION
`hasEntity` returns a boolean (https://github.com/latticexyz/mud/blob/main/packages/recs/src/World.ts#L49), but the add function in ActionSystem is checking against null.


Note: we should update the linter to require using triple equal (!==) to prevent bugs like this in the future.