### PR TITLE
fix: updated template allow_paths

### DIFF
--- a/templates/vanilla/packages/contracts/foundry.toml
+++ b/templates/vanilla/packages/contracts/foundry.toml
@@ -8,7 +8,7 @@ verbosity = 2
 src = "src"
 test = "test"
 out = "out"
-allow_paths = ["../../node_modules", "../../../../packages"]
+allow_paths = ["../../../mud/packages"]
 extra_output_files = [
   "abi",
   "evm.bytecode"


### PR DESCRIPTION
fixes #988

 `allow_paths = ["../../node_modules", "../../../../packages"]`
chaged to
`allow_paths = ["../../../mud/packages"]`