### PR TITLE
feat(cli): make worldgen clean by default

### DIFF
--- a/packages/cli/src/commands/worldgen.ts
+++ b/packages/cli/src/commands/worldgen.ts
@@ -23,7 +23,11 @@ const commandModule: CommandModule<Options, Options> = {
   builder(yargs) {
     return yargs.options({
       configPath: { type: "string", desc: "Path to the config file" },
-      clean: { type: "boolean", desc: "Clear the worldgen directory before generating new interfaces" },
+      clean: {
+        type: "boolean",
+        desc: "Clear the worldgen directory before generating new interfaces (defaults to true)",
+        default: true,
+      },
     });
   },
 


### PR DESCRIPTION
closes #1038 

Turns out we don't need to modify `world` since it uses `world`'s underlying `worldgen` scripts rather than the CLI as its entry point.

This also sort of fixes the original thing I noticed in #1027, which means we could potentially remove the clean step from CI?