### PR TITLE
ci: remove pinned foundry version, use nightly instead

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,8 +18,7 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-      # TODO update when "max fee per gas" issue is fixed for latest nightly
-        version: nightly-87bc53fc6c874bd4c92d97ed180b949e3a36d78c
+        version: nightly
 
     - name: Setup protoc
       uses: arduino/setup-protoc@v1


### PR DESCRIPTION
the issue should be fixed in foundry (https://github.com/foundry-rs/foundry/pull/5163), so it should be fine to remove the pinned version and use the latest nightly 