### PR TITLE
chore: update changeset config for snapshot releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "useCalculatedVersion": true,
+  "prereleaseTemplate": "{tag}-{commit}"
 }
 


### PR DESCRIPTION
- use the next release version as snapshot version (+ a tag)
- use the git commit hash as tag