### PR TITLE
fix(cli): add support for legacy transactions in deploy script

### DIFF
--- a/.changeset/afraid-hotels-bathe.md
+++ b/.changeset/afraid-hotels-bathe.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Add support for legacy transactions in deploy script by falling back to `gasPrice` if `lastBaseFeePerGas` is not available

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -573,7 +573,7 @@ export async function deploy(
         : Math.floor(1_500_000_000 * multiplier)
       : undefined;
     if (maxPriorityFeePerGas) {
-      maxFeePerGas = feeData.lastBaseFeePerGas ? feeData.lastBaseFeePerGas.mul(2).add(maxPriorityFeePerGas) : undefined;
+      maxFeePerGas = feeData.lastBaseFeePerGas?.mul(2).add(maxPriorityFeePerGas);
     } else {
       gasPrice = feeData.gasPrice;
     }

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -572,9 +572,11 @@ export async function deploy(
         ? 0
         : Math.floor(1_500_000_000 * multiplier)
       : undefined;
-    if (maxPriorityFeePerGas)
+    if (maxPriorityFeePerGas) {
       maxFeePerGas = feeData.lastBaseFeePerGas ? feeData.lastBaseFeePerGas.mul(2).add(maxPriorityFeePerGas) : undefined;
-    gasPrice = feeData.gasPrice;
+    } else {
+      gasPrice = feeData.gasPrice;
+    }
   }
 }
 

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -401,7 +401,7 @@ export async function deploy(
       console.log(chalk.gray(`executing deployment of ${contractName} with nonce ${nonce}`));
       let deployPromise;
 
-      if (maxFeePerGas && maxPriorityFeePerGas) {
+      if (maxFeePerGas !== undefined && maxPriorityFeePerGas !== undefined) {
         deployPromise = factory
           .deploy({
             nonce: nonce++,
@@ -410,7 +410,7 @@ export async function deploy(
           })
           .then((c) => (disableTxWait ? c : c.deployed()));
         /// Gas Price === Legacy
-      } else if (gasPrice) {
+      } else if (gasPrice !== null) {
         deployPromise = factory
           .deploy({
             nonce: nonce++,

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -512,8 +512,15 @@ export async function deploy(
     try {
       const gasLimit = await contract.estimateGas[func].apply(null, args);
       console.log(chalk.gray(`executing transaction: ${functionName} with nonce ${nonce}`));
+      const _baseTxConfig = { gasLimit, nonce: nonce++ };
+      const txConfig = Object.assign(
+        _baseTxConfig,
+        maxPriorityFeePerGas !== undefined && maxFeePerGas !== undefined
+          ? { maxPriorityFeePerGas, maxFeePerGas }
+          : { gasPrice }
+      );
       const txPromise = contract[func]
-        .apply(null, [...args, { gasLimit, nonce: nonce++, maxPriorityFeePerGas, maxFeePerGas }])
+        .apply(null, [...args, txConfig])
         .then((tx: any) => (confirmations === 0 ? tx : tx.wait(confirmations)));
       promises.push(txPromise);
       return txPromise;

--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -414,6 +414,7 @@ export async function deploy(
         deployPromise = factory
           .deploy({
             nonce: nonce++,
+            gasPrice,
           })
           .then((c) => (disableTxWait ? c : c.deployed()));
       } else {


### PR DESCRIPTION
The Problem
---
Currently if you try to deploy to networks that do not support EIP-1559 then you need to use the --legacy flag within foundry. The custom deploy script as part of the @latticexyz/cli package throws an error on deploy. This blocks the usage of MUD on SKALE (https://skale.space) which is arguably a top network choice for MUD due to the fast speed and zero gas fees.

The Solution
---
I have made a minor update to the script so that it uses EIP-1159 if the values exist, otherwise it falls back to just gasPrice which works on legacy networks i.e SKALE Chains. 

If all values are undefined then it throws an error which is a catch all meaning that there should not be any new issues that arise. 

Note: I have not done any changeset or bumped version as the documentation on both is limited. 