### PR TITLE
ci: fix changeset release config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,9 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "useCalculatedVersion": true,
-  "prereleaseTemplate": "{tag}-{commit}"
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "{tag}-{commit}"
+  }
 }
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "latticexyz/mud" }],
   "commit": false,
-  "fixed": [["*"]],
+  "fixed": [["**"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
- fixes changeset config to properly release snapshot releases with the snapshot action and release all MUD packages with the same version