### PR TITLE
feat(store-sync): export singletonEntity as const, allow startBlock in syncToRecs

### DIFF
--- a/.changeset/metal-cats-double.md
+++ b/.changeset/metal-cats-double.md
@@ -1,0 +1,15 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Add `startBlock` option to `syncToRecs`.
+
+```ts
+import { syncToRecs } from "@latticexyz/store-sync/recs";
+import worlds from "contracts/worlds.json";
+
+syncToRecs({
+  startBlock: worlds['31337'].blockNumber,
+  ...
+});
+```

--- a/.changeset/nice-moose-love.md
+++ b/.changeset/nice-moose-love.md
@@ -1,0 +1,11 @@
+---
+"@latticexyz/store-sync": minor
+---
+
+Export `singletonEntity` as const rather than within the `syncToRecs` result.
+
+```diff
+- const { singletonEntity, ... } = syncToRecs({ ... });
++ import { singletonEntity, syncToRecs } from "@latticexyz/store-sync/recs";
++ const { ... } = syncToRecs({ ... });
+```

--- a/packages/store-sync/src/recs/index.ts
+++ b/packages/store-sync/src/recs/index.ts
@@ -4,4 +4,5 @@ export * from "./encodeEntity";
 export * from "./entityToHexKeyTuple";
 export * from "./hexKeyTupleToEntity";
 export * from "./recsStorage";
+export * from "./singletonEntity";
 export * from "./syncToRecs";

--- a/packages/store-sync/src/recs/singletonEntity.ts
+++ b/packages/store-sync/src/recs/singletonEntity.ts
@@ -1,0 +1,3 @@
+import { hexKeyTupleToEntity } from "./hexKeyTupleToEntity";
+
+export const singletonEntity = hexKeyTupleToEntity([]);

--- a/packages/store-sync/src/recs/syncToRecs.ts
+++ b/packages/store-sync/src/recs/syncToRecs.ts
@@ -20,13 +20,13 @@ import {
 import { filter, map, tap, mergeMap, from, concatMap, Observable, share, firstValueFrom } from "rxjs";
 import { BlockStorageOperations, blockLogsToStorage } from "../blockLogsToStorage";
 import { recsStorage } from "./recsStorage";
-import { hexKeyTupleToEntity } from "./hexKeyTupleToEntity";
 import { debug } from "./debug";
 import { defineInternalComponents } from "./defineInternalComponents";
 import { getTableKey } from "./getTableKey";
 import { StoreComponentMetadata, SyncStep } from "./common";
 import { encodeEntity } from "./encodeEntity";
 import { createIndexerClient } from "../trpc-indexer";
+import { singletonEntity } from "./singletonEntity";
 
 type SyncToRecsOptions<
   TConfig extends StoreConfig = StoreConfig,
@@ -58,7 +58,6 @@ type SyncToRecsResult<
 > = {
   // TODO: return publicClient?
   components: TComponents & ReturnType<typeof defineInternalComponents>;
-  singletonEntity: Entity;
   latestBlock$: Observable<Block>;
   latestBlockNumber$: Observable<bigint>;
   blockLogs$: Observable<BlockLogs>;
@@ -87,7 +86,7 @@ export async function syncToRecs<
     ...defineInternalComponents(world),
   };
 
-  const singletonEntity = world.registerEntity({ id: hexKeyTupleToEntity([]) });
+  world.registerEntity({ id: singletonEntity });
 
   let startBlock = 0n;
 
@@ -238,7 +237,6 @@ export async function syncToRecs<
 
   return {
     components,
-    singletonEntity,
     latestBlock$,
     latestBlockNumber$,
     blockLogs$,


### PR DESCRIPTION
- Export `singletonEntity` as const rather than within the `syncToRecs` result.
- Add `startBlock` option to `syncToRecs`.