### PR TITLE
docs: update snap sync example conf

### DIFF
--- a/docs/pages/world/snap-sync.mdx
+++ b/docs/pages/world/snap-sync.mdx
@@ -50,6 +50,7 @@ export default mudConfig({
       },
     },
   },
+  modules: [{ name: "SnapSyncModule", root: true, args: [] }],
 });
 ```
 


### PR DESCRIPTION
To use snap sync, you need install snapsync module first. This PR update the config in snap sync example.