### PR TITLE
feat(cli): update set-version to match new release structure, add `--tag`, `--commit`

### DIFF
--- a/.changeset/thin-buses-reply.md
+++ b/.changeset/thin-buses-reply.md
@@ -1,0 +1,15 @@
+---
+"@latticexyz/cli": minor
+---
+
+- update the `set-version` cli command to work with the new release process by adding two new options:
+  - `--tag`: install the latest version of the given tag. For snapshot releases tags correspond to the branch name, commits to `main` result in an automatic snapshot release, so `--tag main` is equivalent to what used to be `-v canary`
+  - `--commit`: install a version based on a given commit hash. Since commits from `main` result in an automatic snapshot release it works for all commits on main, and it works for manual snapshot releases from branches other than main
+- `set-version` now updates all `package.json` nested below the current working directory (expect `node_modules`), so no need for running it each workspace of a monorepo separately.
+
+Example:
+
+```bash
+pnpm mud set-version --tag main && pnpm install
+pnpm mud set-version --commit db19ea39 && pnpm install
+```

--- a/packages/cli/src/commands/set-version.ts
+++ b/packages/cli/src/commands/set-version.ts
@@ -68,19 +68,9 @@ const commandModule: CommandModule<Options, Options> = {
       options.mudVersion = await resolveVersion(options);
 
       // Update all package.json below the current working directory (except in node_modules)
-      const packageJsons = glob.sync("**/package.json");
-      console.log("All package.jsons", packageJsons);
-
-      // Read the current package.json
-      const rootPath = "./package.json";
-      const { workspaces } = updatePackageJson(rootPath, options);
-
-      // Load the package.json of each workspace
-      if (workspaces) {
-        for (const workspace of workspaces) {
-          const filePath = path.join(workspace, "/package.json");
-          updatePackageJson(filePath, options);
-        }
+      const packageJsons = glob.sync("**/package.json").filter((p) => !p.includes("node_modules"));
+      for (const packageJson of packageJsons) {
+        updatePackageJson(packageJson, options);
       }
     } catch (e) {
       logError(e);

--- a/templates/phaser/package.json
+++ b/templates/phaser/package.json
@@ -7,7 +7,7 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
-    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -7,7 +7,7 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
-    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },

--- a/templates/threejs/package.json
+++ b/templates/threejs/package.json
@@ -7,7 +7,7 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
-    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -7,7 +7,7 @@
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
-    "mud:up": "pnpm recursive exec mud set-version -v canary && pnpm install",
+    "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
     "test": "pnpm recursive run test"
   },


### PR DESCRIPTION
- updates the `set-version` cli command to work with the new release structure by adding two new options:
  - `--tag`: install the latest version of the given tag. For snapshot releases tags correspond to the branch name, commits to `main` result in an automatic snapshot release, so `--tag main` is equivalent to what used to be `-v canary`
  - `--commit`: install a version based on a given commit hash. Since commits from `main` result in an automatic snapshot release it works for all commits on main, and it works for manual snapshot releases from branches
- `set-version` now updates all `package.json` nested below the current working directory (expect `node_modules`), so no need for running it each workspace of a monorepo separately.