### PR TITLE
ci: clean rebuild in build action, use turbo cache in all other actions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,21 @@
+name: Build
+description: Build with turbo cache
+runs:
+  using: composite
+  steps:
+    - name: Cache turbo build
+      uses: actions/cache@v3
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-${{ github.ref_name }}-
+          ${{ runner.os }}-turbo-main-
+          ${{ runner.os }}-turbo-
+
+    - name: Build
+      shell: bash
+      run: pnpm turbo run build --cache-dir=.turbo --concurrency 10
+
+    - name: Outdated files, run `pnpm build` and commit them
+      uses: ./.github/actions/require-empty-diff

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -35,24 +35,3 @@ runs:
       shell: bash
       working-directory: packages/schema-type
       run: forge build
-
-    - name: Cache turbo build
-      uses: actions/cache@v3
-      with:
-        path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.ref_name }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.ref_name }}-
-          ${{ runner.os }}-turbo-main-
-          ${{ runner.os }}-turbo-
-
-    - name: Clean
-      shell: bash
-      run: pnpm turbo run clean --cache-dir=.turbo --concurrency 10
-
-    - name: Build
-      shell: bash
-      run: pnpm turbo run build --cache-dir=.turbo --concurrency 10
-
-    - name: Outdated files, run `pnpm build` and commit them
-      uses: ./.github/actions/require-empty-diff

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,17 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Clean
+        shell: bash
+        run: pnpm turbo run clean --concurrency 10
+
+      - name: Build
+        shell: bash
+        run: pnpm turbo run build --concurrency 10
+
+      - name: Outdated files, run `pnpm build` and commit them
+        uses: ./.github/actions/require-empty-diff
+
       - name: Generate gas reports
         run: pnpm gas-report
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Install example dependencies
         working-directory: ./examples/${{ matrix.example }}
         run: pnpm install

--- a/.github/workflows/integration-sandbox.yml
+++ b/.github/workflows/integration-sandbox.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Install integration sandbox dependencies
         working-directory: ./integration-sandbox
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Generate gas reports
         run: pnpm gas-report
 

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Install template dependencies
         working-directory: ./templates/${{ matrix.template }}
         run: pnpm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Run tests
         run: pnpm test
 


### PR DESCRIPTION
* In #1027 we added a `clean` step before the `build` step. The `clean` step removes build artifacts, so afterwards a full rebuild is necessary. This caused an issue if the turbo cache was hit and the rebuild was skipped, eg https://github.com/latticexyz/mud/actions/runs/5293787981/jobs/9582365505?pr=1011
* This PR changes pulls out the `build` step from the the `Setup` composite action and instead creates a new `Build` composite action that uses the turbo cache and does not clean the artifacts
* This new `Build` composite action is used in all actions, except the `Build and validate artifacts` action, which first cleans the artifacts and then performs a full rebuild without the turbo cache.