### PR TITLE
feat(world): Add support for composite keys in KeysWithValue module

### DIFF
--- a/docs/pages/world/modules.mdx
+++ b/docs/pages/world/modules.mdx
@@ -87,7 +87,7 @@ Internally, it works by installing a [hook](https://v2.mud.dev/store/advanced-fe
 
 #### **`KeysWithValueModule`**
 
-The [`KeysWithValueModule`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol) allows for querying for all keys that have a given value in a table. It can only be used on tables that have one key (eg: ECS components).
+The [`KeysWithValueModule`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol) allows for querying for all keys that have a given value in a table. It can only be used on tables that have up to five keys.
 
 As an example, this can be used to ask for all NFTs owned by a specific user (if the table models `NFT ID → Owner`), or all units on a specific position (if the ECS component is modeled as `entity → Position`)
 
@@ -106,7 +106,7 @@ Using `getKeysWithValue` to retrieve all NFTs owned by a specific address:
 import { getKeysWithValue } from "@latticexyz/world/src/modules/keyswithvalue/getKeysWithValue.sol";
 import { Owners, OwnersId } from "../codegen/tables/Owners.sol";
 // get all nfts (as bytes, need to convert to uint256) owned by address 0x42
-bytes32[] memory keysWithValue = getKeysWithValue(world, OwnersId, Owners.encode(address(42)));
+bytes32[][] memory keysWithValue = getKeysWithValue(world, OwnersId, Owners.encode(address(42)));
 ```
 
 Internally, it works by installing a [hook](/store/advanced-features#storage-hooks) that maintains an array of all keys in the table.

--- a/examples/minimal/packages/contracts/test/CounterTest.t.sol
+++ b/examples/minimal/packages/contracts/test/CounterTest.t.sol
@@ -42,7 +42,7 @@ contract CounterTest is MudTest {
   function testKeysWithValue() public {
     bytes32 key = SingletonKey;
     uint32 counter = CounterTable.get(key);
-    bytes32[] memory keysWithValue = getKeysWithValue(CounterTableTableId, CounterTable.encode(counter));
+    bytes32[][] memory keysWithValue = getKeysWithValue(CounterTableTableId, CounterTable.encode(counter));
     assertEq(keysWithValue.length, 1);
   }
 }

--- a/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
+++ b/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
@@ -2,6 +2,22 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "SchemaLib_InvalidLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SchemaLib_StaticTypeAfterDynamicType",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/mud.config.ts
+++ b/packages/world/mud.config.ts
@@ -101,7 +101,11 @@ export default mudConfig({
         valueHash: "bytes32",
       },
       schema: {
-        keysWithValue: "bytes32[]", // For now only supports 1 key per value
+        keys0: "bytes32[]",
+        keys1: "bytes32[]",
+        keys2: "bytes32[]",
+        keys3: "bytes32[]",
+        keys4: "bytes32[]",
       },
       tableIdArgument: true,
     },

--- a/packages/world/src/Tables.sol
+++ b/packages/world/src/Tables.sol
@@ -11,7 +11,7 @@ import { SystemRegistry, SystemRegistryTableId } from "./modules/core/tables/Sys
 import { SystemHooks, SystemHooksTableId } from "./modules/core/tables/SystemHooks.sol";
 import { ResourceType, ResourceTypeTableId } from "./modules/core/tables/ResourceType.sol";
 import { FunctionSelectors, FunctionSelectorsTableId } from "./modules/core/tables/FunctionSelectors.sol";
-import { KeysWithValue } from "./modules/keyswithvalue/tables/KeysWithValue.sol";
+import { KeysWithValue, KeysWithValueData } from "./modules/keyswithvalue/tables/KeysWithValue.sol";
 import { KeysInTable, KeysInTableData, KeysInTableTableId } from "./modules/keysintable/tables/KeysInTable.sol";
 import { UsedKeysIndex, UsedKeysIndexTableId } from "./modules/keysintable/tables/UsedKeysIndex.sol";
 import { UniqueEntity } from "./modules/uniqueentity/tables/UniqueEntity.sol";

--- a/packages/world/src/modules/keysintable/query.sol
+++ b/packages/world/src/modules/keysintable/query.sol
@@ -20,14 +20,6 @@ struct QueryFragment {
   bytes value;
 }
 
-function valuesToTuples(bytes32[] memory flatArr) pure returns (bytes32[][] memory arr) {
-  arr = new bytes32[][](flatArr.length);
-  for (uint256 i; i < flatArr.length; i++) {
-    arr[i] = new bytes32[](1);
-    arr[i][0] = flatArr[i];
-  }
-}
-
 /**
  * Helper function to check whether a given key passes a given query fragment.
  *
@@ -45,7 +37,7 @@ function passesQueryFragment(bytes32[] memory keyTuple, QueryFragment memory fra
 
   if (fragment.queryType == QueryType.HasValue) {
     // Key must have the given value
-    return ArrayLib.includes(valuesToTuples(getKeysWithValue(fragment.tableId, fragment.value)), keyTuple);
+    return ArrayLib.includes(getKeysWithValue(fragment.tableId, fragment.value), keyTuple);
   }
 
   if (fragment.queryType == QueryType.Not) {
@@ -55,7 +47,7 @@ function passesQueryFragment(bytes32[] memory keyTuple, QueryFragment memory fra
 
   if (fragment.queryType == QueryType.NotValue) {
     // Key must not have the given value
-    return !ArrayLib.includes(valuesToTuples(getKeysWithValue(fragment.tableId, fragment.value)), keyTuple);
+    return !ArrayLib.includes(getKeysWithValue(fragment.tableId, fragment.value), keyTuple);
   }
 
   return false;
@@ -78,7 +70,7 @@ function passesQueryFragment(
 
   if (fragment.queryType == QueryType.HasValue) {
     // Key must be have the given value
-    return ArrayLib.includes(valuesToTuples(getKeysWithValue(store, fragment.tableId, fragment.value)), keyTuple);
+    return ArrayLib.includes(getKeysWithValue(store, fragment.tableId, fragment.value), keyTuple);
   }
 
   if (fragment.queryType == QueryType.Not) {
@@ -88,7 +80,7 @@ function passesQueryFragment(
 
   if (fragment.queryType == QueryType.NotValue) {
     // Key must not have the given value
-    return !ArrayLib.includes(valuesToTuples(getKeysWithValue(store, fragment.tableId, fragment.value)), keyTuple);
+    return !ArrayLib.includes(getKeysWithValue(store, fragment.tableId, fragment.value), keyTuple);
   }
 
   return false;
@@ -108,7 +100,7 @@ function query(QueryFragment[] memory fragments) view returns (bytes32[][] memor
   // Create the first interim result
   keyTuples = fragments[0].queryType == QueryType.Has
     ? getKeysInTable(fragments[0].tableId)
-    : valuesToTuples(getKeysWithValue(fragments[0].tableId, fragments[0].value));
+    : getKeysWithValue(fragments[0].tableId, fragments[0].value);
 
   for (uint256 i = 1; i < fragments.length; i++) {
     bytes32[][] memory result = new bytes32[][](0);
@@ -143,7 +135,7 @@ function query(IStore store, QueryFragment[] memory fragments) view returns (byt
   // Create the first interim result
   keyTuples = fragments[0].queryType == QueryType.Has
     ? getKeysInTable(store, fragments[0].tableId)
-    : valuesToTuples(getKeysWithValue(store, fragments[0].tableId, fragments[0].value));
+    : getKeysWithValue(store, fragments[0].tableId, fragments[0].value);
 
   for (uint256 i = 1; i < fragments.length; i++) {
     bytes32[][] memory result = new bytes32[][](0);

--- a/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol
+++ b/packages/world/src/modules/keyswithvalue/KeysWithValueModule.sol
@@ -20,7 +20,7 @@ import { getTargetTableSelector } from "../utils/getTargetTableSelector.sol";
  * from value to list of keys with this value. This mapping is stored in a table registered
  * by the module at the `targetTableId` provided in the install methods arguments.
  *
- * Note: if a table with composite keys is used, only the first key is indexed
+ * Note: this module only supports up to 5 composite keys.
  *
  * Note: this module currently expects to be `delegatecalled` via World.installRootModule.
  * Support for installing it via `World.installModule` depends on `World.callFrom` being implemented.

--- a/packages/world/src/modules/keyswithvalue/getKeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/getKeysWithValue.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.0;
 
 import { IStore } from "@latticexyz/store/src/IStore.sol";
+import { Schema } from "@latticexyz/store/src/Schema.sol";
+import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { MODULE_NAMESPACE } from "./constants.sol";
 import { KeysWithValue } from "./tables/KeysWithValue.sol";
@@ -13,12 +15,35 @@ import { getTargetTableSelector } from "../utils/getTargetTableSelector.sol";
  * Note: this util can only be called within the context of a Store (e.g. from a System or Module).
  * For usage outside of a Store, use the overload that takes an explicit store argument.
  */
-function getKeysWithValue(bytes32 tableId, bytes memory value) view returns (bytes32[] memory keysWithValue) {
+function getKeysWithValue(bytes32 tableId, bytes memory value) view returns (bytes32[][] memory keyTuples) {
   // Get the corresponding reverse mapping table
   bytes32 keysWithValueTableId = getTargetTableSelector(MODULE_NAMESPACE, tableId);
+  bytes32 valueHash = keccak256(value);
 
-  // Get the keys with the given value
-  keysWithValue = KeysWithValue.get(keysWithValueTableId, keccak256(value));
+  Schema schema = StoreSwitch.getKeySchema(tableId);
+  uint256 numFields = schema.numFields();
+  uint256 length = KeysWithValue.lengthKeys0(keysWithValueTableId, valueHash);
+  keyTuples = new bytes32[][](length);
+
+  for (uint256 i; i < length; i++) {
+    keyTuples[i] = new bytes32[](numFields); // the length of the key tuple depends on the schema
+
+    if (numFields > 0) {
+      keyTuples[i][0] = KeysWithValue.getItemKeys0(keysWithValueTableId, valueHash, i);
+      if (numFields > 1) {
+        keyTuples[i][1] = KeysWithValue.getItemKeys1(keysWithValueTableId, valueHash, i);
+        if (numFields > 2) {
+          keyTuples[i][2] = KeysWithValue.getItemKeys2(keysWithValueTableId, valueHash, i);
+          if (numFields > 3) {
+            keyTuples[i][3] = KeysWithValue.getItemKeys3(keysWithValueTableId, valueHash, i);
+            if (numFields > 4) {
+              keyTuples[i][4] = KeysWithValue.getItemKeys4(keysWithValueTableId, valueHash, i);
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -28,10 +53,33 @@ function getKeysWithValue(
   IStore store,
   bytes32 tableId,
   bytes memory value
-) view returns (bytes32[] memory keysWithValue) {
+) view returns (bytes32[][] memory keyTuples) {
   // Get the corresponding reverse mapping table
   bytes32 keysWithValueTableId = getTargetTableSelector(MODULE_NAMESPACE, tableId);
+  bytes32 valueHash = keccak256(value);
 
-  // Get the keys with the given value
-  keysWithValue = KeysWithValue.get(store, keysWithValueTableId, keccak256(value));
+  Schema schema = store.getKeySchema(tableId);
+  uint256 numFields = schema.numFields();
+  uint256 length = KeysWithValue.lengthKeys0(store, keysWithValueTableId, valueHash);
+  keyTuples = new bytes32[][](length);
+
+  for (uint256 i; i < length; i++) {
+    keyTuples[i] = new bytes32[](numFields); // the length of the key tuple depends on the schema
+
+    if (numFields > 0) {
+      keyTuples[i][0] = KeysWithValue.getItemKeys0(store, keysWithValueTableId, valueHash, i);
+      if (numFields > 1) {
+        keyTuples[i][1] = KeysWithValue.getItemKeys1(store, keysWithValueTableId, valueHash, i);
+        if (numFields > 2) {
+          keyTuples[i][2] = KeysWithValue.getItemKeys2(store, keysWithValueTableId, valueHash, i);
+          if (numFields > 3) {
+            keyTuples[i][3] = KeysWithValue.getItemKeys3(store, keysWithValueTableId, valueHash, i);
+            if (numFields > 4) {
+              keyTuples[i][4] = KeysWithValue.getItemKeys4(store, keysWithValueTableId, valueHash, i);
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -17,11 +17,23 @@ import { EncodeArray } from "@latticexyz/store/src/tightcoder/EncodeArray.sol";
 import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
+struct KeysWithValueData {
+  bytes32[] keys0;
+  bytes32[] keys1;
+  bytes32[] keys2;
+  bytes32[] keys3;
+  bytes32[] keys4;
+}
+
 library KeysWithValue {
   /** Get the table's schema */
   function getSchema() internal pure returns (Schema) {
-    SchemaType[] memory _schema = new SchemaType[](1);
+    SchemaType[] memory _schema = new SchemaType[](5);
     _schema[0] = SchemaType.BYTES32_ARRAY;
+    _schema[1] = SchemaType.BYTES32_ARRAY;
+    _schema[2] = SchemaType.BYTES32_ARRAY;
+    _schema[3] = SchemaType.BYTES32_ARRAY;
+    _schema[4] = SchemaType.BYTES32_ARRAY;
 
     return SchemaLib.encode(_schema);
   }
@@ -35,8 +47,12 @@ library KeysWithValue {
 
   /** Get the table's metadata */
   function getMetadata() internal pure returns (string memory, string[] memory) {
-    string[] memory _fieldNames = new string[](1);
-    _fieldNames[0] = "keysWithValue";
+    string[] memory _fieldNames = new string[](5);
+    _fieldNames[0] = "keys0";
+    _fieldNames[1] = "keys1";
+    _fieldNames[2] = "keys2";
+    _fieldNames[3] = "keys3";
+    _fieldNames[4] = "keys4";
     return ("KeysWithValue", _fieldNames);
   }
 
@@ -62,8 +78,8 @@ library KeysWithValue {
     _store.setMetadata(_tableId, _tableName, _fieldNames);
   }
 
-  /** Get keysWithValue */
-  function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
+  /** Get keys0 */
+  function getKeys0(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -71,12 +87,8 @@ library KeysWithValue {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keysWithValue (using the specified store) */
-  function get(
-    IStore _store,
-    bytes32 _tableId,
-    bytes32 valueHash
-  ) internal view returns (bytes32[] memory keysWithValue) {
+  /** Get keys0 (using the specified store) */
+  function getKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -84,24 +96,24 @@ library KeysWithValue {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keysWithValue */
-  function set(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
+  /** Set keys0 */
+  function setKeys0(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
+    StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
 
-  /** Set keysWithValue (using the specified store) */
-  function set(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
+  /** Set keys0 (using the specified store) */
+  function setKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
-    _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
+    _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
 
-  /** Get the length of keysWithValue */
-  function length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+  /** Get the length of keys0 */
+  function lengthKeys0(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -109,8 +121,8 @@ library KeysWithValue {
     return _byteLength / 32;
   }
 
-  /** Get the length of keysWithValue (using the specified store) */
-  function length(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+  /** Get the length of keys0 (using the specified store) */
+  function lengthKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -118,8 +130,8 @@ library KeysWithValue {
     return _byteLength / 32;
   }
 
-  /** Get an item of keysWithValue (unchecked, returns invalid data if index overflows) */
-  function getItem(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+  /** Get an item of keys0 (unchecked, returns invalid data if index overflows) */
+  function getItemKeys0(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -127,8 +139,13 @@ library KeysWithValue {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Get an item of keysWithValue (using the specified store) (unchecked, returns invalid data if index overflows) */
-  function getItem(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+  /** Get an item of keys0 (using the specified store) (unchecked, returns invalid data if index overflows) */
+  function getItemKeys0(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    uint256 _index
+  ) internal view returns (bytes32) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
@@ -136,61 +153,673 @@ library KeysWithValue {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Push an element to keysWithValue */
-  function push(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+  /** Push an element to keys0 */
+  function pushKeys0(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
-  /** Push an element to keysWithValue (using the specified store) */
-  function push(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+  /** Push an element to keys0 (using the specified store) */
+  function pushKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
-  /** Pop an element from keysWithValue */
-  function pop(bytes32 _tableId, bytes32 valueHash) internal {
+  /** Pop an element from keys0 */
+  function popKeys0(bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
 
-  /** Pop an element from keysWithValue (using the specified store) */
-  function pop(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
+  /** Pop an element from keys0 (using the specified store) */
+  function popKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
 
-  /** Update an element of keysWithValue at `_index` */
-  function update(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+  /** Update an element of keys0 at `_index` */
+  function updateKeys0(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
 
-  /** Update an element of keysWithValue (using the specified store) at `_index` */
-  function update(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+  /** Update an element of keys0 (using the specified store) at `_index` */
+  function updateKeys0(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
 
+  /** Get keys1 */
+  function getKeys1(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys1) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get keys1 (using the specified store) */
+  function getKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys1) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Set keys1 */
+  function setKeys1(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys1) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
+  }
+
+  /** Set keys1 (using the specified store) */
+  function setKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys1) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
+  }
+
+  /** Get the length of keys1 */
+  function lengthKeys1(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get the length of keys1 (using the specified store) */
+  function lengthKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get an item of keys1 (unchecked, returns invalid data if index overflows) */
+  function getItemKeys1(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Get an item of keys1 (using the specified store) (unchecked, returns invalid data if index overflows) */
+  function getItemKeys1(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    uint256 _index
+  ) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Push an element to keys1 */
+  function pushKeys1(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to keys1 (using the specified store) */
+  function pushKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
+  }
+
+  /** Pop an element from keys1 */
+  function popKeys1(bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32);
+  }
+
+  /** Pop an element from keys1 (using the specified store) */
+  function popKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.popFromField(_tableId, _keyTuple, 1, 32);
+  }
+
+  /** Update an element of keys1 at `_index` */
+  function updateKeys1(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Update an element of keys1 (using the specified store) at `_index` */
+  function updateKeys1(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Get keys2 */
+  function getKeys2(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys2) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get keys2 (using the specified store) */
+  function getKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys2) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Set keys2 */
+  function setKeys2(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys2) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
+  }
+
+  /** Set keys2 (using the specified store) */
+  function setKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys2) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
+  }
+
+  /** Get the length of keys2 */
+  function lengthKeys2(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get the length of keys2 (using the specified store) */
+  function lengthKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get an item of keys2 (unchecked, returns invalid data if index overflows) */
+  function getItemKeys2(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Get an item of keys2 (using the specified store) (unchecked, returns invalid data if index overflows) */
+  function getItemKeys2(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    uint256 _index
+  ) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Push an element to keys2 */
+  function pushKeys2(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to keys2 (using the specified store) */
+  function pushKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
+  }
+
+  /** Pop an element from keys2 */
+  function popKeys2(bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32);
+  }
+
+  /** Pop an element from keys2 (using the specified store) */
+  function popKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.popFromField(_tableId, _keyTuple, 2, 32);
+  }
+
+  /** Update an element of keys2 at `_index` */
+  function updateKeys2(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Update an element of keys2 (using the specified store) at `_index` */
+  function updateKeys2(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Get keys3 */
+  function getKeys3(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys3) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get keys3 (using the specified store) */
+  function getKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys3) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Set keys3 */
+  function setKeys3(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys3) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
+  }
+
+  /** Set keys3 (using the specified store) */
+  function setKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys3) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
+  }
+
+  /** Get the length of keys3 */
+  function lengthKeys3(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get the length of keys3 (using the specified store) */
+  function lengthKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get an item of keys3 (unchecked, returns invalid data if index overflows) */
+  function getItemKeys3(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Get an item of keys3 (using the specified store) (unchecked, returns invalid data if index overflows) */
+  function getItemKeys3(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    uint256 _index
+  ) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Push an element to keys3 */
+  function pushKeys3(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to keys3 (using the specified store) */
+  function pushKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
+  }
+
+  /** Pop an element from keys3 */
+  function popKeys3(bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32);
+  }
+
+  /** Pop an element from keys3 (using the specified store) */
+  function popKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.popFromField(_tableId, _keyTuple, 3, 32);
+  }
+
+  /** Update an element of keys3 at `_index` */
+  function updateKeys3(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Update an element of keys3 (using the specified store) at `_index` */
+  function updateKeys3(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Get keys4 */
+  function getKeys4(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys4) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get keys4 (using the specified store) */
+  function getKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keys4) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Set keys4 */
+  function setKeys4(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys4) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
+  }
+
+  /** Set keys4 (using the specified store) */
+  function setKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keys4) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
+  }
+
+  /** Get the length of keys4 */
+  function lengthKeys4(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get the length of keys4 (using the specified store) */
+  function lengthKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
+    return _byteLength / 32;
+  }
+
+  /** Get an item of keys4 (unchecked, returns invalid data if index overflows) */
+  function getItemKeys4(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Get an item of keys4 (using the specified store) (unchecked, returns invalid data if index overflows) */
+  function getItemKeys4(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    uint256 _index
+  ) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
+    return (Bytes.slice32(_blob, 0));
+  }
+
+  /** Push an element to keys4 */
+  function pushKeys4(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
+  }
+
+  /** Push an element to keys4 (using the specified store) */
+  function pushKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
+  }
+
+  /** Pop an element from keys4 */
+  function popKeys4(bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32);
+  }
+
+  /** Pop an element from keys4 (using the specified store) */
+  function popKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.popFromField(_tableId, _keyTuple, 4, 32);
+  }
+
+  /** Update an element of keys4 at `_index` */
+  function updateKeys4(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Update an element of keys4 (using the specified store) at `_index` */
+  function updateKeys4(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
+  }
+
+  /** Get the full data */
+  function get(bytes32 _tableId, bytes32 valueHash) internal view returns (KeysWithValueData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
+    return decode(_blob);
+  }
+
+  /** Get the full data (using the specified store) */
+  function get(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash
+  ) internal view returns (KeysWithValueData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
+    return decode(_blob);
+  }
+
+  /** Set the full data using individual values */
+  function set(
+    bytes32 _tableId,
+    bytes32 valueHash,
+    bytes32[] memory keys0,
+    bytes32[] memory keys1,
+    bytes32[] memory keys2,
+    bytes32[] memory keys3,
+    bytes32[] memory keys4
+  ) internal {
+    bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    StoreSwitch.setRecord(_tableId, _keyTuple, _data);
+  }
+
+  /** Set the full data using individual values (using the specified store) */
+  function set(
+    IStore _store,
+    bytes32 _tableId,
+    bytes32 valueHash,
+    bytes32[] memory keys0,
+    bytes32[] memory keys1,
+    bytes32[] memory keys2,
+    bytes32[] memory keys3,
+    bytes32[] memory keys4
+  ) internal {
+    bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = valueHash;
+
+    _store.setRecord(_tableId, _keyTuple, _data);
+  }
+
+  /** Set the full data using the data struct */
+  function set(bytes32 _tableId, bytes32 valueHash, KeysWithValueData memory _table) internal {
+    set(_tableId, valueHash, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
+  }
+
+  /** Set the full data using the data struct (using the specified store) */
+  function set(IStore _store, bytes32 _tableId, bytes32 valueHash, KeysWithValueData memory _table) internal {
+    set(_store, _tableId, valueHash, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
+  }
+
+  /** Decode the tightly packed blob using this table's schema */
+  function decode(bytes memory _blob) internal pure returns (KeysWithValueData memory _table) {
+    // 0 is the total byte length of static data
+    PackedCounter _encodedLengths = PackedCounter.wrap(Bytes.slice32(_blob, 0));
+
+    // Store trims the blob if dynamic fields are all empty
+    if (_blob.length > 0) {
+      uint256 _start;
+      // skip static data length + dynamic lengths word
+      uint256 _end = 32;
+
+      _start = _end;
+      _end += _encodedLengths.atIndex(0);
+      _table.keys0 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+
+      _start = _end;
+      _end += _encodedLengths.atIndex(1);
+      _table.keys1 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+
+      _start = _end;
+      _end += _encodedLengths.atIndex(2);
+      _table.keys2 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+
+      _start = _end;
+      _end += _encodedLengths.atIndex(3);
+      _table.keys3 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+
+      _start = _end;
+      _end += _encodedLengths.atIndex(4);
+      _table.keys4 = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_bytes32());
+    }
+  }
+
   /** Tightly pack full data using this table's schema */
-  function encode(bytes32[] memory keysWithValue) internal pure returns (bytes memory) {
-    uint40[] memory _counters = new uint40[](1);
-    _counters[0] = uint40(keysWithValue.length * 32);
+  function encode(
+    bytes32[] memory keys0,
+    bytes32[] memory keys1,
+    bytes32[] memory keys2,
+    bytes32[] memory keys3,
+    bytes32[] memory keys4
+  ) internal pure returns (bytes memory) {
+    uint40[] memory _counters = new uint40[](5);
+    _counters[0] = uint40(keys0.length * 32);
+    _counters[1] = uint40(keys1.length * 32);
+    _counters[2] = uint40(keys2.length * 32);
+    _counters[3] = uint40(keys3.length * 32);
+    _counters[4] = uint40(keys4.length * 32);
     PackedCounter _encodedLengths = PackedCounterLib.pack(_counters);
 
-    return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((keysWithValue)));
+    return
+      abi.encodePacked(
+        _encodedLengths.unwrap(),
+        EncodeArray.encode((keys0)),
+        EncodeArray.encode((keys1)),
+        EncodeArray.encode((keys2)),
+        EncodeArray.encode((keys3)),
+        EncodeArray.encode((keys4))
+      );
   }
 
   /** Encode keys as a bytes32 array using this table's schema */

--- a/packages/world/test/KeysWithValueModule.t.sol
+++ b/packages/world/test/KeysWithValueModule.t.sol
@@ -15,7 +15,7 @@ import { ROOT_NAMESPACE } from "../src/constants.sol";
 import { CoreModule } from "../src/modules/core/CoreModule.sol";
 import { KeysWithValueModule } from "../src/modules/keyswithvalue/KeysWithValueModule.sol";
 import { MODULE_NAMESPACE } from "../src/modules/keyswithvalue/constants.sol";
-import { KeysWithValue } from "../src/modules/keyswithvalue/tables/KeysWithValue.sol";
+import { KeysWithValue, KeysWithValueData } from "../src/modules/keyswithvalue/tables/KeysWithValue.sol";
 import { getKeysWithValue } from "../src/modules/keyswithvalue/getKeysWithValue.sol";
 import { getTargetTableSelector } from "../src/modules/utils/getTargetTableSelector.sol";
 
@@ -26,32 +26,54 @@ contract KeysWithValueModuleTest is Test, GasReporter {
 
   bytes16 namespace = ROOT_NAMESPACE;
   bytes16 sourceName = bytes16("source");
+  bytes16 compositeName = bytes16("composite");
   bytes32 key1 = keccak256("test");
   bytes32[] keyTuple1;
   bytes32 key2 = keccak256("test2");
   bytes32[] keyTuple2;
+  bytes32 compositeKey1 = keccak256("testcomposite1");
+  bytes32 compositeKey2 = keccak256("testcomposite2");
+  bytes32[] compositeKeyTuple1;
+  bytes32 compositeKey3 = keccak256("testcomposite3");
+  bytes32 compositeKey4 = keccak256("testcomposite3");
+  bytes32[] compositeKeyTuple2;
 
   Schema sourceTableSchema;
   Schema sourceTableKeySchema;
+  Schema compositeTableSchema;
+  Schema compositeTableKeySchema;
   bytes32 sourceTableId;
   bytes32 targetTableId;
+  bytes32 compositeTableId;
+  bytes32 targetCompositeTableId;
 
   function setUp() public {
     sourceTableSchema = SchemaLib.encode(SchemaType.UINT256);
     sourceTableKeySchema = SchemaLib.encode(SchemaType.BYTES32);
+    compositeTableSchema = SchemaLib.encode(SchemaType.UINT256);
+    compositeTableKeySchema = SchemaLib.encode(SchemaType.BYTES32, SchemaType.BYTES32);
     world = IBaseWorld(address(new World()));
     world.installRootModule(new CoreModule(), new bytes(0));
     keyTuple1 = new bytes32[](1);
     keyTuple1[0] = key1;
     keyTuple2 = new bytes32[](1);
     keyTuple2[0] = key2;
+    compositeKeyTuple1 = new bytes32[](2);
+    compositeKeyTuple1[0] = compositeKey1;
+    compositeKeyTuple1[1] = compositeKey2;
+    compositeKeyTuple2 = new bytes32[](2);
+    compositeKeyTuple2[0] = compositeKey3;
+    compositeKeyTuple2[1] = compositeKey4;
     sourceTableId = ResourceSelector.from(namespace, sourceName);
     targetTableId = getTargetTableSelector(MODULE_NAMESPACE, sourceTableId);
+    compositeTableId = ResourceSelector.from(namespace, compositeName);
+    targetCompositeTableId = getTargetTableSelector(MODULE_NAMESPACE, compositeTableId);
   }
 
   function _installKeysWithValueModule() internal {
     // Register source table
     sourceTableId = world.registerTable(namespace, sourceName, sourceTableSchema, sourceTableKeySchema);
+    compositeTableId = world.registerTable(namespace, compositeName, compositeTableSchema, compositeTableKeySchema);
 
     // Install the index module
     // TODO: add support for installing this via installModule
@@ -59,6 +81,7 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     startGasReport("install keys with value module");
     world.installRootModule(keysWithValueModule, abi.encode(sourceTableId));
     endGasReport();
+    world.installRootModule(keysWithValueModule, abi.encode(compositeTableId));
   }
 
   function testInstall() public {
@@ -71,11 +94,34 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     endGasReport();
 
     // Get the list of entities with this value from the target table
-    bytes32[] memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value)));
+    KeysWithValueData memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1);
-    assertEq(keysWithValue[0], key1);
+    assertEq(keysWithValue.keys0.length, 1);
+    assertEq(keysWithValue.keys0[0], key1);
+  }
+
+  function testInstallComposite() public {
+    _installKeysWithValueModule();
+    // Set a value in the source table
+    uint256 value = 1;
+
+    startGasReport("set a record on a table with KeysWithValueModule installed");
+    world.setRecord(namespace, compositeName, compositeKeyTuple1, abi.encodePacked(value));
+    endGasReport();
+
+    // Get the list of entities with this value from the target table
+    KeysWithValueData memory keysWithValue = KeysWithValue.get(
+      world,
+      targetCompositeTableId,
+      keccak256(abi.encode(value))
+    );
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 1);
+    assertEq(keysWithValue.keys0[0], compositeKey1);
+    assertEq(keysWithValue.keys1.length, 1);
+    assertEq(keysWithValue.keys1[0], compositeKey2);
   }
 
   function testSetAndDeleteRecordHook() public {
@@ -87,11 +133,11 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value1));
 
     // Get the list of entities with value1 from the target table
-    bytes32[] memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
+    KeysWithValueData memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1, "1");
-    assertEq(keysWithValue[0], key1, "2");
+    assertEq(keysWithValue.keys0.length, 1, "1");
+    assertEq(keysWithValue.keys0[0], key1, "2");
 
     // Set a another key with the same value
     world.setRecord(namespace, sourceName, keyTuple2, abi.encodePacked(value1));
@@ -100,9 +146,9 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 2);
-    assertEq(keysWithValue[0], key1, "3");
-    assertEq(keysWithValue[1], key2, "4");
+    assertEq(keysWithValue.keys0.length, 2);
+    assertEq(keysWithValue.keys0[0], key1, "3");
+    assertEq(keysWithValue.keys0[1], key2, "4");
 
     // Change the value of the first key
     uint256 value2 = 2;
@@ -115,15 +161,15 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1, "5");
-    assertEq(keysWithValue[0], key2, "6");
+    assertEq(keysWithValue.keys0.length, 1, "5");
+    assertEq(keysWithValue.keys0[0], key2, "6");
 
     // Get the list of entities with value2 from the target table
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value2)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1, "7");
-    assertEq(keysWithValue[0], key1, "8");
+    assertEq(keysWithValue.keys0.length, 1, "7");
+    assertEq(keysWithValue.keys0[0], key1, "8");
 
     // Delete the first key
     startGasReport("delete a record on a table with KeysWithValueModule installed");
@@ -134,7 +180,80 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value2)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 0, "9");
+    assertEq(keysWithValue.keys0.length, 0, "9");
+  }
+
+  function testSetAndDeleteRecordHookComposite() public {
+    _installKeysWithValueModule();
+
+    // Set a value in the source table
+    uint256 value1 = 1;
+
+    world.setRecord(namespace, compositeName, compositeKeyTuple1, abi.encodePacked(value1));
+
+    // Get the list of entities with value1 from the target table
+    KeysWithValueData memory keysWithValue = KeysWithValue.get(
+      world,
+      targetCompositeTableId,
+      keccak256(abi.encode(value1))
+    );
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 1, "1");
+    assertEq(keysWithValue.keys1.length, 1, "2");
+    assertEq(keysWithValue.keys0[0], compositeKey1, "3");
+    assertEq(keysWithValue.keys1[0], compositeKey2, "4");
+
+    // Set a another key with the same value
+    world.setRecord(namespace, compositeName, compositeKeyTuple2, abi.encodePacked(value1));
+
+    // Get the list of entities with value2 from the target table
+    keysWithValue = KeysWithValue.get(world, targetCompositeTableId, keccak256(abi.encode(value1)));
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 2);
+    assertEq(keysWithValue.keys1.length, 2);
+    assertEq(keysWithValue.keys0[0], compositeKey1, "5");
+    assertEq(keysWithValue.keys1[0], compositeKey2, "7");
+    assertEq(keysWithValue.keys0[1], compositeKey3, "6");
+    assertEq(keysWithValue.keys1[1], compositeKey4, "8");
+
+    // Change the value of the first key
+    uint256 value2 = 2;
+
+    startGasReport("change a record on a table with KeysWithValueModule installed");
+    world.setRecord(namespace, compositeName, compositeKeyTuple1, abi.encodePacked(value2));
+    endGasReport();
+
+    // Get the list of entities with value1 from the target table
+    keysWithValue = KeysWithValue.get(world, targetCompositeTableId, keccak256(abi.encode(value1)));
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 1, "9");
+    assertEq(keysWithValue.keys1.length, 1, "10");
+    assertEq(keysWithValue.keys0[0], compositeKey3, "11");
+    assertEq(keysWithValue.keys1[0], compositeKey4, "12");
+
+    // Get the list of entities with value2 from the target table
+    keysWithValue = KeysWithValue.get(world, targetCompositeTableId, keccak256(abi.encode(value2)));
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 1, "13");
+    assertEq(keysWithValue.keys1.length, 1, "14");
+    assertEq(keysWithValue.keys0[0], compositeKey1, "15");
+    assertEq(keysWithValue.keys1[0], compositeKey2, "16");
+
+    // Delete the first key
+    startGasReport("delete a record on a table with KeysWithValueModule installed");
+    world.deleteRecord(namespace, compositeName, compositeKeyTuple1);
+    endGasReport();
+
+    // Get the list of entities with value2 from the target table
+    keysWithValue = KeysWithValue.get(world, targetCompositeTableId, keccak256(abi.encode(value2)));
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.keys0.length, 0, "17");
+    assertEq(keysWithValue.keys1.length, 0, "18");
   }
 
   function testSetField() public {
@@ -148,11 +267,11 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     endGasReport();
 
     // Get the list of entities with value1 from the target table
-    bytes32[] memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
+    KeysWithValueData memory keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1);
-    assertEq(keysWithValue[0], key1);
+    assertEq(keysWithValue.keys0.length, 1);
+    assertEq(keysWithValue.keys0[0], key1);
 
     uint256 value2 = 2;
 
@@ -165,14 +284,14 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value1)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 0);
+    assertEq(keysWithValue.keys0.length, 0);
 
     // Get the list of entities with value2 from the target table
     keysWithValue = KeysWithValue.get(world, targetTableId, keccak256(abi.encode(value2)));
 
     // Assert that the list is correct
-    assertEq(keysWithValue.length, 1);
-    assertEq(keysWithValue[0], key1);
+    assertEq(keysWithValue.keys0.length, 1);
+    assertEq(keysWithValue.keys0[0], key1);
   }
 
   function testGetTargetTableSelector() public {
@@ -202,22 +321,62 @@ contract KeysWithValueModuleTest is Test, GasReporter {
     world.setRecord(namespace, sourceName, keyTuple1, abi.encodePacked(value));
 
     startGasReport("Get list of keys with a given value");
-    bytes32[] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value));
+    bytes32[][] memory keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value));
     endGasReport();
 
     // Assert that the list is correct
     assertEq(keysWithValue.length, 1);
-    assertEq(keysWithValue[0], key1);
+    assertEq(keysWithValue[0].length, 1);
+    assertEq(keysWithValue[0][0], key1);
 
-    // Set a another key with the same value
+    // // Set a another key with the same value
     world.setRecord(namespace, sourceName, keyTuple2, abi.encodePacked(value));
 
-    // Get the list of keys with value from the target table
+    // // Get the list of keys with value from the target table
     keysWithValue = getKeysWithValue(world, sourceTableId, abi.encode(value));
+
+    // // Assert that the list is correct
+    assertEq(keysWithValue.length, 2);
+    assertEq(keysWithValue[0].length, 1);
+    assertEq(keysWithValue[1].length, 1);
+    assertEq(keysWithValue[0][0], key1);
+    assertEq(keysWithValue[1][0], key2);
+  }
+
+  function testGetKeysWithValueCompositeGas() public {
+    // call fuzzed test manually to get gas report
+    testGetKeysWithValue(1);
+  }
+
+  function testGetKeysWithValueComposite(uint256 value) public {
+    _installKeysWithValueModule();
+
+    // Set a value in the source table
+    world.setRecord(namespace, compositeName, compositeKeyTuple1, abi.encodePacked(value));
+
+    startGasReport("Get list of keys with a given value");
+    bytes32[][] memory keysWithValue = getKeysWithValue(world, compositeTableId, abi.encode(value));
+    endGasReport();
+
+    // Assert that the list is correct
+    assertEq(keysWithValue.length, 1);
+    assertEq(keysWithValue[0].length, 2);
+    assertEq(keysWithValue[0][0], compositeKey1);
+    assertEq(keysWithValue[0][1], compositeKey2);
+
+    // Set a another key with the same value
+    world.setRecord(namespace, compositeName, compositeKeyTuple2, abi.encodePacked(value));
+
+    // Get the list of keys with value from the target table
+    keysWithValue = getKeysWithValue(world, compositeTableId, abi.encode(value));
 
     // Assert that the list is correct
     assertEq(keysWithValue.length, 2);
-    assertEq(keysWithValue[0], key1);
-    assertEq(keysWithValue[1], key2);
+    assertEq(keysWithValue[0].length, 2);
+    assertEq(keysWithValue[1].length, 2);
+    assertEq(keysWithValue[0][0], compositeKey1);
+    assertEq(keysWithValue[0][1], compositeKey2);
+    assertEq(keysWithValue[1][0], compositeKey3);
+    assertEq(keysWithValue[1][1], compositeKey4);
   }
 }


### PR DESCRIPTION
- Added support for up to 5 composite keys in the `KeysWithValue` module. Followed the same approach currently being used in the `KeysInTable` module.
- Updated query in `KeysInTable` to no longer need the helper function `valuesToTuples`
- Added test for composite keys
- Updated doc