### PR TITLE
fix(world): no longer skip 0 in KeysWithValueModule

### DIFF
--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -61,18 +61,6 @@
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
-    "test": "testGetKeysWithValue",
-    "name": "install keys with value module",
-    "gasUsed": 626518
-  },
-  {
-    "file": "test/KeysWithValueModule.t.sol",
-    "test": "testGetKeysWithValue",
-    "name": "Get list of keys with a given value",
-    "gasUsed": 7716
-  },
-  {
-    "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetTargetTableSelector",
     "name": "compute the target table selector",
     "gasUsed": 2234
@@ -87,7 +75,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 165703
+    "gasUsed": 165629
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -99,13 +87,25 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 135356
+    "gasUsed": 135282
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
     "gasUsed": 54297
+  },
+  {
+    "file": "test/KeysWithValueModule.t.sol",
+    "test": "testSetAndDeleteRecordHookGas",
+    "name": "install keys with value module",
+    "gasUsed": 626518
+  },
+  {
+    "file": "test/KeysWithValueModule.t.sol",
+    "test": "testSetAndDeleteRecordHookGas",
+    "name": "Get list of keys with a given value",
+    "gasUsed": 7716
   },
   {
     "file": "test/KeysWithValueModule.t.sol",

--- a/packages/world/src/modules/keyswithvalue/KeysWithValueHook.sol
+++ b/packages/world/src/modules/keyswithvalue/KeysWithValueHook.sol
@@ -30,9 +30,6 @@ contract KeysWithValueHook is IStoreHook {
     // Get the previous value
     bytes32 previousValue = keccak256(IBaseWorld(msg.sender).getRecord(sourceTableId, key));
 
-    // Return if the value hasn't changed
-    if (previousValue == keccak256(data)) return;
-
     // Remove the key from the list of keys with the previous value
     _removeKeyFromList(targetTableId, key[0], previousValue);
 

--- a/packages/world/test/KeysWithValueModule.t.sol
+++ b/packages/world/test/KeysWithValueModule.t.sol
@@ -190,16 +190,19 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     assertEq(targetTableSelector.getName(), sourceName);
   }
 
-  function testGetKeysWithValue() public {
+  function testSetAndDeleteRecordHookGas() public {
+    // call fuzzed test manually to get gas report
+    testGetKeysWithValue(1);
+  }
+
+  function testGetKeysWithValue(uint256 value) public {
     _installKeysWithValueModule();
 
     // Set a value in the source table
-    uint256 value1 = 1;
-
-    world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value1));
+    world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value));
 
     startGasReport("Get list of keys with a given value");
-    bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1));
+    bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value));
     endGasReport();
 
     // Assert that the list is correct
@@ -207,10 +210,10 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     assertEq(keysWithValue[0], key1);
 
     // Set a another key with the same value
-    world.setRecord(namespace, sourceName, keyTuple2, abi.encodePacked(value1));
+    world.setRecord(namespace, sourceName, keyTuple2, abi.encodePacked(value));
 
-    // Get the list of keys with value2 from the target table
-    keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value1));
+    // Get the list of keys with value from the target table
+    keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value));
 
     // Assert that the list is correct
     assertEq(keysWithValue.length, 2);


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/1073
the "is changed" optimization doesn't work because 0 is no different from default/absent values,
I could keep it but ignore it if prevValue is 0, but that's hard and only eats more gas for the normal cases
(by hard I mean you can't just compare a blob to 0 - each length of 0s has a different hash - so I need a [memchr, which I have,](https://github.com/dk1a/solidity-stringutils/blob/main/src/utils/memchr.sol) but probably shouldn't put into MUD just for this)

changed the test to be fuzzed, now it includes the prev case (1), and 0, and everything else