### PR TITLE
fix(common): TableId.toHex should also truncate

### DIFF
--- a/packages/common/src/TableId.test.ts
+++ b/packages/common/src/TableId.test.ts
@@ -16,20 +16,18 @@ describe("TableId", () => {
   });
 
   it("truncates namespaces >16 bytes", () => {
-    expect(TableId.toHex("AVeryLongNamespace", "name")).toMatchInlineSnapshot();
+    const hex = "0x41566572794c6f6e674e616d657370616e616d65000000000000000000000000";
+    expect(TableId.toHex("AVeryLongNamespace", "name")).toEqual(hex);
     const tableId = new TableId("AVeryLongNamespace", "name");
-    expect(tableId.toHex()).toMatchInlineSnapshot(
-      '"0x41566572794c6f6e674e616d657370616e616d65000000000000000000000000"'
-    );
+    expect(tableId.toHex()).toEqual(hex);
     expect(TableId.fromHex(tableId.toHex()).namespace).toMatchInlineSnapshot('"AVeryLongNamespa"');
   });
 
   it("truncates names >16 bytes", () => {
-    expect(TableId.toHex("namespace", "AnUnnecessarilyLongName")).toMatchInlineSnapshot();
+    const hex = "0x6e616d65737061636500000000000000416e556e6e65636573736172696c794c";
+    expect(TableId.toHex("namespace", "AnUnnecessarilyLongName")).toEqual(hex);
     const tableId = new TableId("namespace", "AnUnnecessarilyLongName");
-    expect(tableId.toHex()).toMatchInlineSnapshot(
-      '"0x6e616d65737061636500000000000000416e556e6e65636573736172696c794c"'
-    );
+    expect(tableId.toHex()).toEqual(hex);
     expect(TableId.fromHex(tableId.toHex()).name).toMatchInlineSnapshot('"AnUnnecessarilyL"');
   });
 });

--- a/packages/common/src/TableId.test.ts
+++ b/packages/common/src/TableId.test.ts
@@ -9,7 +9,14 @@ describe("TableId", () => {
     );
   });
 
+  it("can convert from hex string", () => {
+    const tableId = TableId.fromHex("0x6e616d657370616365000000000000006e616d65000000000000000000000000");
+    expect(tableId.namespace).toMatchInlineSnapshot('"namespace"');
+    expect(tableId.name).toMatchInlineSnapshot('"name"');
+  });
+
   it("truncates namespaces >16 bytes", () => {
+    expect(TableId.toHex("AVeryLongNamespace", "name")).toMatchInlineSnapshot();
     const tableId = new TableId("AVeryLongNamespace", "name");
     expect(tableId.toHex()).toMatchInlineSnapshot(
       '"0x41566572794c6f6e674e616d657370616e616d65000000000000000000000000"'
@@ -18,16 +25,11 @@ describe("TableId", () => {
   });
 
   it("truncates names >16 bytes", () => {
+    expect(TableId.toHex("namespace", "AnUnnecessarilyLongName")).toMatchInlineSnapshot();
     const tableId = new TableId("namespace", "AnUnnecessarilyLongName");
     expect(tableId.toHex()).toMatchInlineSnapshot(
       '"0x6e616d65737061636500000000000000416e556e6e65636573736172696c794c"'
     );
     expect(TableId.fromHex(tableId.toHex()).name).toMatchInlineSnapshot('"AnUnnecessarilyL"');
-  });
-
-  it("can convert from hex string", () => {
-    const tableId = TableId.fromHex("0x6e616d657370616365000000000000006e616d65000000000000000000000000");
-    expect(tableId.namespace).toMatchInlineSnapshot('"namespace"');
-    expect(tableId.name).toMatchInlineSnapshot('"name"');
   });
 });

--- a/packages/common/src/TableId.ts
+++ b/packages/common/src/TableId.ts
@@ -18,7 +18,10 @@ export class TableId {
   }
 
   static toHex(namespace: string, name: string): Hex {
-    return concatHex([stringToHex(namespace, { size: 16 }), stringToHex(name, { size: 16 })]);
+    return concatHex([
+      stringToHex(namespace.substring(0, 16), { size: 16 }),
+      stringToHex(name.substring(0, 16), { size: 16 }),
+    ]);
   }
 
   static fromHex(hex: Hex): TableId {


### PR DESCRIPTION
missed this in #1173 when pulling changes from #1113 