### PR TITLE
feat(common): allow hooking into mudTransportObserver requests

### DIFF
--- a/.changeset/shiny-turkeys-admire.md
+++ b/.changeset/shiny-turkeys-admire.md
@@ -7,7 +7,7 @@ Adds an onRequest option to mudTransportObserver, so we can hook into transport 
 ```ts
 createPublicClient({
   transport: mudTransportObserver(transport, {
-    function onRequest({method, params) {
+    onRequest({method, params) {
       console.log('got rpc request', method);
     }
   }),

--- a/.changeset/shiny-turkeys-admire.md
+++ b/.changeset/shiny-turkeys-admire.md
@@ -7,7 +7,7 @@ Adds an onRequest option to mudTransportObserver, so we can hook into transport 
 ```ts
 createPublicClient({
   transport: mudTransportObserver(transport, {
-    onRequest({method, params) {
+    onRequest({ method, params }) {
       console.log('got rpc request', method);
     }
   }),

--- a/.changeset/shiny-turkeys-admire.md
+++ b/.changeset/shiny-turkeys-admire.md
@@ -1,0 +1,16 @@
+---
+"@latticexyz/common": minor
+---
+
+Adds an onRequest option to mudTransportObserver, so we can hook into transport requests in a generic way.
+
+```ts
+createPublicClient({
+  transport: mudTransportObserver(transport, {
+    function onRequest({method, params) {
+      console.log('got rpc request', method);
+    }
+  }),
+  ...
+});
+```


### PR DESCRIPTION
Adds an `onRequest` option to `mudTransportObserver`, so we can hook into transport requests in a generic way.