### PR TITLE
refactor(store): optimize Storage library

### DIFF
--- a/.changeset/brave-rings-tickle.md
+++ b/.changeset/brave-rings-tickle.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": patch
+---
+
+Optimize storage library

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -99,55 +99,55 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word)",
-    "gasUsed": 22469
+    "gasUsed": 22456
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word, partial)",
-    "gasUsed": 22432
+    "gasUsed": 22419
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 10 words)",
-    "gasUsed": 200429
+    "gasUsed": 200416
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word)",
-    "gasUsed": 469
+    "gasUsed": 456
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word, partial)",
-    "gasUsed": 532
+    "gasUsed": 519
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 10 words)",
-    "gasUsed": 2429
+    "gasUsed": 2416
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 630
+    "gasUsed": 625
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 577
+    "gasUsed": 572
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 2655
+    "gasUsed": 2650
   },
   {
     "file": "test/Gas.t.sol",
@@ -225,7 +225,7 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 111108
+    "gasUsed": 111103
   },
   {
     "file": "test/Mixed.t.sol",
@@ -381,43 +381,43 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 1 storage slot",
-    "gasUsed": 22503
+    "gasUsed": 22490
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 23158
+    "gasUsed": 23141
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "load 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 1099
+    "gasUsed": 1094
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8152
+    "gasUsed": 8147
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2180
+    "gasUsed": 2175
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4185
+    "gasUsed": 4180
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4471
+    "gasUsed": 4466
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -447,25 +447,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30792
+    "gasUsed": 30782
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18847
+    "gasUsed": 18837
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 32675
+    "gasUsed": 32665
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18730
+    "gasUsed": 18720
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -477,13 +477,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 2914
+    "gasUsed": 2909
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 3587
+    "gasUsed": 3582
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -495,13 +495,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1324
+    "gasUsed": 1319
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10447
+    "gasUsed": 10429
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -519,61 +519,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 66466
+    "gasUsed": 66443
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 74409
+    "gasUsed": 74399
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 30350
+    "gasUsed": 30314
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 23011
+    "gasUsed": 22975
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 66466
+    "gasUsed": 66443
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167846
+    "gasUsed": 167836
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33500
+    "gasUsed": 33464
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 24483
+    "gasUsed": 24447
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16518
+    "gasUsed": 16495
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 39234
+    "gasUsed": 39211
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -597,7 +597,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 109160
+    "gasUsed": 109155
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -639,55 +639,55 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 39378
+    "gasUsed": 39360
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 2915
+    "gasUsed": 2910
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34340
+    "gasUsed": 34322
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 3755
+    "gasUsed": 3750
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56839
+    "gasUsed": 56821
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 3811
+    "gasUsed": 3806
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34971
+    "gasUsed": 34953
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 3826
+    "gasUsed": 3821
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38827
+    "gasUsed": 38822
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -699,7 +699,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 61395
+    "gasUsed": 61390
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -711,25 +711,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 252784
+    "gasUsed": 252779
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 16064
+    "gasUsed": 16041
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 17155
+    "gasUsed": 17132
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 251257
+    "gasUsed": 251252
   },
   {
     "file": "test/StoreMetadata.t.sol",
@@ -753,37 +753,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62243
+    "gasUsed": 62225
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5305
+    "gasUsed": 5300
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39931
+    "gasUsed": 39908
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64400
+    "gasUsed": 64382
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5455
+    "gasUsed": 5450
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39922
+    "gasUsed": 39899
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -849,7 +849,7 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37646
+    "gasUsed": 37641
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -75,7 +75,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "custom encode",
-    "gasUsed": 3357
+    "gasUsed": 3354
   },
   {
     "file": "test/Gas.t.sol",
@@ -87,85 +87,13 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "pass abi encoded bytes to external contract",
-    "gasUsed": 6563
+    "gasUsed": 6551
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "pass custom encoded bytes to external contract",
-    "gasUsed": 1457
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (cold, 1 word)",
-    "gasUsed": 2411
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (cold, 1 word, partial)",
-    "gasUsed": 2460
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (cold, 10 words)",
-    "gasUsed": 19911
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 412
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 460
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadMUD",
-    "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 1914
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (cold, 1 word)",
-    "gasUsed": 2109
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (cold, 1 word, partial)",
-    "gasUsed": 2126
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (cold, 10 words)",
-    "gasUsed": 2569
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (warm, 1 word)",
-    "gasUsed": 109
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (warm, 1 word, partial)",
-    "gasUsed": 126
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageLoadSolidity",
-    "name": "solidity storage load (warm, 10 words)",
-    "gasUsed": 569
+    "gasUsed": 1445
   },
   {
     "file": "test/Gas.t.sol",
@@ -232,6 +160,84 @@
     "test": "testCompareStorageWriteSolidity",
     "name": "solidity storage write (warm, 1 word, partial)",
     "gasUsed": 236
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (warm, 10 words)",
+    "gasUsed": 1988
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 1 word)",
+    "gasUsed": 2411
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 1 word, partial)",
+    "gasUsed": 2460
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 10 words)",
+    "gasUsed": 19911
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (warm, 1 word)",
+    "gasUsed": 412
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (warm, 1 word, partial)",
+    "gasUsed": 460
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (warm, 10 words)",
+    "gasUsed": 1914
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 1 word)",
+    "gasUsed": 2109
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 1 word, partial)",
+    "gasUsed": 2126
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 10 words)",
+    "gasUsed": 19894
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (warm, 1 word)",
+    "gasUsed": 109
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (warm, 1 word, partial)",
+    "gasUsed": 126
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (warm, 10 words)",
+    "gasUsed": 1897
   },
   {
     "file": "test/KeyEncoding.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -99,7 +99,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word)",
-    "gasUsed": 22401
+    "gasUsed": 22339
   },
   {
     "file": "test/Gas.t.sol",
@@ -111,13 +111,13 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 10 words)",
-    "gasUsed": 200361
+    "gasUsed": 199795
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word)",
-    "gasUsed": 401
+    "gasUsed": 339
   },
   {
     "file": "test/Gas.t.sol",
@@ -129,13 +129,13 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 10 words)",
-    "gasUsed": 2361
+    "gasUsed": 1795
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 570
+    "gasUsed": 511
   },
   {
     "file": "test/Gas.t.sol",
@@ -147,7 +147,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 2595
+    "gasUsed": 2056
   },
   {
     "file": "test/Gas.t.sol",
@@ -225,13 +225,13 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 110883
+    "gasUsed": 110887
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 12435
+    "gasUsed": 12438
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -381,25 +381,25 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 1 storage slot",
-    "gasUsed": 22435
+    "gasUsed": 22373
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 23160
+    "gasUsed": 23041
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "load 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 1113
+    "gasUsed": 997
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8092
+    "gasUsed": 8093
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -417,7 +417,7 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4485
+    "gasUsed": 4429
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -447,43 +447,43 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30672
+    "gasUsed": 30674
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18727
+    "gasUsed": 18729
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 32555
+    "gasUsed": 32497
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18610
+    "gasUsed": 18552
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 7266
+    "gasUsed": 7267
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 2854
+    "gasUsed": 2855
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 3527
+    "gasUsed": 3528
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -495,13 +495,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1264
+    "gasUsed": 1265
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10319
+    "gasUsed": 10321
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -519,61 +519,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 66278
+    "gasUsed": 66281
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 74179
+    "gasUsed": 74183
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 30094
+    "gasUsed": 30098
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 22755
+    "gasUsed": 22759
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 66278
+    "gasUsed": 66281
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167506
+    "gasUsed": 167512
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33244
+    "gasUsed": 33248
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 24227
+    "gasUsed": 24231
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16404
+    "gasUsed": 16406
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 39120
+    "gasUsed": 39066
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -597,13 +597,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 108935
+    "gasUsed": 108939
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 6277
+    "gasUsed": 6280
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -639,103 +639,103 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 39250
+    "gasUsed": 39252
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 2855
+    "gasUsed": 2856
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34286
+    "gasUsed": 34231
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 3769
+    "gasUsed": 3713
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56711
+    "gasUsed": 56713
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 3751
+    "gasUsed": 3752
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34843
+    "gasUsed": 34845
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 3766
+    "gasUsed": 3767
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38712
+    "gasUsed": 38714
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1265
+    "gasUsed": 1266
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 61280
+    "gasUsed": 61219
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1514
+    "gasUsed": 1455
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 252559
+    "gasUsed": 252059
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15950
+    "gasUsed": 15952
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 17041
+    "gasUsed": 16927
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 251032
+    "gasUsed": 250532
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "get record from StoreMetadataTable",
-    "gasUsed": 11908
+    "gasUsed": 11430
   },
   {
     "file": "test/StoreSwitch.t.sol",
@@ -753,37 +753,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62115
+    "gasUsed": 62117
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5245
+    "gasUsed": 5246
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39817
+    "gasUsed": 39763
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64272
+    "gasUsed": 64274
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5395
+    "gasUsed": 5396
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39808
+    "gasUsed": 39754
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -849,12 +849,12 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37531
+    "gasUsed": 37533
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4402
+    "gasUsed": 4403
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -135,19 +135,19 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 511
+    "gasUsed": 414
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 591
+    "gasUsed": 494
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 2056
+    "gasUsed": 1935
   },
   {
     "file": "test/Gas.t.sol",
@@ -225,7 +225,7 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 110887
+    "gasUsed": 110824
   },
   {
     "file": "test/Mixed.t.sol",
@@ -393,31 +393,31 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "load 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 997
+    "gasUsed": 897
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8093
+    "gasUsed": 7996
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2194
+    "gasUsed": 2097
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4199
+    "gasUsed": 4102
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4429
+    "gasUsed": 4328
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -447,25 +447,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30674
+    "gasUsed": 30514
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18729
+    "gasUsed": 18569
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 32497
+    "gasUsed": 32334
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18552
+    "gasUsed": 18389
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -477,13 +477,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 2855
+    "gasUsed": 2758
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 3528
+    "gasUsed": 3465
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -495,13 +495,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1265
+    "gasUsed": 1202
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10321
+    "gasUsed": 10258
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -519,61 +519,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 66281
+    "gasUsed": 66155
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 74183
+    "gasUsed": 74023
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 30098
+    "gasUsed": 29950
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 22759
+    "gasUsed": 22600
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 66281
+    "gasUsed": 66155
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167512
+    "gasUsed": 167352
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33248
+    "gasUsed": 33100
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 24231
+    "gasUsed": 24067
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16406
+    "gasUsed": 16246
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 39066
+    "gasUsed": 38902
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -597,7 +597,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 108939
+    "gasUsed": 108876
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -639,55 +639,55 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 39252
+    "gasUsed": 39189
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 2856
+    "gasUsed": 2759
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34231
+    "gasUsed": 34168
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 3713
+    "gasUsed": 3612
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56713
+    "gasUsed": 56650
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 3752
+    "gasUsed": 3655
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34845
+    "gasUsed": 34783
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 3767
+    "gasUsed": 3670
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38714
+    "gasUsed": 38651
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -699,7 +699,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 61219
+    "gasUsed": 61156
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -711,25 +711,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 252059
+    "gasUsed": 251996
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15952
+    "gasUsed": 15792
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 16927
+    "gasUsed": 16763
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 250532
+    "gasUsed": 250469
   },
   {
     "file": "test/StoreMetadata.t.sol",
@@ -753,37 +753,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62117
+    "gasUsed": 62054
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5246
+    "gasUsed": 5149
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39763
+    "gasUsed": 39603
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64274
+    "gasUsed": 64211
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5396
+    "gasUsed": 5299
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39754
+    "gasUsed": 39594
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -849,7 +849,7 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37533
+    "gasUsed": 37470
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -105,7 +105,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word, partial)",
-    "gasUsed": 22438
+    "gasUsed": 22406
   },
   {
     "file": "test/Gas.t.sol",
@@ -123,7 +123,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word, partial)",
-    "gasUsed": 538
+    "gasUsed": 506
   },
   {
     "file": "test/Gas.t.sol",
@@ -141,7 +141,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 494
+    "gasUsed": 462
   },
   {
     "file": "test/Gas.t.sol",
@@ -387,13 +387,13 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 23041
+    "gasUsed": 23009
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "load 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 897
+    "gasUsed": 865
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -405,19 +405,19 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2097
+    "gasUsed": 2065
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4102
+    "gasUsed": 4070
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4328
+    "gasUsed": 4296
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -531,7 +531,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 29864
+    "gasUsed": 29860
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -567,13 +567,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16156
+    "gasUsed": 16124
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 38812
+    "gasUsed": 38780
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -651,13 +651,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34123
+    "gasUsed": 34091
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 3612
+    "gasUsed": 3580
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -717,13 +717,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15702
+    "gasUsed": 15670
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 16673
+    "gasUsed": 16641
   },
   {
     "file": "test/StoreMetadata.t.sol",
@@ -765,7 +765,7 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39513
+    "gasUsed": 39481
   },
   {
     "file": "test/tables/Hooks.t.sol",
@@ -783,7 +783,7 @@
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39504
+    "gasUsed": 39472
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -225,7 +225,7 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 110824
+    "gasUsed": 110779
   },
   {
     "file": "test/Mixed.t.sol",
@@ -447,25 +447,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30514
+    "gasUsed": 30424
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18569
+    "gasUsed": 18479
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 32334
+    "gasUsed": 32244
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18389
+    "gasUsed": 18299
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -483,7 +483,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 3465
+    "gasUsed": 3420
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -501,7 +501,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10258
+    "gasUsed": 10213
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -519,61 +519,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 66155
+    "gasUsed": 66065
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 74023
+    "gasUsed": 73933
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 29950
+    "gasUsed": 29864
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 22600
+    "gasUsed": 22510
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 66155
+    "gasUsed": 66065
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167352
+    "gasUsed": 167262
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33100
+    "gasUsed": 33010
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 24067
+    "gasUsed": 23977
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16246
+    "gasUsed": 16156
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 38902
+    "gasUsed": 38812
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -597,7 +597,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 108876
+    "gasUsed": 108831
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -639,7 +639,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 39189
+    "gasUsed": 39144
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -651,7 +651,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34168
+    "gasUsed": 34123
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -663,31 +663,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56650
+    "gasUsed": 56605
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 3655
+    "gasUsed": 3610
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34783
+    "gasUsed": 34738
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 3670
+    "gasUsed": 3625
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38651
+    "gasUsed": 38606
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -699,7 +699,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 61156
+    "gasUsed": 61111
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -711,25 +711,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 251996
+    "gasUsed": 251951
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15792
+    "gasUsed": 15702
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 16763
+    "gasUsed": 16673
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 250469
+    "gasUsed": 250424
   },
   {
     "file": "test/StoreMetadata.t.sol",
@@ -753,37 +753,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62054
+    "gasUsed": 62009
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5149
+    "gasUsed": 5104
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39603
+    "gasUsed": 39513
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64211
+    "gasUsed": 64166
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5299
+    "gasUsed": 5254
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39594
+    "gasUsed": 39504
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -849,7 +849,7 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37470
+    "gasUsed": 37425
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -75,7 +75,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "custom encode",
-    "gasUsed": 3354
+    "gasUsed": 3357
   },
   {
     "file": "test/Gas.t.sol",
@@ -97,111 +97,141 @@
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (cold, 1 word)",
-    "gasUsed": 22339
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 1 word)",
+    "gasUsed": 2411
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (cold, 1 word, partial)",
-    "gasUsed": 22406
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 1 word, partial)",
+    "gasUsed": 2460
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (cold, 10 words)",
-    "gasUsed": 199795
+    "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load (cold, 10 words)",
+    "gasUsed": 19911
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (warm, 1 word)",
-    "gasUsed": 339
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (warm, 1 word, partial)",
-    "gasUsed": 506
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
-    "name": "MUD storage write (warm, 10 words)",
-    "gasUsed": 1795
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
+    "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 414
+    "gasUsed": 412
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
+    "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 462
+    "gasUsed": 460
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageMUD",
+    "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 1935
+    "gasUsed": 1914
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (cold, 1 word)",
-    "gasUsed": 22107
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 1 word)",
+    "gasUsed": 2109
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (cold, 1 word, partial)",
-    "gasUsed": 22136
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 1 word, partial)",
+    "gasUsed": 2126
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (cold, 10 words)",
-    "gasUsed": 199902
+    "test": "testCompareStorageLoadSolidity",
+    "name": "solidity storage load (cold, 10 words)",
+    "gasUsed": 2569
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (warm, 1 word)",
-    "gasUsed": 107
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (warm, 1 word, partial)",
-    "gasUsed": 236
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
-    "name": "solidity storage write (warm, 10 words)",
-    "gasUsed": 1988
-  },
-  {
-    "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
+    "test": "testCompareStorageLoadSolidity",
     "name": "solidity storage load (warm, 1 word)",
     "gasUsed": 109
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
+    "test": "testCompareStorageLoadSolidity",
     "name": "solidity storage load (warm, 1 word, partial)",
     "gasUsed": 126
   },
   {
     "file": "test/Gas.t.sol",
-    "test": "testCompareStorageSolidity",
+    "test": "testCompareStorageLoadSolidity",
     "name": "solidity storage load (warm, 10 words)",
-    "gasUsed": 1916
+    "gasUsed": 569
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (cold, 1 word)",
+    "gasUsed": 22339
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (cold, 1 word, partial)",
+    "gasUsed": 22406
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (cold, 10 words)",
+    "gasUsed": 199795
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (warm, 1 word)",
+    "gasUsed": 339
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (warm, 1 word, partial)",
+    "gasUsed": 506
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteMUD",
+    "name": "MUD storage write (warm, 10 words)",
+    "gasUsed": 1795
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (cold, 1 word)",
+    "gasUsed": 22107
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (cold, 1 word, partial)",
+    "gasUsed": 22136
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (cold, 10 words)",
+    "gasUsed": 199902
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (warm, 1 word)",
+    "gasUsed": 107
+  },
+  {
+    "file": "test/Gas.t.sol",
+    "test": "testCompareStorageWriteSolidity",
+    "name": "solidity storage write (warm, 1 word, partial)",
+    "gasUsed": 236
   },
   {
     "file": "test/KeyEncoding.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -99,55 +99,55 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word)",
-    "gasUsed": 22456
+    "gasUsed": 22401
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 1 word, partial)",
-    "gasUsed": 22419
+    "gasUsed": 22438
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (cold, 10 words)",
-    "gasUsed": 200416
+    "gasUsed": 200361
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word)",
-    "gasUsed": 456
+    "gasUsed": 401
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 1 word, partial)",
-    "gasUsed": 519
+    "gasUsed": 538
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage write (warm, 10 words)",
-    "gasUsed": 2416
+    "gasUsed": 2361
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word)",
-    "gasUsed": 625
+    "gasUsed": 570
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
-    "gasUsed": 572
+    "gasUsed": 591
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 2650
+    "gasUsed": 2595
   },
   {
     "file": "test/Gas.t.sol",
@@ -225,13 +225,13 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 111103
+    "gasUsed": 110883
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 12600
+    "gasUsed": 12435
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -381,43 +381,43 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 1 storage slot",
-    "gasUsed": 22490
+    "gasUsed": 22435
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 23141
+    "gasUsed": 23160
   },
   {
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "load 34 bytes over 3 storage slots (with offset and safeTrail))",
-    "gasUsed": 1094
+    "gasUsed": 1113
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8147
+    "gasUsed": 8092
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2175
+    "gasUsed": 2194
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4180
+    "gasUsed": 4199
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4466
+    "gasUsed": 4485
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -447,43 +447,43 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30782
+    "gasUsed": 30672
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18837
+    "gasUsed": 18727
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 32665
+    "gasUsed": 32555
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18720
+    "gasUsed": 18610
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 7321
+    "gasUsed": 7266
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 2909
+    "gasUsed": 2854
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 3582
+    "gasUsed": 3527
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -495,13 +495,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1319
+    "gasUsed": 1264
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10429
+    "gasUsed": 10319
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -519,61 +519,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 66443
+    "gasUsed": 66278
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 74399
+    "gasUsed": 74179
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 30314
+    "gasUsed": 30094
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 22975
+    "gasUsed": 22755
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 66443
+    "gasUsed": 66278
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167836
+    "gasUsed": 167506
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33464
+    "gasUsed": 33244
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 24447
+    "gasUsed": 24227
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 16495
+    "gasUsed": 16404
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 39211
+    "gasUsed": 39120
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -597,13 +597,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 109155
+    "gasUsed": 108935
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 6442
+    "gasUsed": 6277
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -639,103 +639,103 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 39360
+    "gasUsed": 39250
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 2910
+    "gasUsed": 2855
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 34322
+    "gasUsed": 34286
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 3750
+    "gasUsed": 3769
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56821
+    "gasUsed": 56711
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 3806
+    "gasUsed": 3751
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34953
+    "gasUsed": 34843
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 3821
+    "gasUsed": 3766
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38822
+    "gasUsed": 38712
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1320
+    "gasUsed": 1265
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 61390
+    "gasUsed": 61280
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1569
+    "gasUsed": 1514
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 252779
+    "gasUsed": 252559
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 16041
+    "gasUsed": 15950
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 17132
+    "gasUsed": 17041
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 251252
+    "gasUsed": 251032
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "get record from StoreMetadataTable",
-    "gasUsed": 12018
+    "gasUsed": 11908
   },
   {
     "file": "test/StoreSwitch.t.sol",
@@ -753,37 +753,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62225
+    "gasUsed": 62115
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5300
+    "gasUsed": 5245
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39908
+    "gasUsed": 39817
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64382
+    "gasUsed": 64272
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5450
+    "gasUsed": 5395
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39899
+    "gasUsed": 39808
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -849,12 +849,12 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37641
+    "gasUsed": 37531
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4457
+    "gasUsed": 4402
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -381,7 +381,7 @@
     "file": "test/Storage.t.sol",
     "test": "testStoreLoad",
     "name": "store 1 storage slot",
-    "gasUsed": 22373
+    "gasUsed": 22339
   },
   {
     "file": "test/Storage.t.sol",
@@ -555,7 +555,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 33010
+    "gasUsed": 32942
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -663,7 +663,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56605
+    "gasUsed": 56571
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -675,7 +675,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34738
+    "gasUsed": 34704
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -753,7 +753,7 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 62009
+    "gasUsed": 61975
   },
   {
     "file": "test/tables/Callbacks.t.sol",
@@ -771,7 +771,7 @@
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 64166
+    "gasUsed": 64132
   },
   {
     "file": "test/tables/Hooks.t.sol",

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -9,10 +9,6 @@ import { Memory } from "./Memory.sol";
  * (see https://github.com/latticexyz/mud/issues/444)
  */
 library Storage {
-  function store(uint256 storagePointer, bytes memory data) internal {
-    store(storagePointer, 0, data);
-  }
-
   function store(uint256 storagePointer, bytes32 data) internal {
     assembly {
       sstore(storagePointer, data)

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -27,48 +27,50 @@ library Storage {
    * @notice Stores raw bytes to storage at the given storagePointer and offset (keeping the rest of the word intact)
    */
   function store(uint256 storagePointer, uint256 offset, uint256 memoryPointer, uint256 length) internal {
-    // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-    unchecked {
-      storagePointer += offset / 32;
-      offset %= 32;
-    }
-
-    // For the first word, if there is an offset, apply a mask to beginning
     if (offset > 0) {
-      // Get the word's remaining length after the offset
-      uint256 wordRemainder;
-      // (safe because of `offset %= 32` at the start)
+      // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
       unchecked {
-        wordRemainder = 32 - offset;
+        storagePointer += offset / 32;
+        offset %= 32;
       }
 
-      uint256 mask = leftMask(length);
-      /// @solidity memory-safe-assembly
-      assembly {
-        // Load data from memory and offset it to match storage
-        let bitOffset := mul(offset, 8)
-        mask := shr(bitOffset, mask)
-        let offsetData := shr(bitOffset, mload(memoryPointer))
+      // For the first word, if there is an offset, apply a mask to beginning
+      if (offset > 0) {
+        // Get the word's remaining length after the offset
+        uint256 wordRemainder;
+        // (safe because of `offset %= 32` at the start)
+        unchecked {
+          wordRemainder = 32 - offset;
+        }
 
-        sstore(
-          storagePointer,
-          or(
-            // Store the middle part
-            and(offsetData, mask),
-            // Preserve the surrounding parts
-            and(sload(storagePointer), not(mask))
+        uint256 mask = leftMask(length);
+        /// @solidity memory-safe-assembly
+        assembly {
+          // Load data from memory and offset it to match storage
+          let bitOffset := mul(offset, 8)
+          mask := shr(bitOffset, mask)
+          let offsetData := shr(bitOffset, mload(memoryPointer))
+
+          sstore(
+            storagePointer,
+            or(
+              // Store the middle part
+              and(offsetData, mask),
+              // Preserve the surrounding parts
+              and(sload(storagePointer), not(mask))
+            )
           )
-        )
-      }
-      // Return if done
-      if (length <= wordRemainder) return;
+        }
+        // Return if done
+        if (length <= wordRemainder) return;
 
-      // Advance pointers
-      storagePointer += 1;
-      // (safe because of `length <= prefixLength` earlier)
-      unchecked {
-        memoryPointer += wordRemainder;
-        length -= wordRemainder;
+        // Advance pointers
+        storagePointer += 1;
+        // (safe because of `length <= prefixLength` earlier)
+        unchecked {
+          memoryPointer += wordRemainder;
+          length -= wordRemainder;
+        }
       }
     }
 
@@ -129,46 +131,48 @@ library Storage {
    * @notice Append raw bytes from storage at the given storagePointer, offset, and length to the given memoryPointer
    */
   function load(uint256 storagePointer, uint256 length, uint256 offset, uint256 memoryPointer) internal view {
-    // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-    unchecked {
-      storagePointer += offset / 32;
-      offset %= 32;
-    }
-
-    // For the first word, if there is an offset, apply a mask to beginning
     if (offset > 0) {
-      // Get the word's remaining length after the offset
-      uint256 wordRemainder;
-      // (safe because of `offset %= 32` at the start)
+      // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
       unchecked {
-        wordRemainder = 32 - offset;
+        storagePointer += offset / 32;
+        offset %= 32;
       }
 
-      uint256 mask = leftMask(wordRemainder);
-      /// @solidity memory-safe-assembly
-      assembly {
-        // Load data from storage and offset it to match memory
-        let offsetData := shl(mul(offset, 8), sload(storagePointer))
+      // For the first word, if there is an offset, apply a mask to beginning
+      if (offset > 0) {
+        // Get the word's remaining length after the offset
+        uint256 wordRemainder;
+        // (safe because of `offset %= 32` at the start)
+        unchecked {
+          wordRemainder = 32 - offset;
+        }
 
-        mstore(
-          memoryPointer,
-          or(
-            // store the middle part
-            and(offsetData, mask),
-            // preserve the surrounding parts
-            and(mload(memoryPointer), not(mask))
+        uint256 mask = leftMask(wordRemainder);
+        /// @solidity memory-safe-assembly
+        assembly {
+          // Load data from storage and offset it to match memory
+          let offsetData := shl(mul(offset, 8), sload(storagePointer))
+
+          mstore(
+            memoryPointer,
+            or(
+              // store the middle part
+              and(offsetData, mask),
+              // preserve the surrounding parts
+              and(mload(memoryPointer), not(mask))
+            )
           )
-        )
-      }
-      // Return if done
-      if (length <= wordRemainder) return;
+        }
+        // Return if done
+        if (length <= wordRemainder) return;
 
-      // Advance pointers
-      storagePointer += 1;
-      // (safe because of `length <= prefixLength` earlier)
-      unchecked {
-        memoryPointer += wordRemainder;
-        length -= wordRemainder;
+        // Advance pointers
+        storagePointer += 1;
+        // (safe because of `length <= prefixLength` earlier)
+        unchecked {
+          memoryPointer += wordRemainder;
+          length -= wordRemainder;
+        }
       }
     }
 

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -111,10 +111,6 @@ library Storage {
     }
   }
 
-  function load(uint256 storagePointer, uint256 length) internal view returns (bytes memory) {
-    return load(storagePointer, length, 0);
-  }
-
   /**
    * @notice Load raw bytes from storage at the given storagePointer, offset, and length
    */

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -21,9 +21,11 @@ library Storage {
   function store(uint256 storagePointer, uint256 offset, uint256 memoryPointer, uint256 length) internal {
     if (offset > 0) {
       // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-      unchecked {
-        storagePointer += offset / 32;
-        offset %= 32;
+      if (offset >= 32) {
+        unchecked {
+          storagePointer += offset / 32;
+          offset %= 32;
+        }
       }
 
       // For the first word, if there is an offset, apply a mask to beginning
@@ -132,9 +134,11 @@ library Storage {
   function load(uint256 storagePointer, uint256 length, uint256 offset, uint256 memoryPointer) internal view {
     if (offset > 0) {
       // Support offsets that are greater than 32 bytes by incrementing the storagePointer and decrementing the offset
-      unchecked {
-        storagePointer += offset / 32;
-        offset %= 32;
+      if (offset >= 32) {
+        unchecked {
+          storagePointer += offset / 32;
+          offset %= 32;
+        }
       }
 
       // For the first word, if there is an offset, apply a mask to beginning

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.0;
 
 import { leftMask } from "./Utils.sol";
+import { Memory } from "./Memory.sol";
 
 /**
  * TODO Probably not fully optimized
@@ -19,11 +20,7 @@ library Storage {
   }
 
   function store(uint256 storagePointer, uint256 offset, bytes memory data) internal {
-    uint256 memoryPointer;
-    assembly {
-      memoryPointer := add(data, 0x20)
-    }
-    store(storagePointer, offset, memoryPointer, data.length);
+    store(storagePointer, offset, Memory.dataPointer(data), data.length);
   }
 
   /**
@@ -124,11 +121,7 @@ library Storage {
     // TODO this will probably use less gas via manual memory allocation
     // (see https://github.com/latticexyz/mud/issues/444)
     result = new bytes(length);
-    uint256 memoryPointer;
-    assembly {
-      memoryPointer := add(result, 0x20)
-    }
-    load(storagePointer, length, offset, memoryPointer);
+    load(storagePointer, length, offset, Memory.dataPointer(result));
     return result;
   }
 

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -65,9 +65,9 @@ library Storage {
         if (length <= wordRemainder) return;
 
         // Advance pointers
-        storagePointer += 1;
-        // (safe because of `length <= prefixLength` earlier)
+        // (safe because of `length <= wordRemainder` earlier)
         unchecked {
+          storagePointer += 1;
           memoryPointer += wordRemainder;
           length -= wordRemainder;
         }
@@ -80,9 +80,8 @@ library Storage {
       assembly {
         sstore(storagePointer, mload(memoryPointer))
       }
-      storagePointer += 1;
-      // (safe unless length is improbably large)
       unchecked {
+        storagePointer += 1;
         memoryPointer += 32;
         length -= 32;
       }
@@ -167,9 +166,9 @@ library Storage {
         if (length <= wordRemainder) return;
 
         // Advance pointers
-        storagePointer += 1;
-        // (safe because of `length <= prefixLength` earlier)
+        // (safe because of `length <= wordRemainder` earlier)
         unchecked {
+          storagePointer += 1;
           memoryPointer += wordRemainder;
           length -= wordRemainder;
         }
@@ -182,9 +181,8 @@ library Storage {
       assembly {
         mstore(memoryPointer, sload(storagePointer))
       }
-      storagePointer += 1;
-      // (safe unless length is improbably large)
       unchecked {
+        storagePointer += 1;
         memoryPointer += 32;
         length -= 32;
       }

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.8.0;
 import { leftMask } from "./Utils.sol";
 import { Memory } from "./Memory.sol";
 
-/**
- * TODO Probably not fully optimized
- * (see https://github.com/latticexyz/mud/issues/444)
- */
 library Storage {
   function store(uint256 storagePointer, bytes32 data) internal {
     assembly {
@@ -20,7 +16,7 @@ library Storage {
   }
 
   /**
-   * @notice Stores raw bytes to storage at the given storagePointer and offset (keeping the rest of the word intact)
+   * Stores raw bytes to storage at the given storagePointer and offset (keeping the rest of the word intact)
    */
   function store(uint256 storagePointer, uint256 offset, uint256 memoryPointer, uint256 length) internal {
     if (offset > 0) {
@@ -108,7 +104,7 @@ library Storage {
   }
 
   /**
-   * @notice Load raw bytes from storage at the given storagePointer, offset, and length
+   * Load raw bytes from storage at the given storagePointer, offset, and length
    */
   function load(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes memory result) {
     uint256 memoryPointer;
@@ -131,7 +127,7 @@ library Storage {
   }
 
   /**
-   * @notice Append raw bytes from storage at the given storagePointer, offset, and length to the given memoryPointer
+   * Append raw bytes from storage at the given storagePointer, offset, and length to the given memoryPointer
    */
   function load(uint256 storagePointer, uint256 length, uint256 offset, uint256 memoryPointer) internal view {
     if (offset > 0) {

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -607,7 +607,7 @@ library StoreCoreInternal {
 
     // Store the provided value in storage
     uint256 dynamicDataLocation = _getDynamicDataLocation(tableId, key, dynamicSchemaIndex);
-    Storage.store({ storagePointer: dynamicDataLocation, data: data });
+    Storage.store({ storagePointer: dynamicDataLocation, offset: 0, data: data });
   }
 
   function _pushToDynamicField(

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -731,7 +731,7 @@ library StoreCoreInternal {
     uint256 location = _getDynamicDataLocation(tableId, key, dynamicSchemaIndex);
     uint256 dataLength = _loadEncodedDynamicDataLength(tableId, key).atIndex(dynamicSchemaIndex);
 
-    return Storage.load({ storagePointer: location, length: dataLength });
+    return Storage.load({ storagePointer: location, length: dataLength, offset: 0 });
   }
 
   /************************************************************************

--- a/packages/store/test/Gas.t.sol
+++ b/packages/store/test/Gas.t.sol
@@ -84,44 +84,7 @@ contract GasTest is Test, GasReporter {
 
     startGasReport("solidity storage write (warm, 10 words)");
     layoutBytes.value = value9Words;
-  }
-
-  function testCompareStorageLoadSolidity() public {
-    (bytes32 valueSimple, bytes16 valuePartial, bytes memory value9Words) = SolidityStorage.generateValues();
-    (
-      SolidityStorage.LayoutSimple storage layoutSimple,
-      SolidityStorage.LayoutPartial storage layoutPartial,
-      SolidityStorage.LayoutBytes storage layoutBytes
-    ) = SolidityStorage.layouts();
-
-    startGasReport("solidity storage load (cold, 1 word)");
-    valueSimple = layoutSimple.value;
     endGasReport();
-
-    startGasReport("solidity storage load (cold, 1 word, partial)");
-    valuePartial = layoutPartial.value;
-    endGasReport();
-
-    startGasReport("solidity storage load (cold, 10 words)");
-    value9Words = layoutBytes.value;
-    endGasReport();
-
-    // warm
-
-    startGasReport("solidity storage load (warm, 1 word)");
-    valueSimple = layoutSimple.value;
-    endGasReport();
-
-    startGasReport("solidity storage load (warm, 1 word, partial)");
-    valuePartial = layoutPartial.value;
-    endGasReport();
-
-    startGasReport("solidity storage load (warm, 10 words)");
-    value9Words = layoutBytes.value;
-    endGasReport();
-
-    // Do something in case the optimizer removes unused assignments
-    someContract.doSomethingWithBytes(abi.encode(valueSimple, valuePartial, value9Words));
   }
 
   // Note that this compares storage writes in isolation, which can be misleading,
@@ -161,42 +124,6 @@ contract GasTest is Test, GasReporter {
     startGasReport("MUD storage write (warm, 10 words)");
     Storage.store(SolidityStorage.STORAGE_SLOT_BYTES, 0, encoded9Words);
     endGasReport();
-  }
-
-  function testCompareStorageLoadMUD() public {
-    (bytes32 valueSimple, bytes16 valuePartial, bytes memory value9Words) = SolidityStorage.generateValues();
-    bytes memory encodedSimple = abi.encodePacked(valueSimple);
-    bytes memory encodedPartial = abi.encodePacked(valuePartial);
-    bytes memory encoded9Words = abi.encodePacked(value9Words.length, value9Words);
-
-    startGasReport("MUD storage load (cold, 1 word)");
-    encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
-    endGasReport();
-
-    startGasReport("MUD storage load (cold, 1 word, partial)");
-    encodedPartial = Storage.load(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedPartial.length, 16);
-    endGasReport();
-
-    startGasReport("MUD storage load (cold, 10 words)");
-    encoded9Words = Storage.load(SolidityStorage.STORAGE_SLOT_BYTES, encoded9Words.length, 0);
-    endGasReport();
-
-    // warm
-
-    startGasReport("MUD storage load (warm, 1 word)");
-    encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
-    endGasReport();
-
-    startGasReport("MUD storage load (warm, 1 word, partial)");
-    encodedPartial = Storage.load(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedPartial.length, 16);
-    endGasReport();
-
-    startGasReport("MUD storage load (warm, 10 words)");
-    encoded9Words = Storage.load(SolidityStorage.STORAGE_SLOT_BYTES, encoded9Words.length, 0);
-    endGasReport();
-
-    // Do something in case the optimizer removes unused assignments
-    someContract.doSomethingWithBytes(abi.encode(encodedSimple, encodedPartial, encoded9Words));
   }
 }
 

--- a/packages/store/test/GasStorageLoad.t.sol
+++ b/packages/store/test/GasStorageLoad.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
+import { Storage } from "../src/Storage.sol";
+import { SolidityStorage, SomeContract } from "./Gas.t.sol";
+
+contract GasStorageLoadTest is Test, GasReporter {
+  SomeContract someContract = new SomeContract();
+
+  // Cold loads require us to initialize the values outside of their test
+  function setUp() public {
+    (bytes32 valueSimple, bytes16 valuePartial, bytes memory value9Words) = SolidityStorage.generateValues();
+    (
+      SolidityStorage.LayoutSimple storage layoutSimple,
+      SolidityStorage.LayoutPartial storage layoutPartial,
+      SolidityStorage.LayoutBytes storage layoutBytes
+    ) = SolidityStorage.layouts();
+
+    layoutSimple.value = valueSimple;
+    layoutPartial.value = valuePartial;
+    layoutBytes.value = value9Words;
+  }
+
+  function testCompareStorageLoadSolidity() public {
+    (bytes32 valueSimple, bytes16 valuePartial, bytes memory value9Words) = SolidityStorage.generateValues();
+    (
+      SolidityStorage.LayoutSimple storage layoutSimple,
+      SolidityStorage.LayoutPartial storage layoutPartial,
+      SolidityStorage.LayoutBytes storage layoutBytes
+    ) = SolidityStorage.layouts();
+
+    startGasReport("solidity storage load (cold, 1 word)");
+    valueSimple = layoutSimple.value;
+    endGasReport();
+
+    startGasReport("solidity storage load (cold, 1 word, partial)");
+    valuePartial = layoutPartial.value;
+    endGasReport();
+
+    startGasReport("solidity storage load (cold, 10 words)");
+    value9Words = layoutBytes.value;
+    endGasReport();
+
+    // warm
+
+    startGasReport("solidity storage load (warm, 1 word)");
+    valueSimple = layoutSimple.value;
+    endGasReport();
+
+    startGasReport("solidity storage load (warm, 1 word, partial)");
+    valuePartial = layoutPartial.value;
+    endGasReport();
+
+    startGasReport("solidity storage load (warm, 10 words)");
+    value9Words = layoutBytes.value;
+    endGasReport();
+
+    // Do something in case the optimizer removes unused assignments
+    someContract.doSomethingWithBytes(abi.encode(valueSimple, valuePartial, value9Words));
+  }
+
+  function testCompareStorageLoadMUD() public {
+    (bytes32 valueSimple, bytes16 valuePartial, bytes memory value9Words) = SolidityStorage.generateValues();
+    bytes memory encodedSimple = abi.encodePacked(valueSimple);
+    bytes memory encodedPartial = abi.encodePacked(valuePartial);
+    bytes memory encoded9Words = abi.encodePacked(value9Words.length, value9Words);
+
+    startGasReport("MUD storage load (cold, 1 word)");
+    encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
+    endGasReport();
+
+    startGasReport("MUD storage load (cold, 1 word, partial)");
+    encodedPartial = Storage.load(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedPartial.length, 16);
+    endGasReport();
+
+    startGasReport("MUD storage load (cold, 10 words)");
+    encoded9Words = Storage.load(SolidityStorage.STORAGE_SLOT_BYTES, encoded9Words.length, 0);
+    endGasReport();
+
+    // warm
+
+    startGasReport("MUD storage load (warm, 1 word)");
+    encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
+    endGasReport();
+
+    startGasReport("MUD storage load (warm, 1 word, partial)");
+    encodedPartial = Storage.load(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedPartial.length, 16);
+    endGasReport();
+
+    startGasReport("MUD storage load (warm, 10 words)");
+    encoded9Words = Storage.load(SolidityStorage.STORAGE_SLOT_BYTES, encoded9Words.length, 0);
+    endGasReport();
+
+    // Do something in case the optimizer removes unused assignments
+    someContract.doSomethingWithBytes(abi.encode(encodedSimple, encodedPartial, encoded9Words));
+  }
+}

--- a/packages/store/test/Storage.t.sol
+++ b/packages/store/test/Storage.t.sol
@@ -27,10 +27,10 @@ contract StorageTest is Test, GasReporter {
     // First store some data to storage at the target slot and two slots after the target slot
 
     startGasReport("store 1 storage slot");
-    Storage.store({ storagePointer: storagePointer, data: originalDataFirstSlot });
+    Storage.store({ storagePointer: storagePointer, offset: 0, data: originalDataFirstSlot });
     endGasReport();
 
-    Storage.store({ storagePointer: storagePointerTwoSlotsAfter, data: originalDataLastSlot });
+    Storage.store({ storagePointer: storagePointerTwoSlotsAfter, offset: 0, data: originalDataLastSlot });
 
     // Then set the target slot, partially overwriting the first and third slot, but using safeTrail and offset
 

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,73 +3,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1255918
+    "gasUsed": 1248704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1255918
+    "gasUsed": 1248704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 189004
+    "gasUsed": 187021
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1255918
+    "gasUsed": 1248704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1255918
+    "gasUsed": 1248704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 28442
+    "gasUsed": 27801
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 270004
+    "gasUsed": 262682
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1255918
+    "gasUsed": 1248704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 27056
+    "gasUsed": 26415
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 141266
+    "gasUsed": 137742
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 606592
+    "gasUsed": 602496
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 7716
+    "gasUsed": 7444
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -81,240 +81,240 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 606592
+    "gasUsed": 602496
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 162059
+    "gasUsed": 159927
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 606592
+    "gasUsed": 602496
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 129713
+    "gasUsed": 127327
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 50859
+    "gasUsed": 49418
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 606592
+    "gasUsed": 602496
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 170334
+    "gasUsed": 168075
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 132692
+    "gasUsed": 130339
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 163160
+    "gasUsed": 160604
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 77029
+    "gasUsed": 75381
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 222474
+    "gasUsed": 220085
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 139829
+    "gasUsed": 138370
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 139055
+    "gasUsed": 137295
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 19621
+    "gasUsed": 19014
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 31559
+    "gasUsed": 31224
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 10806607
+    "gasUsed": 10687510
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 1009010
+    "gasUsed": 997013
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 9522
+    "gasUsed": 9187
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 70209
+    "gasUsed": 68939
   },
   {
     "file": "test/SnapSyncModule.t.sol",
     "test": "testSnapSyncGas",
     "name": "Call snap sync on a table with 1 record",
-    "gasUsed": 39819
+    "gasUsed": 39143
   },
   {
     "file": "test/SnapSyncModule.t.sol",
     "test": "testSnapSyncGas",
     "name": "Call snap sync on a table with 2 records",
-    "gasUsed": 57129
+    "gasUsed": 56220
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 797781
+    "gasUsed": 791266
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 71099
+    "gasUsed": 70073
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 769225
+    "gasUsed": 763358
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 71099
+    "gasUsed": 70073
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 15060
+    "gasUsed": 14659
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 95419
+    "gasUsed": 94777
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 81644
+    "gasUsed": 80591
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 72828
+    "gasUsed": 71771
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 102239
+    "gasUsed": 101182
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 157623
+    "gasUsed": 156426
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 88731
+    "gasUsed": 87674
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 255729
+    "gasUsed": 253992
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 43649
+    "gasUsed": 43248
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetMetadata",
     "name": "Set metadata",
-    "gasUsed": 279560
+    "gasUsed": 278225
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 41504
+    "gasUsed": 41103
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 38906
+    "gasUsed": 38297
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 21696
+    "gasUsed": 21087
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 41285
+    "gasUsed": 40609
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 24487
+    "gasUsed": 23811
   }
 ]


### PR DESCRIPTION
| | Solidity  | MUD |
| -- | -- | -- |
| write (cold, 1 word) | 22107 | 22339 |
| write (cold, 1 word, partial) | 22136 | 22406 |
| write (cold, 10 words) | 199902 | 199795 |
| write (warm, 1 word) | 107 | 339 |
| write (warm, 1 word, partial) | 236 | 506 |
| write (warm, 10 words) | 1988 | 1795 |
| load (cold, 1 word) | 2109 | 2411 |
| load (cold, 1 word, partial) | 2126 | 2460 |
| load (cold, 10 words) | 19894 | 19911 |
| load (warm, 1 word) | 109 | 414 |
| load (warm, 1 word, partial) | 126 | 462 |
| load (warm, 10 words) | 1897 | 1935 |

surprised I got `storage write (warm, 10 words)` to be more efficient than solidity
but also it doesn't mean anything, this is apples to oranges: https://github.com/latticexyz/mud/blob/b4a68649acdc1f84467f63df150a56750f5cbe72/packages/store/test/Gas.t.sol#L107-L110

Not a fan of how big the relative difference in `load (warm, 1 word)` is but it's kinda unavoidable. Rough estimate of reasons:
- internal function - 40 each, and we need 2 (not counting leftMask, optimizer can inline it) for the code to be readable/auditable
- ~40 for jagged head/tail checks (which solidity can do at compile time); more if they actually exist, see `(warm, 1 word, partial)` for jagged head
- ~145 for a cycle (which solidity can hardcode)