### PR TITLE
fix(protocol-parser): only append packed counter if there is dynamic data

### DIFF
--- a/packages/protocol-parser/src/encodeRecord.test.ts
+++ b/packages/protocol-parser/src/encodeRecord.test.ts
@@ -9,4 +9,10 @@ describe("encodeRecord", () => {
       "0x0000000100000000000000000000000000000002000000000000130000000008000000000b0000000000000000000000000000000000000300000004736f6d6520737472696e67"
     );
   });
+
+  it("should not include the packed dynamic lengths if there are no dynamic fields", () => {
+    const schema = { staticFields: ["uint32", "uint128"], dynamicFields: [] } as const;
+    const hex = encodeRecord(schema, [1, 2n]);
+    expect(hex).toBe("0x0000000100000000000000000000000000000002");
+  });
 });

--- a/packages/protocol-parser/src/encodeRecord.ts
+++ b/packages/protocol-parser/src/encodeRecord.ts
@@ -20,9 +20,12 @@ export function encodeRecord(schema: Schema, values: readonly (StaticPrimitiveTy
 
   const dynamicData = dynamicDataItems.join("");
 
-  const packedCounter = `${encodeField("uint56", dynamicTotalByteLength).replace(/^0x/, "")}${dynamicFieldByteLengths
-    .map((length) => encodeField("uint40", length).replace(/^0x/, ""))
-    .join("")}`.padEnd(64, "0");
+  const packedCounter =
+    schema.dynamicFields.length > 0
+      ? `${encodeField("uint56", dynamicTotalByteLength).replace(/^0x/, "")}${dynamicFieldByteLengths
+          .map((length) => encodeField("uint40", length).replace(/^0x/, ""))
+          .join("")}`.padEnd(64, "0")
+      : "";
 
   return `0x${staticData}${packedCounter}${dynamicData}`;
 }

--- a/packages/protocol-parser/src/encodeRecord.ts
+++ b/packages/protocol-parser/src/encodeRecord.ts
@@ -11,6 +11,8 @@ export function encodeRecord(schema: Schema, values: readonly (StaticPrimitiveTy
     .map((value, i) => encodeField(schema.staticFields[i], value).replace(/^0x/, ""))
     .join("");
 
+  if (schema.dynamicFields.length === 0) return `0x${staticData}`;
+
   const dynamicDataItems = dynamicValues.map((value, i) =>
     encodeField(schema.dynamicFields[i], value).replace(/^0x/, "")
   );
@@ -20,12 +22,9 @@ export function encodeRecord(schema: Schema, values: readonly (StaticPrimitiveTy
 
   const dynamicData = dynamicDataItems.join("");
 
-  const packedCounter =
-    schema.dynamicFields.length > 0
-      ? `${encodeField("uint56", dynamicTotalByteLength).replace(/^0x/, "")}${dynamicFieldByteLengths
-          .map((length) => encodeField("uint40", length).replace(/^0x/, ""))
-          .join("")}`.padEnd(64, "0")
-      : "";
+  const packedCounter = `${encodeField("uint56", dynamicTotalByteLength).replace(/^0x/, "")}${dynamicFieldByteLengths
+    .map((length) => encodeField("uint40", length).replace(/^0x/, ""))
+    .join("")}`.padEnd(64, "0");
 
   return `0x${staticData}${packedCounter}${dynamicData}`;
 }


### PR DESCRIPTION
* The packed counter is only appended to the encoded data if there is dynamic data: https://github.com/latticexyz/mud/blob/main/packages/store/src/StoreCore.sol#L434-L442