### PR TITLE
fix(integration-sandbox): use custom setup status

### DIFF
--- a/integration-sandbox/packages/client-vanilla/index.html
+++ b/integration-sandbox/packages/client-vanilla/index.html
@@ -11,8 +11,11 @@
       document.getElementById("button-reset").addEventListener("click", () => set([]));
       document.getElementById("button-push-many").addEventListener("click", () => pushRange(0, 5000));
       document.getElementById("button-push-one").addEventListener("click", () => push(123));
+
+      document.getElementById("setup-status").innerHTML = "finished"
     </script>
     <div>
+      <div id="setup-status" title="Setup status">loading</div>
       <div>List length: <span id="list-length" data-testid="list-length">unset</span></div>
       <div>First item: <span id="first-item" data-testid="first-item">unset</span></div>
       <div>Last item: <span id="last-item" data-testid="last-item">unset</span></div>

--- a/integration-sandbox/packages/contracts/test/index.test.ts
+++ b/integration-sandbox/packages/contracts/test/index.test.ts
@@ -71,8 +71,8 @@ describe("arrays", async () => {
     await expect(pushManyButton).toBeVisible();
     await expect(pushOneButton).toBeVisible();
 
-    // make sure scripts are loaded
-    await page.waitForLoadState("load");
+    // make sure setup is finished before clicking buttons
+    await expect(page.getByTitle("Setup status")).toHaveText("finished");
 
     await resetButton.click();
     await expect(listLength).toHaveText("0");


### PR DESCRIPTION
trying the original fix from https://github.com/latticexyz/mud/pull/991 (which at the end got replaced by `load` event, which unfortunately didn't fix flakiness)