### PR TITLE
style: clean up codegen output

### DIFF
--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -68,7 +68,7 @@ library CounterTable {
   /** Get value */
   function get(bytes32 key) internal view returns (uint32 value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -77,7 +77,7 @@ library CounterTable {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (uint32 value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -86,7 +86,7 @@ library CounterTable {
   /** Set value */
   function set(bytes32 key, uint32 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -94,7 +94,7 @@ library CounterTable {
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -107,13 +107,13 @@ library CounterTable {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -121,7 +121,7 @@ library CounterTable {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
@@ -70,9 +70,9 @@ library Inventory {
   /** Get amount */
   function get(address owner, uint32 item, uint32 itemVariant) internal view returns (uint32 amount) {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -81,9 +81,9 @@ library Inventory {
   /** Get amount (using the specified store) */
   function get(IStore _store, address owner, uint32 item, uint32 itemVariant) internal view returns (uint32 amount) {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -92,9 +92,9 @@ library Inventory {
   /** Set amount */
   function set(address owner, uint32 item, uint32 itemVariant, uint32 amount) internal {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((amount)));
   }
@@ -102,9 +102,9 @@ library Inventory {
   /** Set amount (using the specified store) */
   function set(IStore _store, address owner, uint32 item, uint32 itemVariant, uint32 amount) internal {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((amount)));
   }
@@ -121,17 +121,17 @@ library Inventory {
     uint32 itemVariant
   ) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
   }
 
   /* Delete all data for given keys */
   function deleteRecord(address owner, uint32 item, uint32 itemVariant) internal {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -139,9 +139,9 @@ library Inventory {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, address owner, uint32 item, uint32 itemVariant) internal {
     bytes32[] memory _keyTuple = new bytes32[](3);
-    _keyTuple[0] = bytes32(uint256(uint160((owner))));
-    _keyTuple[1] = bytes32(uint256((item)));
-    _keyTuple[2] = bytes32(uint256((itemVariant)));
+    _keyTuple[0] = bytes32(uint256(uint160(owner)));
+    _keyTuple[1] = bytes32(uint256(item));
+    _keyTuple[2] = bytes32(uint256(itemVariant));
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -84,7 +84,7 @@ library Dynamics1 {
   /** Get staticB32 */
   function getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -93,7 +93,7 @@ library Dynamics1 {
   /** Get staticB32 (using the specified store) */
   function getStaticB32(IStore _store, bytes32 key) internal view returns (bytes32[1] memory staticB32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -102,7 +102,7 @@ library Dynamics1 {
   /** Set staticB32 */
   function setStaticB32(bytes32 key, bytes32[1] memory staticB32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
@@ -110,7 +110,7 @@ library Dynamics1 {
   /** Set staticB32 (using the specified store) */
   function setStaticB32(IStore _store, bytes32 key, bytes32[1] memory staticB32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
@@ -118,7 +118,7 @@ library Dynamics1 {
   /** Get the length of staticB32 */
   function lengthStaticB32(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -127,7 +127,7 @@ library Dynamics1 {
   /** Get the length of staticB32 (using the specified store) */
   function lengthStaticB32(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -136,7 +136,7 @@ library Dynamics1 {
   /** Get an item of staticB32 (unchecked, returns invalid data if index overflows) */
   function getItemStaticB32(bytes32 key, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -145,7 +145,7 @@ library Dynamics1 {
   /** Get an item of staticB32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticB32(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -154,7 +154,7 @@ library Dynamics1 {
   /** Push an element to staticB32 */
   function pushStaticB32(bytes32 key, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -162,7 +162,7 @@ library Dynamics1 {
   /** Push an element to staticB32 (using the specified store) */
   function pushStaticB32(IStore _store, bytes32 key, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -170,7 +170,7 @@ library Dynamics1 {
   /** Pop an element from staticB32 */
   function popStaticB32(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -178,7 +178,7 @@ library Dynamics1 {
   /** Pop an element from staticB32 (using the specified store) */
   function popStaticB32(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -186,7 +186,7 @@ library Dynamics1 {
   /** Update an element of staticB32 at `_index` */
   function updateStaticB32(bytes32 key, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -194,7 +194,7 @@ library Dynamics1 {
   /** Update an element of staticB32 (using the specified store) at `_index` */
   function updateStaticB32(IStore _store, bytes32 key, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -202,7 +202,7 @@ library Dynamics1 {
   /** Get staticI32 */
   function getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
@@ -211,7 +211,7 @@ library Dynamics1 {
   /** Get staticI32 (using the specified store) */
   function getStaticI32(IStore _store, bytes32 key) internal view returns (int32[2] memory staticI32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
@@ -220,7 +220,7 @@ library Dynamics1 {
   /** Set staticI32 */
   function setStaticI32(bytes32 key, int32[2] memory staticI32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
@@ -228,7 +228,7 @@ library Dynamics1 {
   /** Set staticI32 (using the specified store) */
   function setStaticI32(IStore _store, bytes32 key, int32[2] memory staticI32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
@@ -236,7 +236,7 @@ library Dynamics1 {
   /** Get the length of staticI32 */
   function lengthStaticI32(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -245,7 +245,7 @@ library Dynamics1 {
   /** Get the length of staticI32 (using the specified store) */
   function lengthStaticI32(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -254,7 +254,7 @@ library Dynamics1 {
   /** Get an item of staticI32 (unchecked, returns invalid data if index overflows) */
   function getItemStaticI32(bytes32 key, uint256 _index) internal view returns (int32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -263,7 +263,7 @@ library Dynamics1 {
   /** Get an item of staticI32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticI32(IStore _store, bytes32 key, uint256 _index) internal view returns (int32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -272,7 +272,7 @@ library Dynamics1 {
   /** Push an element to staticI32 */
   function pushStaticI32(bytes32 key, int32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -280,7 +280,7 @@ library Dynamics1 {
   /** Push an element to staticI32 (using the specified store) */
   function pushStaticI32(IStore _store, bytes32 key, int32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -288,7 +288,7 @@ library Dynamics1 {
   /** Pop an element from staticI32 */
   function popStaticI32(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -296,7 +296,7 @@ library Dynamics1 {
   /** Pop an element from staticI32 (using the specified store) */
   function popStaticI32(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -304,7 +304,7 @@ library Dynamics1 {
   /** Update an element of staticI32 at `_index` */
   function updateStaticI32(bytes32 key, uint256 _index, int32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -312,7 +312,7 @@ library Dynamics1 {
   /** Update an element of staticI32 (using the specified store) at `_index` */
   function updateStaticI32(IStore _store, bytes32 key, uint256 _index, int32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -320,7 +320,7 @@ library Dynamics1 {
   /** Get staticU128 */
   function getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
@@ -329,7 +329,7 @@ library Dynamics1 {
   /** Get staticU128 (using the specified store) */
   function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
@@ -338,7 +338,7 @@ library Dynamics1 {
   /** Set staticU128 */
   function setStaticU128(bytes32 key, uint128[3] memory staticU128) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
@@ -346,7 +346,7 @@ library Dynamics1 {
   /** Set staticU128 (using the specified store) */
   function setStaticU128(IStore _store, bytes32 key, uint128[3] memory staticU128) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
@@ -354,7 +354,7 @@ library Dynamics1 {
   /** Get the length of staticU128 */
   function lengthStaticU128(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 16;
@@ -363,7 +363,7 @@ library Dynamics1 {
   /** Get the length of staticU128 (using the specified store) */
   function lengthStaticU128(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 16;
@@ -372,7 +372,7 @@ library Dynamics1 {
   /** Get an item of staticU128 (unchecked, returns invalid data if index overflows) */
   function getItemStaticU128(bytes32 key, uint256 _index) internal view returns (uint128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -381,7 +381,7 @@ library Dynamics1 {
   /** Get an item of staticU128 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticU128(IStore _store, bytes32 key, uint256 _index) internal view returns (uint128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -390,7 +390,7 @@ library Dynamics1 {
   /** Push an element to staticU128 */
   function pushStaticU128(bytes32 key, uint128 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -398,7 +398,7 @@ library Dynamics1 {
   /** Push an element to staticU128 (using the specified store) */
   function pushStaticU128(IStore _store, bytes32 key, uint128 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -406,7 +406,7 @@ library Dynamics1 {
   /** Pop an element from staticU128 */
   function popStaticU128(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 16);
   }
@@ -414,7 +414,7 @@ library Dynamics1 {
   /** Pop an element from staticU128 (using the specified store) */
   function popStaticU128(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 16);
   }
@@ -422,7 +422,7 @@ library Dynamics1 {
   /** Update an element of staticU128 at `_index` */
   function updateStaticU128(bytes32 key, uint256 _index, uint128 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
   }
@@ -430,7 +430,7 @@ library Dynamics1 {
   /** Update an element of staticU128 (using the specified store) at `_index` */
   function updateStaticU128(IStore _store, bytes32 key, uint256 _index, uint128 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
   }
@@ -438,7 +438,7 @@ library Dynamics1 {
   /** Get staticAddrs */
   function getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -447,7 +447,7 @@ library Dynamics1 {
   /** Get staticAddrs (using the specified store) */
   function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -456,7 +456,7 @@ library Dynamics1 {
   /** Set staticAddrs */
   function setStaticAddrs(bytes32 key, address[4] memory staticAddrs) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
@@ -464,7 +464,7 @@ library Dynamics1 {
   /** Set staticAddrs (using the specified store) */
   function setStaticAddrs(IStore _store, bytes32 key, address[4] memory staticAddrs) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
@@ -472,7 +472,7 @@ library Dynamics1 {
   /** Get the length of staticAddrs */
   function lengthStaticAddrs(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 20;
@@ -481,7 +481,7 @@ library Dynamics1 {
   /** Get the length of staticAddrs (using the specified store) */
   function lengthStaticAddrs(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 20;
@@ -490,7 +490,7 @@ library Dynamics1 {
   /** Get an item of staticAddrs (unchecked, returns invalid data if index overflows) */
   function getItemStaticAddrs(bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -499,7 +499,7 @@ library Dynamics1 {
   /** Get an item of staticAddrs (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticAddrs(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -508,7 +508,7 @@ library Dynamics1 {
   /** Push an element to staticAddrs */
   function pushStaticAddrs(bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -516,7 +516,7 @@ library Dynamics1 {
   /** Push an element to staticAddrs (using the specified store) */
   function pushStaticAddrs(IStore _store, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -524,7 +524,7 @@ library Dynamics1 {
   /** Pop an element from staticAddrs */
   function popStaticAddrs(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 20);
   }
@@ -532,7 +532,7 @@ library Dynamics1 {
   /** Pop an element from staticAddrs (using the specified store) */
   function popStaticAddrs(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 20);
   }
@@ -540,7 +540,7 @@ library Dynamics1 {
   /** Update an element of staticAddrs at `_index` */
   function updateStaticAddrs(bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
   }
@@ -548,7 +548,7 @@ library Dynamics1 {
   /** Update an element of staticAddrs (using the specified store) at `_index` */
   function updateStaticAddrs(IStore _store, bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
   }
@@ -556,7 +556,7 @@ library Dynamics1 {
   /** Get staticBools */
   function getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
@@ -565,7 +565,7 @@ library Dynamics1 {
   /** Get staticBools (using the specified store) */
   function getStaticBools(IStore _store, bytes32 key) internal view returns (bool[5] memory staticBools) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
@@ -574,7 +574,7 @@ library Dynamics1 {
   /** Set staticBools */
   function setStaticBools(bytes32 key, bool[5] memory staticBools) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
@@ -582,7 +582,7 @@ library Dynamics1 {
   /** Set staticBools (using the specified store) */
   function setStaticBools(IStore _store, bytes32 key, bool[5] memory staticBools) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
@@ -590,7 +590,7 @@ library Dynamics1 {
   /** Get the length of staticBools */
   function lengthStaticBools(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 1;
@@ -599,7 +599,7 @@ library Dynamics1 {
   /** Get the length of staticBools (using the specified store) */
   function lengthStaticBools(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 1;
@@ -608,7 +608,7 @@ library Dynamics1 {
   /** Get an item of staticBools (unchecked, returns invalid data if index overflows) */
   function getItemStaticBools(bytes32 key, uint256 _index) internal view returns (bool) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -617,7 +617,7 @@ library Dynamics1 {
   /** Get an item of staticBools (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticBools(IStore _store, bytes32 key, uint256 _index) internal view returns (bool) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -626,7 +626,7 @@ library Dynamics1 {
   /** Push an element to staticBools */
   function pushStaticBools(bytes32 key, bool _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -634,7 +634,7 @@ library Dynamics1 {
   /** Push an element to staticBools (using the specified store) */
   function pushStaticBools(IStore _store, bytes32 key, bool _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -642,7 +642,7 @@ library Dynamics1 {
   /** Pop an element from staticBools */
   function popStaticBools(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1);
   }
@@ -650,7 +650,7 @@ library Dynamics1 {
   /** Pop an element from staticBools (using the specified store) */
   function popStaticBools(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 4, 1);
   }
@@ -658,7 +658,7 @@ library Dynamics1 {
   /** Update an element of staticBools at `_index` */
   function updateStaticBools(bytes32 key, uint256 _index, bool _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
   }
@@ -666,7 +666,7 @@ library Dynamics1 {
   /** Update an element of staticBools (using the specified store) at `_index` */
   function updateStaticBools(IStore _store, bytes32 key, uint256 _index, bool _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
   }
@@ -674,7 +674,7 @@ library Dynamics1 {
   /** Get the full data */
   function get(bytes32 key) internal view returns (Dynamics1Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -683,7 +683,7 @@ library Dynamics1 {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Dynamics1Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -701,7 +701,7 @@ library Dynamics1 {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -719,7 +719,7 @@ library Dynamics1 {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -797,13 +797,13 @@ library Dynamics1 {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -811,7 +811,7 @@ library Dynamics1 {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -78,7 +78,7 @@ library Dynamics2 {
   /** Get u64 */
   function getU64(bytes32 key) internal view returns (uint64[] memory u64) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
@@ -87,7 +87,7 @@ library Dynamics2 {
   /** Get u64 (using the specified store) */
   function getU64(IStore _store, bytes32 key) internal view returns (uint64[] memory u64) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
@@ -96,7 +96,7 @@ library Dynamics2 {
   /** Set u64 */
   function setU64(bytes32 key, uint64[] memory u64) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
   }
@@ -104,7 +104,7 @@ library Dynamics2 {
   /** Set u64 (using the specified store) */
   function setU64(IStore _store, bytes32 key, uint64[] memory u64) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
   }
@@ -112,7 +112,7 @@ library Dynamics2 {
   /** Get the length of u64 */
   function lengthU64(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 8;
@@ -121,7 +121,7 @@ library Dynamics2 {
   /** Get the length of u64 (using the specified store) */
   function lengthU64(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 8;
@@ -130,7 +130,7 @@ library Dynamics2 {
   /** Get an item of u64 (unchecked, returns invalid data if index overflows) */
   function getItemU64(bytes32 key, uint256 _index) internal view returns (uint64) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
     return (uint64(Bytes.slice8(_blob, 0)));
@@ -139,7 +139,7 @@ library Dynamics2 {
   /** Get an item of u64 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemU64(IStore _store, bytes32 key, uint256 _index) internal view returns (uint64) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
     return (uint64(Bytes.slice8(_blob, 0)));
@@ -148,7 +148,7 @@ library Dynamics2 {
   /** Push an element to u64 */
   function pushU64(bytes32 key, uint64 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -156,7 +156,7 @@ library Dynamics2 {
   /** Push an element to u64 (using the specified store) */
   function pushU64(IStore _store, bytes32 key, uint64 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -164,7 +164,7 @@ library Dynamics2 {
   /** Pop an element from u64 */
   function popU64(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 8);
   }
@@ -172,7 +172,7 @@ library Dynamics2 {
   /** Pop an element from u64 (using the specified store) */
   function popU64(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 8);
   }
@@ -180,7 +180,7 @@ library Dynamics2 {
   /** Update an element of u64 at `_index` */
   function updateU64(bytes32 key, uint256 _index, uint64 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
   }
@@ -188,7 +188,7 @@ library Dynamics2 {
   /** Update an element of u64 (using the specified store) at `_index` */
   function updateU64(IStore _store, bytes32 key, uint256 _index, uint64 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
   }
@@ -196,7 +196,7 @@ library Dynamics2 {
   /** Get str */
   function getStr(bytes32 key) internal view returns (string memory str) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (string(_blob));
@@ -205,7 +205,7 @@ library Dynamics2 {
   /** Get str (using the specified store) */
   function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (string(_blob));
@@ -214,7 +214,7 @@ library Dynamics2 {
   /** Set str */
   function setStr(bytes32 key, string memory str) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((str)));
   }
@@ -222,7 +222,7 @@ library Dynamics2 {
   /** Set str (using the specified store) */
   function setStr(IStore _store, bytes32 key, string memory str) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, bytes((str)));
   }
@@ -230,7 +230,7 @@ library Dynamics2 {
   /** Get the length of str */
   function lengthStr(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -239,7 +239,7 @@ library Dynamics2 {
   /** Get the length of str (using the specified store) */
   function lengthStr(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -248,7 +248,7 @@ library Dynamics2 {
   /** Get an item of str (unchecked, returns invalid data if index overflows) */
   function getItemStr(bytes32 key, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -257,7 +257,7 @@ library Dynamics2 {
   /** Get an item of str (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStr(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -266,7 +266,7 @@ library Dynamics2 {
   /** Push a slice to str */
   function pushStr(bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -274,7 +274,7 @@ library Dynamics2 {
   /** Push a slice to str (using the specified store) */
   function pushStr(IStore _store, bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -282,7 +282,7 @@ library Dynamics2 {
   /** Pop a slice from str */
   function popStr(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -290,7 +290,7 @@ library Dynamics2 {
   /** Pop a slice from str (using the specified store) */
   function popStr(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -298,7 +298,7 @@ library Dynamics2 {
   /** Update a slice of str at `_index` */
   function updateStr(bytes32 key, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -306,7 +306,7 @@ library Dynamics2 {
   /** Update a slice of str (using the specified store) at `_index` */
   function updateStr(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -314,7 +314,7 @@ library Dynamics2 {
   /** Get b */
   function getB(bytes32 key) internal view returns (bytes memory b) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (bytes(_blob));
@@ -323,7 +323,7 @@ library Dynamics2 {
   /** Get b (using the specified store) */
   function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (bytes(_blob));
@@ -332,7 +332,7 @@ library Dynamics2 {
   /** Set b */
   function setB(bytes32 key, bytes memory b) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, bytes((b)));
   }
@@ -340,7 +340,7 @@ library Dynamics2 {
   /** Set b (using the specified store) */
   function setB(IStore _store, bytes32 key, bytes memory b) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, bytes((b)));
   }
@@ -348,7 +348,7 @@ library Dynamics2 {
   /** Get the length of b */
   function lengthB(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 1;
@@ -357,7 +357,7 @@ library Dynamics2 {
   /** Get the length of b (using the specified store) */
   function lengthB(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 1;
@@ -366,7 +366,7 @@ library Dynamics2 {
   /** Get an item of b (unchecked, returns invalid data if index overflows) */
   function getItemB(bytes32 key, uint256 _index) internal view returns (bytes memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -375,7 +375,7 @@ library Dynamics2 {
   /** Get an item of b (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemB(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -384,7 +384,7 @@ library Dynamics2 {
   /** Push a slice to b */
   function pushB(bytes32 key, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
   }
@@ -392,7 +392,7 @@ library Dynamics2 {
   /** Push a slice to b (using the specified store) */
   function pushB(IStore _store, bytes32 key, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
   }
@@ -400,7 +400,7 @@ library Dynamics2 {
   /** Pop a slice from b */
   function popB(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 1);
   }
@@ -408,7 +408,7 @@ library Dynamics2 {
   /** Pop a slice from b (using the specified store) */
   function popB(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 1);
   }
@@ -416,7 +416,7 @@ library Dynamics2 {
   /** Update a slice of b at `_index` */
   function updateB(bytes32 key, uint256 _index, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
   }
@@ -424,7 +424,7 @@ library Dynamics2 {
   /** Update a slice of b (using the specified store) at `_index` */
   function updateB(IStore _store, bytes32 key, uint256 _index, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
   }
@@ -432,7 +432,7 @@ library Dynamics2 {
   /** Get the full data */
   function get(bytes32 key) internal view returns (Dynamics2Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -441,7 +441,7 @@ library Dynamics2 {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Dynamics2Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -452,7 +452,7 @@ library Dynamics2 {
     bytes memory _data = encode(u64, str, b);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -462,7 +462,7 @@ library Dynamics2 {
     bytes memory _data = encode(u64, str, b);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -516,13 +516,13 @@ library Dynamics2 {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -530,7 +530,7 @@ library Dynamics2 {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -70,7 +70,7 @@ library Ephemeral {
     bytes memory _data = encode(value);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -80,7 +80,7 @@ library Ephemeral {
     bytes memory _data = encode(value);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -93,6 +93,6 @@ library Ephemeral {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -107,11 +107,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (uint256 v1) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -131,11 +131,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (uint256 v1) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -146,11 +146,11 @@ library Statics {
   /** Set v1 */
   function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -170,11 +170,11 @@ library Statics {
     uint256 v1
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -192,11 +192,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (int32 v2) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -216,11 +216,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (int32 v2) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -231,11 +231,11 @@ library Statics {
   /** Set v2 */
   function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -255,11 +255,11 @@ library Statics {
     int32 v2
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -277,11 +277,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (bytes16 v3) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -301,11 +301,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (bytes16 v3) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -316,11 +316,11 @@ library Statics {
   /** Set v3 */
   function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -340,11 +340,11 @@ library Statics {
     bytes16 v3
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -362,11 +362,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (address v4) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -386,11 +386,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (address v4) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -401,11 +401,11 @@ library Statics {
   /** Set v4 */
   function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -425,11 +425,11 @@ library Statics {
     address v4
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -447,11 +447,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (bool v5) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -471,11 +471,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (bool v5) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -486,11 +486,11 @@ library Statics {
   /** Set v5 */
   function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -510,11 +510,11 @@ library Statics {
     bool v5
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -532,11 +532,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum1 v6) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -556,11 +556,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum1 v6) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -571,11 +571,11 @@ library Statics {
   /** Set v6 */
   function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -595,11 +595,11 @@ library Statics {
     Enum1 v6
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -617,11 +617,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum2 v7) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -641,11 +641,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum2 v7) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -656,11 +656,11 @@ library Statics {
   /** Set v7 */
   function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -680,11 +680,11 @@ library Statics {
     Enum2 v7
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -702,11 +702,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -726,11 +726,11 @@ library Statics {
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -758,11 +758,11 @@ library Statics {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
 
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -790,11 +790,11 @@ library Statics {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
 
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -887,11 +887,11 @@ library Statics {
     Enum2 k7
   ) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
   }
@@ -899,11 +899,11 @@ library Statics {
   /* Delete all data for given keys */
   function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
@@ -922,11 +922,11 @@ library Statics {
     Enum2 k7
   ) internal {
     bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256((k1)));
-    _keyTuple[1] = bytes32(uint256(uint32((k2))));
-    _keyTuple[2] = bytes32((k3));
-    _keyTuple[3] = bytes32(uint256(uint160((k4))));
-    _keyTuple[4] = _boolToBytes32((k5));
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -151,16 +151,17 @@ export function renderTableId(staticResourceData: StaticResourceData) {
   };
 }
 
-export function renderValueTypeToBytes32(name: string, { staticByteLength, typeUnwrap, internalTypeId }: RenderType) {
-  const bits = staticByteLength * 8;
-  const innerText = `${typeUnwrap}(${name})`;
+export function renderValueTypeToBytes32(name: string, { typeUnwrap, internalTypeId }: RenderType) {
+  const innerText = typeUnwrap.length ? `${typeUnwrap}(${name})` : name;
 
-  if (internalTypeId.match(/^uint\d{1,3}$/)) {
-    return `bytes32(uint256(${innerText}))`;
-  } else if (internalTypeId.match(/^int\d{1,3}$/)) {
-    return `bytes32(uint256(uint${bits}(${innerText})))`;
+  if (internalTypeId === "bytes32") {
+    return innerText;
   } else if (internalTypeId.match(/^bytes\d{1,2}$/)) {
     return `bytes32(${innerText})`;
+  } else if (internalTypeId.match(/^uint\d{1,3}$/)) {
+    return `bytes32(uint256(${innerText}))`;
+  } else if (internalTypeId.match(/^int\d{1,3}$/)) {
+    return `bytes32(uint256(int256(${innerText})))`;
   } else if (internalTypeId === "address") {
     return `bytes32(uint256(uint160(${innerText})))`;
   } else if (internalTypeId === "bool") {

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -68,7 +68,7 @@ library Callbacks {
   /** Get value */
   function get(bytes32 key) internal view returns (bytes24[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
@@ -77,7 +77,7 @@ library Callbacks {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (bytes24[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
@@ -86,7 +86,7 @@ library Callbacks {
   /** Set value */
   function set(bytes32 key, bytes24[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -94,7 +94,7 @@ library Callbacks {
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, bytes24[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -102,7 +102,7 @@ library Callbacks {
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 24;
@@ -111,7 +111,7 @@ library Callbacks {
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 24;
@@ -120,7 +120,7 @@ library Callbacks {
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 key, uint256 _index) internal view returns (bytes24) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
     return (Bytes.slice24(_blob, 0));
@@ -129,7 +129,7 @@ library Callbacks {
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes24) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
     return (Bytes.slice24(_blob, 0));
@@ -138,7 +138,7 @@ library Callbacks {
   /** Push an element to value */
   function push(bytes32 key, bytes24 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -146,7 +146,7 @@ library Callbacks {
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, bytes24 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -154,7 +154,7 @@ library Callbacks {
   /** Pop an element from value */
   function pop(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 24);
   }
@@ -162,7 +162,7 @@ library Callbacks {
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 24);
   }
@@ -170,7 +170,7 @@ library Callbacks {
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, bytes24 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
   }
@@ -178,7 +178,7 @@ library Callbacks {
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, bytes24 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
   }
@@ -195,13 +195,13 @@ library Callbacks {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -209,7 +209,7 @@ library Callbacks {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -68,7 +68,7 @@ library Hooks {
   /** Get value */
   function get(bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -77,7 +77,7 @@ library Hooks {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -86,7 +86,7 @@ library Hooks {
   /** Set value */
   function set(bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -94,7 +94,7 @@ library Hooks {
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -102,7 +102,7 @@ library Hooks {
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -111,7 +111,7 @@ library Hooks {
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -120,7 +120,7 @@ library Hooks {
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -129,7 +129,7 @@ library Hooks {
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -138,7 +138,7 @@ library Hooks {
   /** Push an element to value */
   function push(bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -146,7 +146,7 @@ library Hooks {
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -154,7 +154,7 @@ library Hooks {
   /** Pop an element from value */
   function pop(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -162,7 +162,7 @@ library Hooks {
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -170,7 +170,7 @@ library Hooks {
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -178,7 +178,7 @@ library Hooks {
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -195,13 +195,13 @@ library Hooks {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -209,7 +209,7 @@ library Hooks {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -81,7 +81,7 @@ library Mixed {
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -90,7 +90,7 @@ library Mixed {
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -99,7 +99,7 @@ library Mixed {
   /** Set u32 */
   function setU32(bytes32 key, uint32 u32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
   }
@@ -107,7 +107,7 @@ library Mixed {
   /** Set u32 (using the specified store) */
   function setU32(IStore _store, bytes32 key, uint32 u32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
   }
@@ -115,7 +115,7 @@ library Mixed {
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -124,7 +124,7 @@ library Mixed {
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -133,7 +133,7 @@ library Mixed {
   /** Set u128 */
   function setU128(bytes32 key, uint128 u128) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
   }
@@ -141,7 +141,7 @@ library Mixed {
   /** Set u128 (using the specified store) */
   function setU128(IStore _store, bytes32 key, uint128 u128) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
   }
@@ -149,7 +149,7 @@ library Mixed {
   /** Get a32 */
   function getA32(bytes32 key) internal view returns (uint32[] memory a32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -158,7 +158,7 @@ library Mixed {
   /** Get a32 (using the specified store) */
   function getA32(IStore _store, bytes32 key) internal view returns (uint32[] memory a32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -167,7 +167,7 @@ library Mixed {
   /** Set a32 */
   function setA32(bytes32 key, uint32[] memory a32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
   }
@@ -175,7 +175,7 @@ library Mixed {
   /** Set a32 (using the specified store) */
   function setA32(IStore _store, bytes32 key, uint32[] memory a32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
   }
@@ -183,7 +183,7 @@ library Mixed {
   /** Get the length of a32 */
   function lengthA32(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -192,7 +192,7 @@ library Mixed {
   /** Get the length of a32 (using the specified store) */
   function lengthA32(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -201,7 +201,7 @@ library Mixed {
   /** Get an item of a32 (unchecked, returns invalid data if index overflows) */
   function getItemA32(bytes32 key, uint256 _index) internal view returns (uint32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -210,7 +210,7 @@ library Mixed {
   /** Get an item of a32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemA32(IStore _store, bytes32 key, uint256 _index) internal view returns (uint32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -219,7 +219,7 @@ library Mixed {
   /** Push an element to a32 */
   function pushA32(bytes32 key, uint32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -227,7 +227,7 @@ library Mixed {
   /** Push an element to a32 (using the specified store) */
   function pushA32(IStore _store, bytes32 key, uint32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -235,7 +235,7 @@ library Mixed {
   /** Pop an element from a32 */
   function popA32(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -243,7 +243,7 @@ library Mixed {
   /** Pop an element from a32 (using the specified store) */
   function popA32(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -251,7 +251,7 @@ library Mixed {
   /** Update an element of a32 at `_index` */
   function updateA32(bytes32 key, uint256 _index, uint32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -259,7 +259,7 @@ library Mixed {
   /** Update an element of a32 (using the specified store) at `_index` */
   function updateA32(IStore _store, bytes32 key, uint256 _index, uint32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -267,7 +267,7 @@ library Mixed {
   /** Get s */
   function getS(bytes32 key) internal view returns (string memory s) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return (string(_blob));
@@ -276,7 +276,7 @@ library Mixed {
   /** Get s (using the specified store) */
   function getS(IStore _store, bytes32 key) internal view returns (string memory s) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return (string(_blob));
@@ -285,7 +285,7 @@ library Mixed {
   /** Set s */
   function setS(bytes32 key, string memory s) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((s)));
   }
@@ -293,7 +293,7 @@ library Mixed {
   /** Set s (using the specified store) */
   function setS(IStore _store, bytes32 key, string memory s) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 3, bytes((s)));
   }
@@ -301,7 +301,7 @@ library Mixed {
   /** Get the length of s */
   function lengthS(bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 1;
@@ -310,7 +310,7 @@ library Mixed {
   /** Get the length of s (using the specified store) */
   function lengthS(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 1;
@@ -319,7 +319,7 @@ library Mixed {
   /** Get an item of s (unchecked, returns invalid data if index overflows) */
   function getItemS(bytes32 key, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -328,7 +328,7 @@ library Mixed {
   /** Get an item of s (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemS(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -337,7 +337,7 @@ library Mixed {
   /** Push a slice to s */
   function pushS(bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
   }
@@ -345,7 +345,7 @@ library Mixed {
   /** Push a slice to s (using the specified store) */
   function pushS(IStore _store, bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
   }
@@ -353,7 +353,7 @@ library Mixed {
   /** Pop a slice from s */
   function popS(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1);
   }
@@ -361,7 +361,7 @@ library Mixed {
   /** Pop a slice from s (using the specified store) */
   function popS(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 1);
   }
@@ -369,7 +369,7 @@ library Mixed {
   /** Update a slice of s at `_index` */
   function updateS(bytes32 key, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
   }
@@ -377,7 +377,7 @@ library Mixed {
   /** Update a slice of s (using the specified store) at `_index` */
   function updateS(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
   }
@@ -385,7 +385,7 @@ library Mixed {
   /** Get the full data */
   function get(bytes32 key) internal view returns (MixedData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -394,7 +394,7 @@ library Mixed {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (MixedData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -405,7 +405,7 @@ library Mixed {
     bytes memory _data = encode(u32, u128, a32, s);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -415,7 +415,7 @@ library Mixed {
     bytes memory _data = encode(u32, u128, a32, s);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -468,13 +468,13 @@ library Mixed {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -482,7 +482,7 @@ library Mixed {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -75,7 +75,7 @@ library StoreMetadata {
   /** Get tableName */
   function getTableName(bytes32 tableId) internal view returns (string memory tableName) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (string(_blob));
@@ -84,7 +84,7 @@ library StoreMetadata {
   /** Get tableName (using the specified store) */
   function getTableName(IStore _store, bytes32 tableId) internal view returns (string memory tableName) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (string(_blob));
@@ -93,7 +93,7 @@ library StoreMetadata {
   /** Set tableName */
   function setTableName(bytes32 tableId, string memory tableName) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, bytes((tableName)));
   }
@@ -101,7 +101,7 @@ library StoreMetadata {
   /** Set tableName (using the specified store) */
   function setTableName(IStore _store, bytes32 tableId, string memory tableName) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.setField(_tableId, _keyTuple, 0, bytes((tableName)));
   }
@@ -109,7 +109,7 @@ library StoreMetadata {
   /** Get the length of tableName */
   function lengthTableName(bytes32 tableId) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 1;
@@ -118,7 +118,7 @@ library StoreMetadata {
   /** Get the length of tableName (using the specified store) */
   function lengthTableName(IStore _store, bytes32 tableId) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 1;
@@ -127,7 +127,7 @@ library StoreMetadata {
   /** Get an item of tableName (unchecked, returns invalid data if index overflows) */
   function getItemTableName(bytes32 tableId, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -136,7 +136,7 @@ library StoreMetadata {
   /** Get an item of tableName (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemTableName(IStore _store, bytes32 tableId, uint256 _index) internal view returns (string memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -145,7 +145,7 @@ library StoreMetadata {
   /** Push a slice to tableName */
   function pushTableName(bytes32 tableId, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
   }
@@ -153,7 +153,7 @@ library StoreMetadata {
   /** Push a slice to tableName (using the specified store) */
   function pushTableName(IStore _store, bytes32 tableId, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
   }
@@ -161,7 +161,7 @@ library StoreMetadata {
   /** Pop a slice from tableName */
   function popTableName(bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 1);
   }
@@ -169,7 +169,7 @@ library StoreMetadata {
   /** Pop a slice from tableName (using the specified store) */
   function popTableName(IStore _store, bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.popFromField(_tableId, _keyTuple, 0, 1);
   }
@@ -177,7 +177,7 @@ library StoreMetadata {
   /** Update a slice of tableName at `_index` */
   function updateTableName(bytes32 tableId, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
   }
@@ -185,7 +185,7 @@ library StoreMetadata {
   /** Update a slice of tableName (using the specified store) at `_index` */
   function updateTableName(IStore _store, bytes32 tableId, uint256 _index, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
   }
@@ -193,7 +193,7 @@ library StoreMetadata {
   /** Get abiEncodedFieldNames */
   function getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (bytes(_blob));
@@ -205,7 +205,7 @@ library StoreMetadata {
     bytes32 tableId
   ) internal view returns (bytes memory abiEncodedFieldNames) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (bytes(_blob));
@@ -214,7 +214,7 @@ library StoreMetadata {
   /** Set abiEncodedFieldNames */
   function setAbiEncodedFieldNames(bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
   }
@@ -222,7 +222,7 @@ library StoreMetadata {
   /** Set abiEncodedFieldNames (using the specified store) */
   function setAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
   }
@@ -230,7 +230,7 @@ library StoreMetadata {
   /** Get the length of abiEncodedFieldNames */
   function lengthAbiEncodedFieldNames(bytes32 tableId) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -239,7 +239,7 @@ library StoreMetadata {
   /** Get the length of abiEncodedFieldNames (using the specified store) */
   function lengthAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -248,7 +248,7 @@ library StoreMetadata {
   /** Get an item of abiEncodedFieldNames (unchecked, returns invalid data if index overflows) */
   function getItemAbiEncodedFieldNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -261,7 +261,7 @@ library StoreMetadata {
     uint256 _index
   ) internal view returns (bytes memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -270,7 +270,7 @@ library StoreMetadata {
   /** Push a slice to abiEncodedFieldNames */
   function pushAbiEncodedFieldNames(bytes32 tableId, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -278,7 +278,7 @@ library StoreMetadata {
   /** Push a slice to abiEncodedFieldNames (using the specified store) */
   function pushAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -286,7 +286,7 @@ library StoreMetadata {
   /** Pop a slice from abiEncodedFieldNames */
   function popAbiEncodedFieldNames(bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -294,7 +294,7 @@ library StoreMetadata {
   /** Pop a slice from abiEncodedFieldNames (using the specified store) */
   function popAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -302,7 +302,7 @@ library StoreMetadata {
   /** Update a slice of abiEncodedFieldNames at `_index` */
   function updateAbiEncodedFieldNames(bytes32 tableId, uint256 _index, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -310,7 +310,7 @@ library StoreMetadata {
   /** Update a slice of abiEncodedFieldNames (using the specified store) at `_index` */
   function updateAbiEncodedFieldNames(IStore _store, bytes32 tableId, uint256 _index, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -318,7 +318,7 @@ library StoreMetadata {
   /** Get the full data */
   function get(bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -327,7 +327,7 @@ library StoreMetadata {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -338,7 +338,7 @@ library StoreMetadata {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -348,7 +348,7 @@ library StoreMetadata {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -397,13 +397,13 @@ library StoreMetadata {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 tableId) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -411,7 +411,7 @@ library StoreMetadata {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 tableId) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((tableId));
+    _keyTuple[0] = tableId;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -75,7 +75,7 @@ library Vector2 {
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -84,7 +84,7 @@ library Vector2 {
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -93,7 +93,7 @@ library Vector2 {
   /** Set x */
   function setX(bytes32 key, uint32 x) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -101,7 +101,7 @@ library Vector2 {
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, uint32 x) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -109,7 +109,7 @@ library Vector2 {
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -118,7 +118,7 @@ library Vector2 {
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -127,7 +127,7 @@ library Vector2 {
   /** Set y */
   function setY(bytes32 key, uint32 y) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -135,7 +135,7 @@ library Vector2 {
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, uint32 y) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -143,7 +143,7 @@ library Vector2 {
   /** Get the full data */
   function get(bytes32 key) internal view returns (Vector2Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -152,7 +152,7 @@ library Vector2 {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Vector2Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -163,7 +163,7 @@ library Vector2 {
     bytes memory _data = encode(x, y);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -173,7 +173,7 @@ library Vector2 {
     bytes memory _data = encode(x, y);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -203,13 +203,13 @@ library Vector2 {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -217,7 +217,7 @@ library Vector2 {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -72,7 +72,7 @@ library FunctionSelectors {
   /** Get namespace */
   function getNamespace(bytes4 functionSelector) internal view returns (bytes16 namespace) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice16(_blob, 0));
@@ -81,7 +81,7 @@ library FunctionSelectors {
   /** Get namespace (using the specified store) */
   function getNamespace(IStore _store, bytes4 functionSelector) internal view returns (bytes16 namespace) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice16(_blob, 0));
@@ -90,7 +90,7 @@ library FunctionSelectors {
   /** Set namespace */
   function setNamespace(bytes4 functionSelector, bytes16 namespace) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
   }
@@ -98,7 +98,7 @@ library FunctionSelectors {
   /** Set namespace (using the specified store) */
   function setNamespace(IStore _store, bytes4 functionSelector, bytes16 namespace) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
   }
@@ -106,7 +106,7 @@ library FunctionSelectors {
   /** Get name */
   function getName(bytes4 functionSelector) internal view returns (bytes16 name) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (Bytes.slice16(_blob, 0));
@@ -115,7 +115,7 @@ library FunctionSelectors {
   /** Get name (using the specified store) */
   function getName(IStore _store, bytes4 functionSelector) internal view returns (bytes16 name) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (Bytes.slice16(_blob, 0));
@@ -124,7 +124,7 @@ library FunctionSelectors {
   /** Set name */
   function setName(bytes4 functionSelector, bytes16 name) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
   }
@@ -132,7 +132,7 @@ library FunctionSelectors {
   /** Set name (using the specified store) */
   function setName(IStore _store, bytes4 functionSelector, bytes16 name) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
   }
@@ -140,7 +140,7 @@ library FunctionSelectors {
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice4(_blob, 0));
@@ -152,7 +152,7 @@ library FunctionSelectors {
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice4(_blob, 0));
@@ -161,7 +161,7 @@ library FunctionSelectors {
   /** Set systemFunctionSelector */
   function setSystemFunctionSelector(bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
   }
@@ -169,7 +169,7 @@ library FunctionSelectors {
   /** Set systemFunctionSelector (using the specified store) */
   function setSystemFunctionSelector(IStore _store, bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
   }
@@ -179,7 +179,7 @@ library FunctionSelectors {
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -191,7 +191,7 @@ library FunctionSelectors {
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -202,7 +202,7 @@ library FunctionSelectors {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -218,7 +218,7 @@ library FunctionSelectors {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -242,13 +242,13 @@ library FunctionSelectors {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes4 functionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -256,7 +256,7 @@ library FunctionSelectors {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes4 functionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((functionSelector));
+    _keyTuple[0] = bytes32(functionSelector);
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -71,7 +71,7 @@ library ResourceType {
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
@@ -80,7 +80,7 @@ library ResourceType {
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
@@ -89,7 +89,7 @@ library ResourceType {
   /** Set resourceType */
   function set(bytes32 resourceSelector, Resource resourceType) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
   }
@@ -97,7 +97,7 @@ library ResourceType {
   /** Set resourceType (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, Resource resourceType) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
   }
@@ -110,13 +110,13 @@ library ResourceType {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -124,7 +124,7 @@ library ResourceType {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -68,7 +68,7 @@ library SystemHooks {
   /** Get value */
   function get(bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -77,7 +77,7 @@ library SystemHooks {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -86,7 +86,7 @@ library SystemHooks {
   /** Set value */
   function set(bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -94,7 +94,7 @@ library SystemHooks {
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -102,7 +102,7 @@ library SystemHooks {
   /** Get the length of value */
   function length(bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -111,7 +111,7 @@ library SystemHooks {
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -120,7 +120,7 @@ library SystemHooks {
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 resourceSelector, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -129,7 +129,7 @@ library SystemHooks {
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 resourceSelector, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -138,7 +138,7 @@ library SystemHooks {
   /** Push an element to value */
   function push(bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -146,7 +146,7 @@ library SystemHooks {
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -154,7 +154,7 @@ library SystemHooks {
   /** Pop an element from value */
   function pop(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -162,7 +162,7 @@ library SystemHooks {
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -170,7 +170,7 @@ library SystemHooks {
   /** Update an element of value at `_index` */
   function update(bytes32 resourceSelector, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -178,7 +178,7 @@ library SystemHooks {
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 resourceSelector, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -195,13 +195,13 @@ library SystemHooks {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -209,7 +209,7 @@ library SystemHooks {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -68,7 +68,7 @@ library SystemRegistry {
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice32(_blob, 0));
@@ -77,7 +77,7 @@ library SystemRegistry {
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice32(_blob, 0));
@@ -86,7 +86,7 @@ library SystemRegistry {
   /** Set resourceSelector */
   function set(address system, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
   }
@@ -94,7 +94,7 @@ library SystemRegistry {
   /** Set resourceSelector (using the specified store) */
   function set(IStore _store, address system, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
   }
@@ -107,13 +107,13 @@ library SystemRegistry {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(address system) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
   }
 
   /* Delete all data for given keys */
   function deleteRecord(address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -121,7 +121,7 @@ library SystemRegistry {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160((system))));
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -70,7 +70,7 @@ library Systems {
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -79,7 +79,7 @@ library Systems {
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -88,7 +88,7 @@ library Systems {
   /** Set system */
   function setSystem(bytes32 resourceSelector, address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
   }
@@ -96,7 +96,7 @@ library Systems {
   /** Set system (using the specified store) */
   function setSystem(IStore _store, bytes32 resourceSelector, address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
   }
@@ -104,7 +104,7 @@ library Systems {
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -113,7 +113,7 @@ library Systems {
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -122,7 +122,7 @@ library Systems {
   /** Set publicAccess */
   function setPublicAccess(bytes32 resourceSelector, bool publicAccess) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
   }
@@ -130,7 +130,7 @@ library Systems {
   /** Set publicAccess (using the specified store) */
   function setPublicAccess(IStore _store, bytes32 resourceSelector, bool publicAccess) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
   }
@@ -138,7 +138,7 @@ library Systems {
   /** Get the full data */
   function get(bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -147,7 +147,7 @@ library Systems {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -158,7 +158,7 @@ library Systems {
     bytes memory _data = encode(system, publicAccess);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -168,7 +168,7 @@ library Systems {
     bytes memory _data = encode(system, publicAccess);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -188,13 +188,13 @@ library Systems {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -202,7 +202,7 @@ library Systems {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((resourceSelector));
+    _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -84,7 +84,7 @@ library KeysInTable {
   /** Get keys0 */
   function getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -93,7 +93,7 @@ library KeysInTable {
   /** Get keys0 (using the specified store) */
   function getKeys0(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -102,7 +102,7 @@ library KeysInTable {
   /** Set keys0 */
   function setKeys0(bytes32 sourceTable, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
@@ -110,7 +110,7 @@ library KeysInTable {
   /** Set keys0 (using the specified store) */
   function setKeys0(IStore _store, bytes32 sourceTable, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
@@ -118,7 +118,7 @@ library KeysInTable {
   /** Get the length of keys0 */
   function lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -127,7 +127,7 @@ library KeysInTable {
   /** Get the length of keys0 (using the specified store) */
   function lengthKeys0(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -136,7 +136,7 @@ library KeysInTable {
   /** Get an item of keys0 (unchecked, returns invalid data if index overflows) */
   function getItemKeys0(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -145,7 +145,7 @@ library KeysInTable {
   /** Get an item of keys0 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys0(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -154,7 +154,7 @@ library KeysInTable {
   /** Push an element to keys0 */
   function pushKeys0(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -162,7 +162,7 @@ library KeysInTable {
   /** Push an element to keys0 (using the specified store) */
   function pushKeys0(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -170,7 +170,7 @@ library KeysInTable {
   /** Pop an element from keys0 */
   function popKeys0(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -178,7 +178,7 @@ library KeysInTable {
   /** Pop an element from keys0 (using the specified store) */
   function popKeys0(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -186,7 +186,7 @@ library KeysInTable {
   /** Update an element of keys0 at `_index` */
   function updateKeys0(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -194,7 +194,7 @@ library KeysInTable {
   /** Update an element of keys0 (using the specified store) at `_index` */
   function updateKeys0(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -202,7 +202,7 @@ library KeysInTable {
   /** Get keys1 */
   function getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -211,7 +211,7 @@ library KeysInTable {
   /** Get keys1 (using the specified store) */
   function getKeys1(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -220,7 +220,7 @@ library KeysInTable {
   /** Set keys1 */
   function setKeys1(bytes32 sourceTable, bytes32[] memory keys1) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
   }
@@ -228,7 +228,7 @@ library KeysInTable {
   /** Set keys1 (using the specified store) */
   function setKeys1(IStore _store, bytes32 sourceTable, bytes32[] memory keys1) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
   }
@@ -236,7 +236,7 @@ library KeysInTable {
   /** Get the length of keys1 */
   function lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 32;
@@ -245,7 +245,7 @@ library KeysInTable {
   /** Get the length of keys1 (using the specified store) */
   function lengthKeys1(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 32;
@@ -254,7 +254,7 @@ library KeysInTable {
   /** Get an item of keys1 (unchecked, returns invalid data if index overflows) */
   function getItemKeys1(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -263,7 +263,7 @@ library KeysInTable {
   /** Get an item of keys1 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys1(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -272,7 +272,7 @@ library KeysInTable {
   /** Push an element to keys1 */
   function pushKeys1(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -280,7 +280,7 @@ library KeysInTable {
   /** Push an element to keys1 (using the specified store) */
   function pushKeys1(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -288,7 +288,7 @@ library KeysInTable {
   /** Pop an element from keys1 */
   function popKeys1(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32);
   }
@@ -296,7 +296,7 @@ library KeysInTable {
   /** Pop an element from keys1 (using the specified store) */
   function popKeys1(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 1, 32);
   }
@@ -304,7 +304,7 @@ library KeysInTable {
   /** Update an element of keys1 at `_index` */
   function updateKeys1(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
   }
@@ -312,7 +312,7 @@ library KeysInTable {
   /** Update an element of keys1 (using the specified store) at `_index` */
   function updateKeys1(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
   }
@@ -320,7 +320,7 @@ library KeysInTable {
   /** Get keys2 */
   function getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -329,7 +329,7 @@ library KeysInTable {
   /** Get keys2 (using the specified store) */
   function getKeys2(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -338,7 +338,7 @@ library KeysInTable {
   /** Set keys2 */
   function setKeys2(bytes32 sourceTable, bytes32[] memory keys2) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
   }
@@ -346,7 +346,7 @@ library KeysInTable {
   /** Set keys2 (using the specified store) */
   function setKeys2(IStore _store, bytes32 sourceTable, bytes32[] memory keys2) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
   }
@@ -354,7 +354,7 @@ library KeysInTable {
   /** Get the length of keys2 */
   function lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 32;
@@ -363,7 +363,7 @@ library KeysInTable {
   /** Get the length of keys2 (using the specified store) */
   function lengthKeys2(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 32;
@@ -372,7 +372,7 @@ library KeysInTable {
   /** Get an item of keys2 (unchecked, returns invalid data if index overflows) */
   function getItemKeys2(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -381,7 +381,7 @@ library KeysInTable {
   /** Get an item of keys2 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys2(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -390,7 +390,7 @@ library KeysInTable {
   /** Push an element to keys2 */
   function pushKeys2(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -398,7 +398,7 @@ library KeysInTable {
   /** Push an element to keys2 (using the specified store) */
   function pushKeys2(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -406,7 +406,7 @@ library KeysInTable {
   /** Pop an element from keys2 */
   function popKeys2(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32);
   }
@@ -414,7 +414,7 @@ library KeysInTable {
   /** Pop an element from keys2 (using the specified store) */
   function popKeys2(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 2, 32);
   }
@@ -422,7 +422,7 @@ library KeysInTable {
   /** Update an element of keys2 at `_index` */
   function updateKeys2(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
   }
@@ -430,7 +430,7 @@ library KeysInTable {
   /** Update an element of keys2 (using the specified store) at `_index` */
   function updateKeys2(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
   }
@@ -438,7 +438,7 @@ library KeysInTable {
   /** Get keys3 */
   function getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -447,7 +447,7 @@ library KeysInTable {
   /** Get keys3 (using the specified store) */
   function getKeys3(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -456,7 +456,7 @@ library KeysInTable {
   /** Set keys3 */
   function setKeys3(bytes32 sourceTable, bytes32[] memory keys3) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
   }
@@ -464,7 +464,7 @@ library KeysInTable {
   /** Set keys3 (using the specified store) */
   function setKeys3(IStore _store, bytes32 sourceTable, bytes32[] memory keys3) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
   }
@@ -472,7 +472,7 @@ library KeysInTable {
   /** Get the length of keys3 */
   function lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 32;
@@ -481,7 +481,7 @@ library KeysInTable {
   /** Get the length of keys3 (using the specified store) */
   function lengthKeys3(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 32;
@@ -490,7 +490,7 @@ library KeysInTable {
   /** Get an item of keys3 (unchecked, returns invalid data if index overflows) */
   function getItemKeys3(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -499,7 +499,7 @@ library KeysInTable {
   /** Get an item of keys3 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys3(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -508,7 +508,7 @@ library KeysInTable {
   /** Push an element to keys3 */
   function pushKeys3(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -516,7 +516,7 @@ library KeysInTable {
   /** Push an element to keys3 (using the specified store) */
   function pushKeys3(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -524,7 +524,7 @@ library KeysInTable {
   /** Pop an element from keys3 */
   function popKeys3(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32);
   }
@@ -532,7 +532,7 @@ library KeysInTable {
   /** Pop an element from keys3 (using the specified store) */
   function popKeys3(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 3, 32);
   }
@@ -540,7 +540,7 @@ library KeysInTable {
   /** Update an element of keys3 at `_index` */
   function updateKeys3(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
   }
@@ -548,7 +548,7 @@ library KeysInTable {
   /** Update an element of keys3 (using the specified store) at `_index` */
   function updateKeys3(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
   }
@@ -556,7 +556,7 @@ library KeysInTable {
   /** Get keys4 */
   function getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -565,7 +565,7 @@ library KeysInTable {
   /** Get keys4 (using the specified store) */
   function getKeys4(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -574,7 +574,7 @@ library KeysInTable {
   /** Set keys4 */
   function setKeys4(bytes32 sourceTable, bytes32[] memory keys4) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
   }
@@ -582,7 +582,7 @@ library KeysInTable {
   /** Set keys4 (using the specified store) */
   function setKeys4(IStore _store, bytes32 sourceTable, bytes32[] memory keys4) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
   }
@@ -590,7 +590,7 @@ library KeysInTable {
   /** Get the length of keys4 */
   function lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 32;
@@ -599,7 +599,7 @@ library KeysInTable {
   /** Get the length of keys4 (using the specified store) */
   function lengthKeys4(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 32;
@@ -608,7 +608,7 @@ library KeysInTable {
   /** Get an item of keys4 (unchecked, returns invalid data if index overflows) */
   function getItemKeys4(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -617,7 +617,7 @@ library KeysInTable {
   /** Get an item of keys4 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys4(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -626,7 +626,7 @@ library KeysInTable {
   /** Push an element to keys4 */
   function pushKeys4(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -634,7 +634,7 @@ library KeysInTable {
   /** Push an element to keys4 (using the specified store) */
   function pushKeys4(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -642,7 +642,7 @@ library KeysInTable {
   /** Pop an element from keys4 */
   function popKeys4(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32);
   }
@@ -650,7 +650,7 @@ library KeysInTable {
   /** Pop an element from keys4 (using the specified store) */
   function popKeys4(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 4, 32);
   }
@@ -658,7 +658,7 @@ library KeysInTable {
   /** Update an element of keys4 at `_index` */
   function updateKeys4(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
   }
@@ -666,7 +666,7 @@ library KeysInTable {
   /** Update an element of keys4 (using the specified store) at `_index` */
   function updateKeys4(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
   }
@@ -674,7 +674,7 @@ library KeysInTable {
   /** Get the full data */
   function get(bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -683,7 +683,7 @@ library KeysInTable {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -701,7 +701,7 @@ library KeysInTable {
     bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -719,7 +719,7 @@ library KeysInTable {
     bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -797,13 +797,13 @@ library KeysInTable {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -811,7 +811,7 @@ library KeysInTable {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((sourceTable));
+    _keyTuple[0] = sourceTable;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -71,8 +71,8 @@ library UsedKeysIndex {
   /** Get has */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -81,8 +81,8 @@ library UsedKeysIndex {
   /** Get has (using the specified store) */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -91,8 +91,8 @@ library UsedKeysIndex {
   /** Set has */
   function setHas(bytes32 sourceTable, bytes32 keysHash, bool has) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
   }
@@ -100,8 +100,8 @@ library UsedKeysIndex {
   /** Set has (using the specified store) */
   function setHas(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
   }
@@ -109,8 +109,8 @@ library UsedKeysIndex {
   /** Get index */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint40(Bytes.slice5(_blob, 0)));
@@ -119,8 +119,8 @@ library UsedKeysIndex {
   /** Get index (using the specified store) */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint40(Bytes.slice5(_blob, 0)));
@@ -129,8 +129,8 @@ library UsedKeysIndex {
   /** Set index */
   function setIndex(bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
   }
@@ -138,8 +138,8 @@ library UsedKeysIndex {
   /** Set index (using the specified store) */
   function setIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
   }
@@ -147,8 +147,8 @@ library UsedKeysIndex {
   /** Get the full data */
   function get(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -157,8 +157,8 @@ library UsedKeysIndex {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -169,8 +169,8 @@ library UsedKeysIndex {
     bytes memory _data = encode(has, index);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -180,8 +180,8 @@ library UsedKeysIndex {
     bytes memory _data = encode(has, index);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -201,15 +201,15 @@ library UsedKeysIndex {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 sourceTable, bytes32 keysHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -217,8 +217,8 @@ library UsedKeysIndex {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((sourceTable));
-    _keyTuple[1] = bytes32((keysHash));
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -65,7 +65,7 @@ library KeysWithValue {
   /** Get keysWithValue */
   function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -78,7 +78,7 @@ library KeysWithValue {
     bytes32 valueHash
   ) internal view returns (bytes32[] memory keysWithValue) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -87,7 +87,7 @@ library KeysWithValue {
   /** Set keysWithValue */
   function set(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
   }
@@ -95,7 +95,7 @@ library KeysWithValue {
   /** Set keysWithValue (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
   }
@@ -103,7 +103,7 @@ library KeysWithValue {
   /** Get the length of keysWithValue */
   function length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -112,7 +112,7 @@ library KeysWithValue {
   /** Get the length of keysWithValue (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -121,7 +121,7 @@ library KeysWithValue {
   /** Get an item of keysWithValue (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -130,7 +130,7 @@ library KeysWithValue {
   /** Get an item of keysWithValue (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -139,7 +139,7 @@ library KeysWithValue {
   /** Push an element to keysWithValue */
   function push(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -147,7 +147,7 @@ library KeysWithValue {
   /** Push an element to keysWithValue (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -155,7 +155,7 @@ library KeysWithValue {
   /** Pop an element from keysWithValue */
   function pop(bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -163,7 +163,7 @@ library KeysWithValue {
   /** Pop an element from keysWithValue (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -171,7 +171,7 @@ library KeysWithValue {
   /** Update an element of keysWithValue at `_index` */
   function update(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -179,7 +179,7 @@ library KeysWithValue {
   /** Update an element of keysWithValue (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -196,13 +196,13 @@ library KeysWithValue {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -210,7 +210,7 @@ library KeysWithValue {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((valueHash));
+    _keyTuple[0] = valueHash;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -73,8 +73,8 @@ library InstalledModules {
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -87,8 +87,8 @@ library InstalledModules {
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -97,8 +97,8 @@ library InstalledModules {
   /** Set moduleAddress */
   function setModuleAddress(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
   }
@@ -106,8 +106,8 @@ library InstalledModules {
   /** Set moduleAddress (using the specified store) */
   function setModuleAddress(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
   }
@@ -115,8 +115,8 @@ library InstalledModules {
   /** Get the full data */
   function get(bytes16 moduleName, bytes32 argumentsHash) internal view returns (InstalledModulesData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -129,8 +129,8 @@ library InstalledModules {
     bytes32 argumentsHash
   ) internal view returns (InstalledModulesData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -141,8 +141,8 @@ library InstalledModules {
     bytes memory _data = encode(moduleAddress);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -152,8 +152,8 @@ library InstalledModules {
     bytes memory _data = encode(moduleAddress);
 
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -184,15 +184,15 @@ library InstalledModules {
     bytes32 argumentsHash
   ) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes16 moduleName, bytes32 argumentsHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -200,8 +200,8 @@ library InstalledModules {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 moduleName, bytes32 argumentsHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((moduleName));
-    _keyTuple[1] = bytes32((argumentsHash));
+    _keyTuple[0] = bytes32(moduleName);
+    _keyTuple[1] = argumentsHash;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -68,7 +68,7 @@ library NamespaceOwner {
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -77,7 +77,7 @@ library NamespaceOwner {
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -86,7 +86,7 @@ library NamespaceOwner {
   /** Set owner */
   function set(bytes16 namespace, address owner) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
   }
@@ -94,7 +94,7 @@ library NamespaceOwner {
   /** Set owner (using the specified store) */
   function set(IStore _store, bytes16 namespace, address owner) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
   }
@@ -107,13 +107,13 @@ library NamespaceOwner {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes16 namespace) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -121,7 +121,7 @@ library NamespaceOwner {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 namespace) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((namespace));
+    _keyTuple[0] = bytes32(namespace);
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -69,8 +69,8 @@ library ResourceAccess {
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -79,8 +79,8 @@ library ResourceAccess {
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -89,8 +89,8 @@ library ResourceAccess {
   /** Set access */
   function set(bytes32 resourceSelector, address caller, bool access) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
   }
@@ -98,8 +98,8 @@ library ResourceAccess {
   /** Set access (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address caller, bool access) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
   }
@@ -112,15 +112,15 @@ library ResourceAccess {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector, address caller) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -128,8 +128,8 @@ library ResourceAccess {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector, address caller) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32((resourceSelector));
-    _keyTuple[1] = bytes32(uint256(uint160((caller))));
+    _keyTuple[0] = resourceSelector;
+    _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -65,7 +65,7 @@ library AddressArray {
   /** Get value */
   function get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -74,7 +74,7 @@ library AddressArray {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -83,7 +83,7 @@ library AddressArray {
   /** Set value */
   function set(bytes32 _tableId, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -91,7 +91,7 @@ library AddressArray {
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -99,7 +99,7 @@ library AddressArray {
   /** Get the length of value */
   function length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -108,7 +108,7 @@ library AddressArray {
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -117,7 +117,7 @@ library AddressArray {
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -126,7 +126,7 @@ library AddressArray {
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -135,7 +135,7 @@ library AddressArray {
   /** Push an element to value */
   function push(bytes32 _tableId, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -143,7 +143,7 @@ library AddressArray {
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -151,7 +151,7 @@ library AddressArray {
   /** Pop an element from value */
   function pop(bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -159,7 +159,7 @@ library AddressArray {
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -167,7 +167,7 @@ library AddressArray {
   /** Update an element of value at `_index` */
   function update(bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -175,7 +175,7 @@ library AddressArray {
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -192,13 +192,13 @@ library AddressArray {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -206,7 +206,7 @@ library AddressArray {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -78,7 +78,7 @@ library Position {
   /** Get x */
   function getX(bytes32 key) internal view returns (int32 x) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -87,7 +87,7 @@ library Position {
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (int32 x) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -96,7 +96,7 @@ library Position {
   /** Set x */
   function setX(bytes32 key, int32 x) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -104,7 +104,7 @@ library Position {
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, int32 x) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -112,7 +112,7 @@ library Position {
   /** Get y */
   function getY(bytes32 key) internal view returns (int32 y) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -121,7 +121,7 @@ library Position {
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (int32 y) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -130,7 +130,7 @@ library Position {
   /** Set y */
   function setY(bytes32 key, int32 y) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -138,7 +138,7 @@ library Position {
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, int32 y) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -146,7 +146,7 @@ library Position {
   /** Get z */
   function getZ(bytes32 key) internal view returns (int32 z) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -155,7 +155,7 @@ library Position {
   /** Get z (using the specified store) */
   function getZ(IStore _store, bytes32 key) internal view returns (int32 z) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -164,7 +164,7 @@ library Position {
   /** Set z */
   function setZ(bytes32 key, int32 z) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
   }
@@ -172,7 +172,7 @@ library Position {
   /** Set z (using the specified store) */
   function setZ(IStore _store, bytes32 key, int32 z) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
   }
@@ -180,7 +180,7 @@ library Position {
   /** Get the full data */
   function get(bytes32 key) internal view returns (PositionData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -189,7 +189,7 @@ library Position {
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (PositionData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -200,7 +200,7 @@ library Position {
     bytes memory _data = encode(x, y, z);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -210,7 +210,7 @@ library Position {
     bytes memory _data = encode(x, y, z);
 
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -242,13 +242,13 @@ library Position {
   /** Encode keys as a bytes32 array using this table's schema */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
     _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -256,7 +256,7 @@ library Position {
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32((key));
+    _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }


### PR DESCRIPTION
small tweak to codegen to 1) not wrap in parens if we don't need to and 2) not type cast bytes32 if it's already there (gonna move this out to not pollute the diff)

(needs #1001 merged first + rebase)