### PR TITLE
feat(common): move zero gas fee override to `createContract`

### DIFF
--- a/.changeset/tricky-kangaroos-love.md
+++ b/.changeset/tricky-kangaroos-love.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/common": minor
+---
+
+- Moves zero gas fee override to `createContract` until https://github.com/wagmi-dev/viem/pull/963 or similar feature lands
+- Skip simulation if `gas` is provided

--- a/packages/common/src/chains/mudFoundry.ts
+++ b/packages/common/src/chains/mudFoundry.ts
@@ -1,18 +1,7 @@
-import { defineTransactionRequest } from "viem";
 import { foundry } from "viem/chains";
+import { MUDChain } from "./types";
 
 export const mudFoundry = {
   ...foundry,
-  formatters: {
-    transactionRequest: defineTransactionRequest({
-      format() {
-        // Temporarily override base fee for MUD's anvil config
-        // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
-        return {
-          maxFeePerGas: 0n,
-          maxPriorityFeePerGas: 0n,
-        };
-      },
-    }),
-  },
-};
+  // We may override chain settings here
+} as const satisfies MUDChain;

--- a/packages/common/src/createBurnerAccount.ts
+++ b/packages/common/src/createBurnerAccount.ts
@@ -3,20 +3,8 @@ import { privateKeyToAccount } from "viem/accounts";
 
 export function createBurnerAccount(privateKey: Hex): Account {
   const account = privateKeyToAccount(privateKey);
-
-  // Temporarily override base fee for MUD's anvil config
-  // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
-  const signTransaction: typeof account.signTransaction = async (transaction, ...args) => {
-    // TODO: refine check for mud anvil (0 base fee)
-    if (transaction.chainId === 31337) {
-      transaction.maxFeePerGas = 0n;
-      transaction.maxPriorityFeePerGas = 0n;
-    }
-    return account.signTransaction(transaction, ...args);
-  };
-
+  // We may override account features here
   return {
     ...account,
-    signTransaction,
   };
 }

--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -17,12 +17,11 @@ import pQueue from "p-queue";
 import pRetry from "p-retry";
 import { createNonceManager } from "./createNonceManager";
 import { debug as parentDebug } from "./debug";
+import { UnionOmit } from "./type-utils/common";
 
 const debug = parentDebug.extend("createContract");
 
-export type UnionOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
-
-// copied from viem because it isn't exported
+// copied from viem because this isn't exported
 // TODO: import from viem?
 function getFunctionParameters(values: [args?: readonly unknown[], options?: object]): {
   args: readonly unknown[];

--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -20,6 +20,8 @@ import { debug as parentDebug } from "./debug";
 
 const debug = parentDebug.extend("createContract");
 
+export type UnionOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+
 // copied from viem because it isn't exported
 // TODO: import from viem?
 function getFunctionParameters(values: [args?: readonly unknown[], options?: object]): {
@@ -72,31 +74,59 @@ export function createContract<
       {
         get(_, functionName: string): GetContractReturnType<Abi, PublicClient, WalletClient>["write"][string] {
           return async (...parameters) => {
-            const { args, options } = getFunctionParameters(parameters as any);
+            const { args, options } = <
+              {
+                args: unknown[];
+                options: UnionOmit<WriteContractParameters, "abi" | "address" | "functionName" | "args">;
+              }
+            >getFunctionParameters(parameters as any);
 
             async function write(): Promise<Hex> {
               if (!nonceManager.hasNonce()) {
                 await nonceManager.resetNonce();
               }
 
+              // Temporarily override base fee for our default anvil config
+              // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
+              // TODO: more specific mud foundry check? or can we safely assume anvil+mud will be block fee zero for now?
+              if (
+                walletClient.chain.id === 31337 &&
+                options.maxFeePerGas == null &&
+                options.maxPriorityFeePerGas == null
+              ) {
+                options.maxFeePerGas = 0n;
+                options.maxPriorityFeePerGas = 0n;
+              }
+
+              if (options.gas) {
+                const nonce = nonceManager.nextNonce();
+                debug("gas provided, skipping simulate and calling write function with nonce", nonce, options);
+                return await walletClient.writeContract({
+                  address,
+                  abi,
+                  functionName,
+                  args,
+                  nonce,
+                  ...options,
+                } as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>);
+              }
+
               debug("simulating write", functionName, args, options);
               const { request } = await publicClient.simulateContract({
-                account: walletClient.account,
                 address,
                 abi,
                 functionName,
                 args,
                 ...options,
+                account: options.account ?? walletClient.account,
               } as unknown as SimulateContractParameters<TAbi, typeof functionName, TChain>);
 
               const nonce = nonceManager.nextNonce();
               debug("calling write function with nonce", nonce, request);
-              const result = await walletClient.writeContract({
+              return await walletClient.writeContract({
                 nonce,
                 ...request,
               } as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>);
-
-              return result;
             }
 
             return await queue.add(

--- a/packages/common/src/type-utils/common.ts
+++ b/packages/common/src/type-utils/common.ts
@@ -17,3 +17,5 @@ export type OrDefault<T, Default> = T extends undefined ? Default : T;
 export type OrDefaults<T extends object, Defaults> = {
   [key in keyof Defaults]: key extends keyof T ? OrDefault<T[key], Defaults[key]> : Defaults[key];
 };
+
+export type UnionOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;


### PR DESCRIPTION
closes https://github.com/latticexyz/mud/issues/1264

- Moves zero gas fee override to `createContract` until https://github.com/wagmi-dev/viem/pull/963 or similar feature lands
- Skip simulation if `gas` is provided