### PR TITLE
ci: build before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Build
+        uses: ./.github/actions/build
+
       - name: Generate gas reports
         run: pnpm gas-report
 


### PR DESCRIPTION
followup to #1045 - missed the second clause of the release action