### PR TITLE
refactor(store): clean up Memory, make mcopy pure

### DIFF
--- a/.changeset/nice-pandas-knock.md
+++ b/.changeset/nice-pandas-knock.md
@@ -1,0 +1,8 @@
+---
+"@latticexyz/cli": patch
+"@latticexyz/common": patch
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Clean up Memory.sol, make mcopy pure

--- a/e2e/packages/contracts/src/codegen/tables/Multi.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Multi.sol
@@ -235,7 +235,7 @@ library Multi {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(int256 num, bool value) internal view returns (bytes memory) {
+  function encode(int256 num, bool value) internal pure returns (bytes memory) {
     return abi.encodePacked(num, value);
   }
 

--- a/e2e/packages/contracts/src/codegen/tables/Number.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Number.sol
@@ -100,7 +100,7 @@ library Number {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 value) internal view returns (bytes memory) {
+  function encode(uint32 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/e2e/packages/contracts/src/codegen/tables/NumberList.sol
+++ b/e2e/packages/contracts/src/codegen/tables/NumberList.sol
@@ -169,7 +169,7 @@ library NumberList {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32[] memory value) internal view returns (bytes memory) {
+  function encode(uint32[] memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(value.length * 4);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/e2e/packages/contracts/src/codegen/tables/Vector.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Vector.sol
@@ -196,7 +196,7 @@ library Vector {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(int32 x, int32 y) internal view returns (bytes memory) {
+  function encode(int32 x, int32 y) internal pure returns (bytes memory) {
     return abi.encodePacked(x, y);
   }
 

--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -100,7 +100,7 @@ library CounterTable {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 value) internal view returns (bytes memory) {
+  function encode(uint32 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
@@ -110,7 +110,7 @@ library Inventory {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 amount) internal view returns (bytes memory) {
+  function encode(uint32 amount) internal pure returns (bytes memory) {
     return abi.encodePacked(amount);
   }
 

--- a/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
@@ -83,7 +83,7 @@ library MessageTable {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(string memory value) internal view returns (bytes memory) {
+  function encode(string memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(bytes(value).length);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -735,7 +735,7 @@ library Dynamics1 {
   }
 
   /** Decode the tightly packed blob using this table's schema */
-  function decode(bytes memory _blob) internal view returns (Dynamics1Data memory _table) {
+  function decode(bytes memory _blob) internal pure returns (Dynamics1Data memory _table) {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
@@ -774,7 +774,7 @@ library Dynamics1 {
     uint128[3] memory staticU128,
     address[4] memory staticAddrs,
     bool[5] memory staticBools
-  ) internal view returns (bytes memory) {
+  ) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](5);
     _counters[0] = uint40(staticB32.length * 32);
     _counters[1] = uint40(staticI32.length * 4);
@@ -852,7 +852,7 @@ function toStaticArray_bool_5(bool[] memory _value) pure returns (bool[5] memory
   }
 }
 
-function fromStaticArray_bytes32_1(bytes32[1] memory _value) view returns (bytes32[] memory _result) {
+function fromStaticArray_bytes32_1(bytes32[1] memory _value) pure returns (bytes32[] memory _result) {
   _result = new bytes32[](1);
   uint256 fromPointer;
   uint256 toPointer;
@@ -863,7 +863,7 @@ function fromStaticArray_bytes32_1(bytes32[1] memory _value) view returns (bytes
   Memory.copy(fromPointer, toPointer, 32);
 }
 
-function fromStaticArray_int32_2(int32[2] memory _value) view returns (int32[] memory _result) {
+function fromStaticArray_int32_2(int32[2] memory _value) pure returns (int32[] memory _result) {
   _result = new int32[](2);
   uint256 fromPointer;
   uint256 toPointer;
@@ -874,7 +874,7 @@ function fromStaticArray_int32_2(int32[2] memory _value) view returns (int32[] m
   Memory.copy(fromPointer, toPointer, 64);
 }
 
-function fromStaticArray_uint128_3(uint128[3] memory _value) view returns (uint128[] memory _result) {
+function fromStaticArray_uint128_3(uint128[3] memory _value) pure returns (uint128[] memory _result) {
   _result = new uint128[](3);
   uint256 fromPointer;
   uint256 toPointer;
@@ -885,7 +885,7 @@ function fromStaticArray_uint128_3(uint128[3] memory _value) view returns (uint1
   Memory.copy(fromPointer, toPointer, 96);
 }
 
-function fromStaticArray_address_4(address[4] memory _value) view returns (address[] memory _result) {
+function fromStaticArray_address_4(address[4] memory _value) pure returns (address[] memory _result) {
   _result = new address[](4);
   uint256 fromPointer;
   uint256 toPointer;
@@ -896,7 +896,7 @@ function fromStaticArray_address_4(address[4] memory _value) view returns (addre
   Memory.copy(fromPointer, toPointer, 128);
 }
 
-function fromStaticArray_bool_5(bool[5] memory _value) view returns (bool[] memory _result) {
+function fromStaticArray_bool_5(bool[5] memory _value) pure returns (bool[] memory _result) {
   _result = new bool[](5);
   uint256 fromPointer;
   uint256 toPointer;

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -478,7 +478,7 @@ library Dynamics2 {
   }
 
   /** Decode the tightly packed blob using this table's schema */
-  function decode(bytes memory _blob) internal view returns (Dynamics2Data memory _table) {
+  function decode(bytes memory _blob) internal pure returns (Dynamics2Data memory _table) {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
@@ -503,7 +503,7 @@ library Dynamics2 {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint64[] memory u64, string memory str, bytes memory b) internal view returns (bytes memory) {
+  function encode(uint64[] memory u64, string memory str, bytes memory b) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](3);
     _counters[0] = uint40(u64.length * 8);
     _counters[1] = uint40(bytes(str).length);

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -86,7 +86,7 @@ library Ephemeral {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint256 value) internal view returns (bytes memory) {
+  function encode(uint256 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -451,7 +451,7 @@ library Singleton {
   /** Decode the tightly packed blob using this table's schema */
   function decode(
     bytes memory _blob
-  ) internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
+  ) internal pure returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
     // 32 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 32));
 
@@ -483,7 +483,7 @@ library Singleton {
     uint32[2] memory v2,
     uint32[2] memory v3,
     uint32[1] memory v4
-  ) internal view returns (bytes memory) {
+  ) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](3);
     _counters[0] = uint40(v2.length * 4);
     _counters[1] = uint40(v3.length * 4);
@@ -534,7 +534,7 @@ function toStaticArray_uint32_1(uint32[] memory _value) pure returns (uint32[1] 
   }
 }
 
-function fromStaticArray_uint32_2(uint32[2] memory _value) view returns (uint32[] memory _result) {
+function fromStaticArray_uint32_2(uint32[2] memory _value) pure returns (uint32[] memory _result) {
   _result = new uint32[](2);
   uint256 fromPointer;
   uint256 toPointer;
@@ -545,7 +545,7 @@ function fromStaticArray_uint32_2(uint32[2] memory _value) view returns (uint32[
   Memory.copy(fromPointer, toPointer, 64);
 }
 
-function fromStaticArray_uint32_1(uint32[1] memory _value) view returns (uint32[] memory _result) {
+function fromStaticArray_uint32_1(uint32[1] memory _value) pure returns (uint32[] memory _result) {
   _result = new uint32[](1);
   uint256 fromPointer;
   uint256 toPointer;

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -872,7 +872,7 @@ library Statics {
     bool v5,
     Enum1 v6,
     Enum2 v7
-  ) internal view returns (bytes memory) {
+  ) internal pure returns (bytes memory) {
     return abi.encodePacked(v1, v2, v3, v4, v5, v6, v7);
   }
 

--- a/packages/common/src/codegen/render-solidity/renderTypeHelpers.ts
+++ b/packages/common/src/codegen/render-solidity/renderTypeHelpers.ts
@@ -83,7 +83,7 @@ function renderUnwrapperStaticArray(
   return `
     function ${functionName}(
       ${elementType}[${staticLength}] memory _value
-    ) view returns (
+    ) pure returns (
       ${internalTypeId} memory _result
     ) {
       _result = new ${internalTypeId}(${staticLength});

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -81,7 +81,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "custom decode",
-    "gasUsed": 2124
+    "gasUsed": 2127
   },
   {
     "file": "test/Gas.t.sol",
@@ -123,7 +123,7 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 13455
+    "gasUsed": 13458
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -231,37 +231,37 @@
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (0 bytes) to bytes memory",
-    "gasUsed": 473
+    "gasUsed": 476
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (2 bytes) to bytes memory",
-    "gasUsed": 508
+    "gasUsed": 511
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (32 bytes) to bytes memory",
-    "gasUsed": 507
+    "gasUsed": 724
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (34 bytes) to bytes memory",
-    "gasUsed": 585
+    "gasUsed": 727
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (1024 bytes) to bytes memory",
-    "gasUsed": 4849
+    "gasUsed": 7443
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testToBytes",
     "name": "Slice (1024x1024 bytes) to bytes memory",
-    "gasUsed": 6616506
+    "gasUsed": 9205372
   },
   {
     "file": "test/Slice.t.sol",
@@ -339,25 +339,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 29291
+    "gasUsed": 29294
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 19346
+    "gasUsed": 19349
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 31174
+    "gasUsed": 31177
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 19229
+    "gasUsed": 19232
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -609,13 +609,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 16605
+    "gasUsed": 16611
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 17696
+    "gasUsed": 17702
   },
   {
     "file": "test/StoreMetadata.t.sol",
@@ -627,7 +627,7 @@
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "get record from StoreMetadataTable",
-    "gasUsed": 12116
+    "gasUsed": 12689
   },
   {
     "file": "test/StoreSwitch.t.sol",

--- a/packages/store/src/Memory.sol
+++ b/packages/store/src/Memory.sol
@@ -4,63 +4,45 @@ pragma solidity >=0.8.0;
 import { leftMask } from "./Utils.sol";
 
 library Memory {
-  function load(uint256 memoryPointer) internal pure returns (bytes32 data) {
-    assembly {
-      data := mload(memoryPointer)
-    }
-  }
-
-  function load(uint256 memoryPointer, uint256 offset) internal pure returns (bytes32 data) {
-    assembly {
-      data := mload(add(memoryPointer, offset))
-    }
-  }
-
+  /**
+   * In dynamic arrays the first word stores the length of data, after which comes data.
+   * Example: 0x40 0x01 0x02
+   *          ^len ^data
+   */
   function dataPointer(bytes memory data) internal pure returns (uint256 memoryPointer) {
     assembly {
       memoryPointer := add(data, 0x20)
     }
   }
 
-  function lengthPointer(bytes memory data) internal pure returns (uint256 memoryPointer) {
-    assembly {
-      memoryPointer := data
-    }
-  }
-
-  function store(uint256 memoryPointer, bytes32 value) internal pure {
-    assembly {
-      mstore(memoryPointer, value)
-    }
-  }
-
-  function copy(uint256 fromPointer, uint256 toPointer, uint256 length) internal view {
-    if (length > 32) {
+  function copy(uint256 fromPointer, uint256 toPointer, uint256 length) internal pure {
+    // copy 32-byte chunks
+    while (length >= 32) {
+      /// @solidity memory-safe-assembly
       assembly {
-        pop(
-          staticcall(
-            gas(), // gas (unused is returned)
-            0x04, // identity precompile address
-            fromPointer, // argsOffset
-            length, // argsSize: byte size to copy
-            toPointer, // retOffset
-            length // retSize: byte size to copy
-          )
-        )
+        mstore(toPointer, mload(fromPointer))
       }
-    } else {
-      uint256 mask = leftMask(length);
-      assembly {
-        mstore(
-          toPointer,
-          or(
-            // Store the left part
-            and(mload(fromPointer), mask),
-            // Preserve the right part
-            and(mload(toPointer), not(mask))
-          )
-        )
+      // safe because total addition will be <= length (ptr+len is implicitly safe)
+      unchecked {
+        toPointer += 32;
+        fromPointer += 32;
+        length -= 32;
       }
+    }
+    // copy the 0-31 length tail
+    // (the rest is an inlined `mstoreN`)
+    uint256 mask = leftMask(length);
+    /// @solidity memory-safe-assembly
+    assembly {
+      mstore(
+        toPointer,
+        or(
+          // store the left part
+          and(mload(fromPointer), mask),
+          // preserve the right part
+          and(mload(toPointer), not(mask))
+        )
+      )
     }
   }
 }

--- a/packages/store/src/Memory.sol
+++ b/packages/store/src/Memory.sol
@@ -5,7 +5,7 @@ import { leftMask } from "./Utils.sol";
 
 library Memory {
   /**
-   * In dynamic arrays the first word stores the length of data, after which comes data.
+   * In dynamic arrays the first word stores the length of data, after which comes the data.
    * Example: 0x40 0x01 0x02
    *          ^len ^data
    */
@@ -16,21 +16,20 @@ library Memory {
   }
 
   function copy(uint256 fromPointer, uint256 toPointer, uint256 length) internal pure {
-    // copy 32-byte chunks
+    // Copy 32-byte chunks
     while (length >= 32) {
       /// @solidity memory-safe-assembly
       assembly {
         mstore(toPointer, mload(fromPointer))
       }
-      // safe because total addition will be <= length (ptr+len is implicitly safe)
+      // Safe because total addition will be <= length (ptr+len is implicitly safe)
       unchecked {
         toPointer += 32;
         fromPointer += 32;
         length -= 32;
       }
     }
-    // copy the 0-31 length tail
-    // (the rest is an inlined `mstoreN`)
+    // Copy the 0-31 length tail
     uint256 mask = leftMask(length);
     /// @solidity memory-safe-assembly
     assembly {

--- a/packages/store/src/Slice.sol
+++ b/packages/store/src/Slice.sol
@@ -85,7 +85,7 @@ library SliceInstance {
    * @dev Copies the slice to a new bytes array
    * The slice will NOT point to the new bytes array
    */
-  function toBytes(Slice self) internal view returns (bytes memory data) {
+  function toBytes(Slice self) internal pure returns (bytes memory data) {
     uint256 fromPointer = pointer(self);
     uint256 _length = length(self);
 

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -436,7 +436,9 @@ library StoreCore {
     memoryPointer += staticLength;
 
     // Append the encoded dynamic length
-    Memory.store(memoryPointer, dynamicDataLength.unwrap());
+    assembly {
+      mstore(memoryPointer, dynamicDataLength)
+    }
     // Advance memoryPointer by the length of `dynamicDataLength` (1 word)
     memoryPointer += 0x20;
 

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -184,7 +184,7 @@ library Callbacks {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bytes24[] memory value) internal view returns (bytes memory) {
+  function encode(bytes24[] memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(value.length * 24);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -184,7 +184,7 @@ library Hooks {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address[] memory value) internal view returns (bytes memory) {
+  function encode(address[] memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(value.length * 20);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -152,7 +152,7 @@ library KeyEncoding {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bool value) internal view returns (bytes memory) {
+  function encode(bool value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -431,7 +431,7 @@ library Mixed {
   }
 
   /** Decode the tightly packed blob using this table's schema */
-  function decode(bytes memory _blob) internal view returns (MixedData memory _table) {
+  function decode(bytes memory _blob) internal pure returns (MixedData memory _table) {
     // 20 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 20));
 
@@ -456,7 +456,7 @@ library Mixed {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal view returns (bytes memory) {
+  function encode(uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](2);
     _counters[0] = uint40(a32.length * 4);
     _counters[1] = uint40(bytes(s).length);

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -364,7 +364,7 @@ library StoreMetadata {
   }
 
   /** Decode the tightly packed blob using this table's schema */
-  function decode(bytes memory _blob) internal view returns (StoreMetadataData memory _table) {
+  function decode(bytes memory _blob) internal pure returns (StoreMetadataData memory _table) {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
@@ -385,7 +385,7 @@ library StoreMetadata {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(string memory tableName, bytes memory abiEncodedFieldNames) internal view returns (bytes memory) {
+  function encode(string memory tableName, bytes memory abiEncodedFieldNames) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](2);
     _counters[0] = uint40(bytes(tableName).length);
     _counters[1] = uint40(bytes(abiEncodedFieldNames).length);

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -196,7 +196,7 @@ library Vector2 {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 x, uint32 y) internal view returns (bytes memory) {
+  function encode(uint32 x, uint32 y) internal pure returns (bytes memory) {
     return abi.encodePacked(x, y);
   }
 

--- a/packages/store/ts/codegen/record.ts
+++ b/packages/store/ts/codegen/record.ts
@@ -95,7 +95,7 @@ function renderDecodeFunction({ structName, fields, staticFields, dynamicFields 
     // decode static (optionally) and dynamic data
     return `
     /** Decode the tightly packed blob using this table's schema */
-    function decode(bytes memory _blob) internal view returns (${renderedDecodedRecord}) {
+    function decode(bytes memory _blob) internal pure returns (${renderedDecodedRecord}) {
       // ${totalStaticLength} is the total byte length of static data
       PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, ${totalStaticLength})); 
 

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -124,7 +124,7 @@ library ${libraryName} {
   /** Tightly pack full data using this table's schema */
   function encode(${renderArguments(
     options.fields.map(({ name, typeWithLocation }) => `${typeWithLocation} ${name}`)
-  )}) internal view returns (bytes memory) {
+  )}) internal pure returns (bytes memory) {
     ${renderEncodedLengths(dynamicFields)}
     return abi.encodePacked(${renderArguments([
       renderArguments(staticFields.map(({ name }) => name)),

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -39,7 +39,7 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 292113
+    "gasUsed": 292632
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -57,7 +57,7 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 153351
+    "gasUsed": 153524
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -297,24 +297,24 @@
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 38033
+    "gasUsed": 38043
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 22830
+    "gasUsed": 22833
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 40364
+    "gasUsed": 40377
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 25566
+    "gasUsed": 25579
   }
 ]

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -235,7 +235,7 @@ library FunctionSelectors {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) internal view returns (bytes memory) {
+  function encode(bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) internal pure returns (bytes memory) {
     return abi.encodePacked(namespace, name, systemFunctionSelector);
   }
 

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -103,7 +103,7 @@ library ResourceType {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(Resource resourceType) internal view returns (bytes memory) {
+  function encode(Resource resourceType) internal pure returns (bytes memory) {
     return abi.encodePacked(resourceType);
   }
 

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -184,7 +184,7 @@ library SystemHooks {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address[] memory value) internal view returns (bytes memory) {
+  function encode(address[] memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(value.length * 20);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -100,7 +100,7 @@ library SystemRegistry {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bytes32 resourceSelector) internal view returns (bytes memory) {
+  function encode(bytes32 resourceSelector) internal pure returns (bytes memory) {
     return abi.encodePacked(resourceSelector);
   }
 

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -181,7 +181,7 @@ library Systems {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address system, bool publicAccess) internal view returns (bytes memory) {
+  function encode(address system, bool publicAccess) internal pure returns (bytes memory) {
     return abi.encodePacked(system, publicAccess);
   }
 

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -735,7 +735,7 @@ library KeysInTable {
   }
 
   /** Decode the tightly packed blob using this table's schema */
-  function decode(bytes memory _blob) internal view returns (KeysInTableData memory _table) {
+  function decode(bytes memory _blob) internal pure returns (KeysInTableData memory _table) {
     // 0 is the total byte length of static data
     PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
 
@@ -774,7 +774,7 @@ library KeysInTable {
     bytes32[] memory keys2,
     bytes32[] memory keys3,
     bytes32[] memory keys4
-  ) internal view returns (bytes memory) {
+  ) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](5);
     _counters[0] = uint40(keys0.length * 32);
     _counters[1] = uint40(keys1.length * 32);

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -194,7 +194,7 @@ library UsedKeysIndex {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bool has, uint40 index) internal view returns (bytes memory) {
+  function encode(bool has, uint40 index) internal pure returns (bytes memory) {
     return abi.encodePacked(has, index);
   }
 

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -185,7 +185,7 @@ library KeysWithValue {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bytes32[] memory keysWithValue) internal view returns (bytes memory) {
+  function encode(bytes32[] memory keysWithValue) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(keysWithValue.length * 32);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -92,7 +92,7 @@ library UniqueEntity {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint256 value) internal view returns (bytes memory) {
+  function encode(uint256 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -174,7 +174,7 @@ library InstalledModules {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address moduleAddress) internal view returns (bytes memory) {
+  function encode(address moduleAddress) internal pure returns (bytes memory) {
     return abi.encodePacked(moduleAddress);
   }
 

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -100,7 +100,7 @@ library NamespaceOwner {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address owner) internal view returns (bytes memory) {
+  function encode(address owner) internal pure returns (bytes memory) {
     return abi.encodePacked(owner);
   }
 

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -105,7 +105,7 @@ library ResourceAccess {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bool access) internal view returns (bytes memory) {
+  function encode(bool access) internal pure returns (bytes memory) {
     return abi.encodePacked(access);
   }
 

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -181,7 +181,7 @@ library AddressArray {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(address[] memory value) internal view returns (bytes memory) {
+  function encode(address[] memory value) internal pure returns (bytes memory) {
     uint40[] memory _counters = new uint40[](1);
     _counters[0] = uint40(value.length * 20);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -92,7 +92,7 @@ library Bool {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(bool value) internal view returns (bytes memory) {
+  function encode(bool value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
@@ -95,7 +95,7 @@ library Counter {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 value) internal view returns (bytes memory) {
+  function encode(uint32 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/templates/react/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/react/packages/contracts/src/codegen/tables/Counter.sol
@@ -95,7 +95,7 @@ library Counter {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 value) internal view returns (bytes memory) {
+  function encode(uint32 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -235,7 +235,7 @@ library Position {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(int32 x, int32 y, int32 z) internal view returns (bytes memory) {
+  function encode(int32 x, int32 y, int32 z) internal pure returns (bytes memory) {
     return abi.encodePacked(x, y, z);
   }
 

--- a/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
@@ -95,7 +95,7 @@ library Counter {
   }
 
   /** Tightly pack full data using this table's schema */
-  function encode(uint32 value) internal view returns (bytes memory) {
+  function encode(uint32 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/1086
fixes part of https://github.com/latticexyz/mud/issues/1133

this significantly ups the gas cost of mcopy and consequently `Slice.toBytes()`, but we shouldn't need this memory copying in the first place, which I'll address in a later PR

(it doesn't affect much, only some dynamic fields)