### PR TITLE
chore: synchronize versioning across all packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "latticexyz/mud" }],
   "commit": false,
-  "fixed": [],
+  "fixed": [["*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
- we want all mud packages to have the same version number to make it easier for consumers to upgrade all of them to compatible versions
- more info: https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md