### PR TITLE
docs: fix git clone command

### DIFF
--- a/docs/pages/tutorials/emojimon/getting-started.mdx
+++ b/docs/pages/tutorials/emojimon/getting-started.mdx
@@ -14,7 +14,7 @@ Most projects in MUD are started by running `pnpm create mud <project name>`, bu
 To get started you can fork or clone from the [Emojimon starter kit repo](https://github.com/latticexyz/emojimon) or use the command below.
 
 ```bash copy
-git clone github.com:latticexyz/emojimon.git
+git clone https://github.com/latticexyz/emojimon.git
 ```
 
 Afterwards, run the following commands to install the dependencies and start up MUD's services (anvil node, contracts deployer, and client):

--- a/docs/pages/tutorials/emojimon/getting-started.mdx
+++ b/docs/pages/tutorials/emojimon/getting-started.mdx
@@ -14,7 +14,7 @@ Most projects in MUD are started by running `pnpm create mud <project name>`, bu
 To get started you can fork or clone from the [Emojimon starter kit repo](https://github.com/latticexyz/emojimon) or use the command below.
 
 ```bash copy
-git clone git@github.com:latticexyz/emojimon.git
+git clone github.com:latticexyz/emojimon.git
 ```
 
 Afterwards, run the following commands to install the dependencies and start up MUD's services (anvil node, contracts deployer, and client):


### PR DESCRIPTION
It doesn't work as `git clone git@github.com`, it works as `git clone github.com`