### PR TITLE
test(e2e): actually sync from MODE in e2e test

### DIFF
--- a/e2e/packages/client-vanilla/src/mud/getNetworkConfig.ts
+++ b/e2e/packages/client-vanilla/src/mud/getNetworkConfig.ts
@@ -49,5 +49,6 @@ export async function getNetworkConfig(): Promise<NetworkConfig> {
     initialBlockNumber,
     snapSync: params.get("snapSync") === "true",
     disableCache: params.get("cache") === "false",
+    cacheAgeThreshold: 0,
   };
 }

--- a/e2e/packages/sync-test/rpcSync.test.ts
+++ b/e2e/packages/sync-test/rpcSync.test.ts
@@ -82,6 +82,11 @@ describe("Sync from RPC", async () => {
     await pop(page);
     await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(4999, 1, 0)] } }] });
 
+    // Expect data to still be there after initial sync
+    await page.reload();
+    await waitForInitialSync(page);
+    await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(4999, 1, 0)] } }] });
+
     // Should not have thrown errors
     asyncErrorHandler.expectNoAsyncErrors();
   });

--- a/e2e/packages/sync-test/setup/syncMode.ts
+++ b/e2e/packages/sync-test/setup/syncMode.ts
@@ -21,7 +21,10 @@ export function syncMode(reportError: (error: string) => void) {
 
   modeProcess.stdout?.on("data", (data) => {
     const dataString = data.toString();
-    const errors = extractLineContaining("ERROR", dataString).join("\n");
+    const errors = [
+      ...extractLineContaining("ERROR", dataString),
+      ...extractLineContaining("error while serializing", dataString),
+    ].join("\n");
     if (errors) {
       console.log(chalk.magenta("[mode error]:", errors));
       reject(errors);
@@ -31,7 +34,10 @@ export function syncMode(reportError: (error: string) => void) {
 
   modeProcess.stderr?.on("data", (data) => {
     const dataString = data.toString();
-    const modeErrors = extractLineContaining("ERROR", dataString).join("\n");
+    const modeErrors = [
+      ...extractLineContaining("ERROR", dataString),
+      ...extractLineContaining("error while serializing", dataString),
+    ].join("\n");
     if (modeErrors) {
       const errorMessage = chalk.magenta("[mode error]:", modeErrors);
       console.log(errorMessage);

--- a/packages/network/src/workers/SyncWorker.ts
+++ b/packages/network/src/workers/SyncWorker.ts
@@ -118,7 +118,7 @@ export class SyncWorker<C extends Components> implements DoWork<Input, NetworkEv
     devObservables.worldAddress$.next(worldContract.address);
 
     // Set default values for cacheAgeThreshold and cacheInterval
-    const cacheAgeThreshold = config.cacheAgeThreshold || 100;
+    const cacheAgeThreshold = config.cacheAgeThreshold ?? 100;
     const cacheInterval = config.cacheInterval || 1;
 
     // Set up

--- a/packages/protocol-parser/src/abiTypesToSchema.test.ts
+++ b/packages/protocol-parser/src/abiTypesToSchema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { abiTypesToSchema } from "./abiTypesToSchema";
+
+describe("hexToSchema", () => {
+  it("converts hex to schema", () => {
+    expect(abiTypesToSchema(["bool"])).toMatchInlineSnapshot(`
+      {
+        "dynamicFields": [],
+        "staticFields": [
+          "bool",
+        ],
+      }
+    `);
+    expect(abiTypesToSchema(["bool", "bool[]"])).toMatchInlineSnapshot(`
+      {
+        "dynamicFields": [
+          "bool[]",
+        ],
+        "staticFields": [
+          "bool",
+        ],
+      }
+    `);
+    expect(abiTypesToSchema(["bytes32", "int32", "uint256[]", "address[]", "bytes", "string"])).toMatchInlineSnapshot(`
+      {
+        "dynamicFields": [
+          "uint256[]",
+          "address[]",
+          "bytes",
+          "string",
+        ],
+        "staticFields": [
+          "bytes32",
+          "int32",
+        ],
+      }
+    `);
+  });
+});

--- a/packages/protocol-parser/src/abiTypesToSchema.ts
+++ b/packages/protocol-parser/src/abiTypesToSchema.ts
@@ -1,0 +1,12 @@
+import { DynamicAbiType, SchemaAbiType, StaticAbiType, isDynamicAbiType } from "@latticexyz/schema-type";
+import { Schema } from "./common";
+
+export function abiTypesToSchema(abiTypes: SchemaAbiType[]): Schema {
+  const staticFields: StaticAbiType[] = [];
+  const dynamicFields: DynamicAbiType[] = [];
+  for (const abiType of abiTypes) {
+    if (isDynamicAbiType(abiType)) dynamicFields.push(abiType);
+    else staticFields.push(abiType);
+  }
+  return { staticFields, dynamicFields };
+}

--- a/packages/protocol-parser/src/index.ts
+++ b/packages/protocol-parser/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./abiTypesToSchema";
 export * from "./common";
 export * from "./decodeDynamicField";
 export * from "./decodeKeyTuple";


### PR DESCRIPTION
- turns out the end-to-end tests were never actually syncing from MODE because the cacheThreshold was too high (so the client would always fall back to syncing from the local cache)
- this PR fixes that, and also checks for an additional MODE error that is logged as a warning 
