### PR TITLE
fix(cli): temporary workaround to reset anvil base fee to 0

### DIFF
--- a/packages/cli/src/utils/deployHandler.ts
+++ b/packages/cli/src/utils/deployHandler.ts
@@ -6,7 +6,7 @@ import { loadConfig } from "@latticexyz/config/node";
 import { StoreConfig } from "@latticexyz/store";
 import { WorldConfig } from "@latticexyz/world";
 import { deploy } from "../utils/deploy";
-import { forge, getRpcUrl, getSrcDirectory } from "@latticexyz/common/foundry";
+import { cast, forge, getRpcUrl, getSrcDirectory } from "@latticexyz/common/foundry";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { getChainId } from "../utils/getChainId";
 
@@ -78,6 +78,13 @@ export async function deployHandler(args: DeployOptions) {
     console.log(
       chalk.bgGreen(chalk.whiteBright(`\n Deployment result (written to ${mudConfig.worldsFile} and ${outputDir}): \n`))
     );
+
+    // Reset base fee back to 0 if deploying to a local chain.
+    // This is a temporary workaround until the issue is fixed upstream,
+    // see https://github.com/foundry-rs/foundry/issues/5161
+    if ((await getChainId(rpc)) === 31337) {
+      cast(["rpc", "anvil_setNextBlockBaseFeePerGas", "0"]);
+    }
   }
 
   console.log(deploymentInfo);


### PR DESCRIPTION
Anvil is currently increasing the base fee to 1 after a MUD deploy, this temporary workaround is resetting the base fee to 0 after a deployment. We can remove this workaround once the issue is fixed upstream, see https://github.com/foundry-rs/foundry/issues/5161.