### PR TITLE
docs: Add link to conventional specs

### DIFF
--- a/docs/pages/contribute.mdx
+++ b/docs/pages/contribute.mdx
@@ -33,4 +33,5 @@ The following steps are only necessary if you want to contribute to MUD. To use 
 
 ### Pull requests
 
-MUD follows the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and PR titles. Please keep the scope of your PR small (rather open multiple small PRs than one huge PR) and follow the conventional commit spec.
+MUD follows the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and PR titles.
+Please keep the scope of your PR small (rather open multiple small PRs than one huge PR) and follow [the conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
Tiny change