### PR TITLE
fix(store): align Store event names between IStoreWrite and StoreCore

### DIFF
--- a/.changeset/large-hats-walk.md
+++ b/.changeset/large-hats-walk.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": patch
+---
+
+Align Store events parameter naming between IStoreWrite and StoreCore

--- a/packages/store/abi/StoreCore.sol/StoreCore.abi.json
+++ b/packages/store/abi/StoreCore.sol/StoreCore.abi.json
@@ -5,7 +5,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -49,7 +49,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -80,7 +80,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -18,9 +18,9 @@ library StoreCore {
   using TableId for bytes32;
 
   // note: the preimage of the tuple of keys used to index is part of the event, so it can be used by indexers
-  event StoreSetRecord(bytes32 tableId, bytes32[] key, bytes data);
-  event StoreSetField(bytes32 tableId, bytes32[] key, uint8 schemaIndex, bytes data);
-  event StoreDeleteRecord(bytes32 tableId, bytes32[] key);
+  event StoreSetRecord(bytes32 table, bytes32[] key, bytes data);
+  event StoreSetField(bytes32 table, bytes32[] key, uint8 schemaIndex, bytes data);
+  event StoreDeleteRecord(bytes32 table, bytes32[] key);
   event StoreEphemeralRecord(bytes32 table, bytes32[] key, bytes data);
 
   /**

--- a/packages/world/abi/StoreCore.sol/StoreCore.abi.json
+++ b/packages/world/abi/StoreCore.sol/StoreCore.abi.json
@@ -5,7 +5,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -49,7 +49,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -80,7 +80,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {

--- a/packages/world/abi/src/StoreCore.sol/StoreCore.abi.json
+++ b/packages/world/abi/src/StoreCore.sol/StoreCore.abi.json
@@ -5,7 +5,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -49,7 +49,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {
@@ -80,7 +80,7 @@
       {
         "indexed": false,
         "internalType": "bytes32",
-        "name": "tableId",
+        "name": "table",
         "type": "bytes32"
       },
       {


### PR DESCRIPTION
- StoreCore had `tableId` while `IStoreWrite` had `table`, which created two entries in the generated ABI and caused a `duplicate definition` warning
- A nicer solution for this would be to only declare these events once and emit them in `StoreCore` as `IStoreWrite.StoreSetRecord`, but this is only supported from Solidity version 0.8.21 (see https://github.com/ethereum/solidity/pull/14274) and updating the Solidity version is a slightly bigger change than this quick fix