### PR TITLE
fix: remove devEmit when sending events from SyncWorker

### DIFF
--- a/.changeset/tricky-frogs-beam.md
+++ b/.changeset/tricky-frogs-beam.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/network": patch
+---
+
+fix: remove devEmit function when sending network events from SyncWorker

--- a/.changeset/tricky-frogs-beam.md
+++ b/.changeset/tricky-frogs-beam.md
@@ -2,4 +2,4 @@
 "@latticexyz/network": patch
 ---
 
-fix: remove devEmit function when sending network events from SyncWorker
+Remove devEmit function when sending network events from SyncWorker because they can't be serialized across the web worker boundary.

--- a/packages/network/src/types.ts
+++ b/packages/network/src/types.ts
@@ -92,6 +92,7 @@ export type NetworkComponentUpdate<C extends Components = Components> = {
     partialValue?: Partial<ComponentValue<SchemaOf<C[key]>>>;
     initialValue?: ComponentValue<SchemaOf<C[key]>>;
     ephemeral?: boolean;
+    devEmit?: () => void;
   };
 }[keyof C] & {
   entity: Entity;

--- a/packages/network/src/v2/ecsEventFromLog.ts
+++ b/packages/network/src/v2/ecsEventFromLog.ts
@@ -16,7 +16,7 @@ export const ecsEventFromLog = async (
   log: Log,
   parsedLog: LogDescription,
   lastEventInTx: boolean
-): Promise<(NetworkComponentUpdate & { devEmit: () => void }) | undefined> => {
+): Promise<NetworkComponentUpdate | undefined> => {
   const { blockNumber, transactionHash, logIndex } = log;
   const { args, name } = parsedLog;
 

--- a/packages/network/src/v2/fetchStoreEvents.ts
+++ b/packages/network/src/v2/fetchStoreEvents.ts
@@ -42,7 +42,7 @@ export async function fetchStoreEvents(
   // We defer the emissions of dev events because `ecsEventFromLog` is async and emitting them
   // from within that function causes them to arrive out of order. It's better if our emitter
   // can guarantee ordering for now.
-  events.forEach((event) => event.devEmit());
+  events.forEach((event) => event?.devEmit && event.devEmit());
 
   return events;
 }

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -162,7 +162,14 @@ export class SyncWorker<C extends Components> implements DoWork<Input, NetworkEv
         }
       }
 
-      this.output$.next(event as NetworkEvent<C>);
+      const networkEvent = event as NetworkEvent<C>;
+      if (isNetworkComponentUpdateEvent(networkEvent)) {
+        // Remove devEmit from event before passing it to the main thread
+        // because it is not serializable
+        delete networkEvent.devEmit;
+      }
+
+      this.output$.next(networkEvent);
     });
     const streamStartBlockNumberPromise = awaitStreamValue(blockNumber$);
 


### PR DESCRIPTION
big hack that just removes `devEmit` when we are sending events from the SyncWorker

lmk if this is too hacky and you have a less terrible way of doing it