### PR TITLE
fix(common): use posixPath in solidityRelativeImportPath

### DIFF
--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -68,7 +68,7 @@ export function solidityRelativeImportPath(fromPath: string, usedInPath: string)
   // 1st "./" must be added because path strips it,
   // but solidity expects it unless there's "../" ("./../" is fine).
   // 2nd and 3rd "./" forcefully avoid absolute paths (everything is relative to `src`).
-  return "./" + path.relative("./" + usedInPath, "./" + fromPath);
+  return posixPath("./" + path.relative("./" + usedInPath, "./" + fromPath));
 }
 
 /**


### PR DESCRIPTION
Doesn't fix any current issues
`solidityRelativeImportPath` is only used in `renderAbsoluteImports`, which already wraps the path in `posixPath`
But since `solidityRelativeImportPath` is exported it could be used somewhere else in the future, this fix helps avoid sudden windows-only bugs