### PR TITLE
build: use older foundry version in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
+      # TODO update when "max fee per gas" issue is fixed for latest nightly
         version: nightly-87bc53fc6c874bd4c92d97ed180b949e3a36d78c
 
     - name: Setup protoc

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: nightly-87bc53fc6c874bd4c92d97ed180b949e3a36d78c
 
     - name: Setup protoc
       uses: arduino/setup-protoc@v1


### PR DESCRIPTION
fixes the recent examples/templates CI failures
@Kooshaba this is based on ur comments from discord, do u have more context on the root issue?