### PR TITLE
docs: fix homepage title

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -13,6 +13,7 @@ import Link from "next/link";
     </>
   }
 />
+
 <div style={{ display: "flex", justifyContent: "center" }}>
   <div style={{ marginTop: "12px" }}>
     <Logo />

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -7,7 +7,7 @@ const config: DocsThemeConfig = {
   useNextSeoProps() {
     const { asPath } = useRouter();
     return {
-      titleTemplate: asPath === "/" ? "%s" : "%s – MUD",
+      titleTemplate: asPath === "/" ? "MUD – a framework for ambitious Ethereum applications" : "%s – MUD",
     };
   },
   project: {


### PR DESCRIPTION
Apparently Nextra wants an h1 to determine the page title, otherwise it falls back to the filename rather than what's defined in `_meta`, so we'll force it via the SEO settings.