### PR TITLE
style: change `localhost` to `127.0.0.1`

### DIFF
--- a/docs/pages/cli.mdx
+++ b/docs/pages/cli.mdx
@@ -76,7 +76,7 @@ To run the dev server with a custom development node:
 anvil --port 8545
 
 # Terminal 2:
-pnpm mud dev-contracts --tsgenOutput ../client/src/mud --rpc localhost:8545
+pnpm mud dev-contracts --tsgenOutput ../client/src/mud --rpc 127.0.0.1:8545
 ```
 
 ### `deploy`
@@ -89,7 +89,7 @@ When using the deployer, you must set the private key of the deployer using the 
 
 To set the profile used by the deployer, either set your `FOUNDRY_PROFILE` environment variable, or pass `--profile <profileName>` to the deployer (eg: `mud deploy --profile optimism-mainnet`).
 
-The RPC used by the deployer will be `http://localhost:8545` if no profile is set, otherwise it will be read from the `eth_rpc_url` configuration field of the Foundry profile.
+The RPC used by the deployer will be `http://127.0.0.1:8545` if no profile is set, otherwise it will be read from the `eth_rpc_url` configuration field of the Foundry profile.
 
 Example profile:
 

--- a/docs/pages/indexer.mdx
+++ b/docs/pages/indexer.mdx
@@ -38,7 +38,7 @@ They are written under the assumption you are using `anvil` for your test chain,
 1. Run this command as a sanity check to verify the indexer is working correctly:
 
    ```sh
-   curl 'http://localhost:3001/findAll?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' | jq
+   curl 'http://127.0.0.1:3001/findAll?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' | jq
    ```
 
    The result should be nicely formatted (and long) JSON output.
@@ -103,7 +103,7 @@ To understand the result, it is easiest to look at it inside Node.
 1. Read the result and enter `node`:
 
    ```sh
-   curl 'http://localhost:3001/findAll?batch=wd&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' > res.json
+   curl 'http://127.0.0.1:3001/findAll?batch=wd&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' > res.json
    node
    ```
 

--- a/docs/pages/quick-start.mdx
+++ b/docs/pages/quick-start.mdx
@@ -41,7 +41,7 @@ If all went well you should see this in your command line.
 
 ![MUD CLI](./quick-start-mud-cli.png)
 
-After deployment is successful, pop over to [http://localhost:3000](http://localhost:3000) and checkout your live app. When you visit you’ll see an increment button and dev tools open in the right-hand panel. Try clicking the button and seeing what updates in the dev tools!
+After deployment is successful, pop over to [http://127.0.0.1:3000](http://127.0.0.1:3000) and checkout your live app. When you visit you’ll see an increment button and dev tools open in the right-hand panel. Try clicking the button and seeing what updates in the dev tools!
 
 If you want to open or close the dev tools at any time, you can press the ` key on your keyboard or the button on the bottom right.
 

--- a/docs/pages/tutorials/emojimon/getting-started.mdx
+++ b/docs/pages/tutorials/emojimon/getting-started.mdx
@@ -31,4 +31,4 @@ If all went well you should see this in your command line.
 
 ![A successful MUD deployment](../../quick-start-mud-cli.png)
 
-After deployment is successful, pop over to [http://localhost:3000](http://localhost:3000) and checkout your live app. At this point you can open up your code editor and get started!
+After deployment is successful, pop over to [http://127.0.0.1:3000](http://127.0.0.1:3000) and checkout your live app. At this point you can open up your code editor and get started!

--- a/docs/pages/tutorials/minimal.mdx
+++ b/docs/pages/tutorials/minimal.mdx
@@ -24,7 +24,7 @@ To create the basic version to modify, follow these steps:
    ```
 
 1. Browse to the URL that the client package gives you.
-   Usually that is `http://localhost:3000`, but it could vary if there's another application using that port.
+   Usually that is `http://127.0.0.1:3000`, but it could vary if there's another application using that port.
 
 ## The tutorials
 

--- a/docs/pages/world/deployer.mdx
+++ b/docs/pages/world/deployer.mdx
@@ -8,7 +8,7 @@ The deployer also supports Foundry profile to deploy to different chains.
 
 To set the profile used by the deployer, either set your `FOUNDRY_PROFILE` environment variable, or pass `--profile <profileName>` to the deployer (eg: `mud deploy --profile optimism-mainnet`).
 
-The RPC used by the deployer will be [http://localhost:8545](http://localhost:8545) if no profile is set, otherwise it will be read from the `eth_rpc_url` configuration field of the Foundry profile.
+The RPC used by the deployer will be [http://127.0.0.1:8545](http://127.0.0.1:8545) if no profile is set, otherwise it will be read from the `eth_rpc_url` configuration field of the Foundry profile.
 
 Example profile:
 

--- a/e2e/packages/sync-test/modeSync.test.ts
+++ b/e2e/packages/sync-test/modeSync.test.ts
@@ -33,7 +33,7 @@ describe("Sync from MODE", async () => {
   const anvilPort = 8545;
   const rpc = `http://127.0.0.1:${anvilPort}`;
   let modeProcess: ExecaChildProcess;
-  const modeUrl = "http://localhost:50092";
+  const modeUrl = "http://127.0.0.1:50092";
 
   beforeEach(async () => {
     asyncErrorHandler.resetErrors();

--- a/e2e/packages/sync-test/setup/openClientWithRootAccount.ts
+++ b/e2e/packages/sync-test/setup/openClientWithRootAccount.ts
@@ -7,5 +7,5 @@ dotenv.config({ path: "../contracts/.env" });
 export async function openClientWithRootAccount(page: Page, options?: { modeUrl?: string }) {
   const modeFragment = options?.modeUrl ? `&mode=${options.modeUrl}` : "";
   const privateKeyFragment = `&privateKey=${process.env.PRIVATE_KEY}`;
-  await page.goto(`http://127.0.0.1:3000?cache=false${modeFragment}${privateKeyFragment}`);
+  await page.goto(`http://localhost:3000?cache=false${modeFragment}${privateKeyFragment}`);
 }

--- a/e2e/packages/sync-test/setup/openClientWithRootAccount.ts
+++ b/e2e/packages/sync-test/setup/openClientWithRootAccount.ts
@@ -7,5 +7,5 @@ dotenv.config({ path: "../contracts/.env" });
 export async function openClientWithRootAccount(page: Page, options?: { modeUrl?: string }) {
   const modeFragment = options?.modeUrl ? `&mode=${options.modeUrl}` : "";
   const privateKeyFragment = `&privateKey=${process.env.PRIVATE_KEY}`;
-  await page.goto(`http://localhost:3000?cache=false${modeFragment}${privateKeyFragment}`);
+  await page.goto(`http://127.0.0.1:3000?cache=false${modeFragment}${privateKeyFragment}`);
 }

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -6,4 +6,4 @@ This example project demonstrates how to use the MUD framework to create a simpl
 
 1. Since this project uses local MUD dependencies, you need to prepare them first by running this command in the MUD root directory: `pnpm install && pnpm build`
 2. To start the development environment of this project, run `pnpm dev` in the project root. This will start a local chain, deploy the contracts in `packages/contracts`, and start a development server for the client. By default the react client (`packages/client-react`) will be used. To use the vanilla client instead, run `pnpm dev:client-vanilla`.
-3. Open [localhost:3000](http://localhost:3000) in your browser.
+3. Open [127.0.0.1:3000](http://127.0.0.1:3000) in your browser.

--- a/examples/minimal/packages/client-react/package.json
+++ b/examples/minimal/packages/client-react/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/minimal/packages/client-vanilla/package.json
+++ b/examples/minimal/packages/client-vanilla/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/services/Makefile
+++ b/packages/services/Makefile
@@ -1,4 +1,4 @@
-WS_URL=ws://localhost:8545
+WS_URL=ws://127.0.0.1:8545
 
 GITCOMMIT := $(shell git rev-parse HEAD)
 GITDATE := $(shell git show -s --format='%ct')

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -70,7 +70,7 @@ metrics:
   port: 6060
 ```
 
-7. If you're running with the default 127.0.0.1 / `31337` chain, make sure there is a local node running for the chain you want to connect to. For example, a hardhat node or an anvil node.
+7. If you're running with the default local (`31337`) chain, make sure there is a local node running for the chain you want to connect to. For example, a hardhat node or an anvil node.
 8. Run the MODE service
 
 ```bash

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -52,7 +52,7 @@ make mode
 
 ```yaml
 chains:
-  - name: "127.0.0.1"
+  - name: "foundry"
     id: "31337"
     rpc:
       http: "http://127.0.0.1:8545"

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -21,7 +21,7 @@ The following services are available for use with MUD V2. For more details on ea
 1. Install Docker for Mac (https://docs.docker.com/docker-for-mac/install/)
 2. Install Docker Compose (https://docs.docker.com/compose/install/)
 3. Run `docker-compose -f docker-compose.mode.yaml up`. This will start services for both MODE and PostgresDB.
-4. By default it will connect to a local anvil node at `localhost:8545`. If you want to connect to a different node, you can change the `rpc.http` and `rpc.ws` fields in the `config.mode-docker.yaml` file.
+4. By default it will connect to a local anvil node at `127.0.0.1:8545`. If you want to connect to a different node, you can change the `rpc.http` and `rpc.ws` fields in the `config.mode-docker.yaml` file.
 
 #### Running the MODE service
 
@@ -52,13 +52,13 @@ make mode
 
 ```yaml
 chains:
-  - name: "localhost"
+  - name: "127.0.0.1"
     id: "31337"
     rpc:
-      http: "http://localhost:8545"
-      ws: "ws://localhost:8545"
+      http: "http://127.0.0.1:8545"
+      ws: "ws://127.0.0.1:8545"
 db:
-  dsn: "postgresql://localhost:5432/mode_ephemeral?sslmode=disable&replication=database"
+  dsn: "postgresql://127.0.0.1:5432/mode_ephemeral?sslmode=disable&replication=database"
   wipe: false
 sync:
   enabled: true
@@ -70,7 +70,7 @@ metrics:
   port: 6060
 ```
 
-7. If you're running with the default localhost / `31337` chain, make sure there is a local node running for the chain you want to connect to. For example, a hardhat node or an anvil node.
+7. If you're running with the default 127.0.0.1 / `31337` chain, make sure there is a local node running for the chain you want to connect to. For example, a hardhat node or an anvil node.
 8. Run the MODE service
 
 ```bash
@@ -92,7 +92,7 @@ brew install grpcurl
 10. MODE exposes a `QueryLayer` gRPC server on port `50091` by default. You can use a gRPC client to interact with the service API. For example, to query for the current state of an indexed MUD world deployed at address `0xff738496c8cd898dC31b670D067162200C5c20A1` and on local chain with ID `31337`, you can use the `GetState` RPC endpoint:
 
 ```bash
-grpcurl -plaintext -d '{"chainTables": [], "worldTables": [], "namespace": {"chainId":"31337", "worldAddress": "0xff738496c8cd898dC31b670D067162200C5c20A1"}}' localhost:50091 mode.QueryLayer/GetState
+grpcurl -plaintext -d '{"chainTables": [], "worldTables": [], "namespace": {"chainId":"31337", "worldAddress": "0xff738496c8cd898dC31b670D067162200C5c20A1"}}' 127.0.0.1:50091 mode.QueryLayer/GetState
 ```
 
 After the initial setup, to quickly re-build and run the MODE service, you can use

--- a/packages/services/README.v1.md
+++ b/packages/services/README.v1.md
@@ -6,7 +6,7 @@ Every service is a Go stand-alone binary that can be run individually. Entry-poi
 
 Each service exposes a gRPC server and a wrapper HTPP server (for ability to make gRPC wrapped requests from a web client, e.g. TypeScript MUD client). By default the gRPC server runs at the default `PORT` (specified above and in each `main.go` file) and the HTTP server runs at that `PORT + 1`. For example, the snapshot service has a gRPC server exposed on `50061` and a wrapper server is automatically exposed on `50062`.
 
-Each service has specific command-line arguments. Each service requires a connection to an Ethereum node (for same network where your MUD application is deployed on) via a websocket. By default, all websocket connection URL parameters use a `127.0.0.1` instance running at port `8545`, so the full URL is `ws://127.0.0.1:8545`.
+Each service has specific command-line arguments. Each service requires a connection to an Ethereum node (for same network where your MUD application is deployed on) via a websocket. By default, all websocket connection URL parameters use a local instance running at port `8545`, so the full URL is `ws://127.0.0.1:8545`.
 
 #### Dockerfile
 

--- a/packages/services/README.v1.md
+++ b/packages/services/README.v1.md
@@ -6,7 +6,7 @@ Every service is a Go stand-alone binary that can be run individually. Entry-poi
 
 Each service exposes a gRPC server and a wrapper HTPP server (for ability to make gRPC wrapped requests from a web client, e.g. TypeScript MUD client). By default the gRPC server runs at the default `PORT` (specified above and in each `main.go` file) and the HTTP server runs at that `PORT + 1`. For example, the snapshot service has a gRPC server exposed on `50061` and a wrapper server is automatically exposed on `50062`.
 
-Each service has specific command-line arguments. Each service requires a connection to an Ethereum node (for same network where your MUD application is deployed on) via a websocket. By default, all websocket connection URL parameters use a `localhost` instance running at port `8545`, so the full URL is `ws://localhost:8545`.
+Each service has specific command-line arguments. Each service requires a connection to an Ethereum node (for same network where your MUD application is deployed on) via a websocket. By default, all websocket connection URL parameters use a `127.0.0.1` instance running at port `8545`, so the full URL is `ws://127.0.0.1:8545`.
 
 #### Dockerfile
 
@@ -59,7 +59,7 @@ As mentioned earlier, there is an HTTP server that gets run along the gRPC serve
 For quick testing or experimentation with the services, we recommend using [grpcurl](https://github.com/fullstorydev/grpcurl). For example, once you build and run the snapshot service locally you can test the endpoint which returns the latest known and computed state to the service like this
 
 ```
-grpcurl -plaintext -d '{"worldAddress": "<WORLD_ADDRESS>"}' localhost:50061 ecssnapshot.ECSStateSnapshotService/GetStateLatest
+grpcurl -plaintext -d '{"worldAddress": "<WORLD_ADDRESS>"}' 127.0.0.1:50061 ecssnapshot.ECSStateSnapshotService/GetStateLatest
 ```
 
 Note that the port is the gRPC server port and not the HTTP server port, since we are sending a raw gRPC request directly.

--- a/packages/services/cmd/ecs-relay/main.go
+++ b/packages/services/cmd/ecs-relay/main.go
@@ -50,7 +50,7 @@ import (
 )
 
 var (
-	wsUrl                  = flag.String("ws-url", "ws://localhost:8545", "Websocket Url")
+	wsUrl                  = flag.String("ws-url", "ws://127.0.0.1:8545", "Websocket Url")
 	port                   = flag.Int("port", 50071, "gRPC Server Port")
 	idleTimeoutTime        = flag.Int("idle-timeout-time", 30, "Time in seconds after which a client connection times out. Defaults to 30s")
 	idleDisconnectInterval = flag.Int("idle-disconnect-interval", 60, "Time in seconds for how often to disconnect idle clients. Defaults to 60s")

--- a/packages/services/cmd/ecs-snapshot/main.go
+++ b/packages/services/cmd/ecs-snapshot/main.go
@@ -55,7 +55,7 @@ import (
 )
 
 var (
-	wsUrl                            = flag.String("ws-url", "ws://localhost:8545", "Websocket Url")
+	wsUrl                            = flag.String("ws-url", "ws://127.0.0.1:8545", "Websocket Url")
 	port                             = flag.Int("port", 50061, "gRPC Server Port")
 	worldAddresses                   = flag.String("worldAddresses", "", "List of world addresses to index ECS state for. Defaults to empty string which will listen for all world events from all addresses")
 	block                            = flag.Int64("block", 0, "Block to start taking snapshots from. Defaults to 0")

--- a/packages/services/cmd/ecs-stream/main.go
+++ b/packages/services/cmd/ecs-stream/main.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	wsUrl       = flag.String("ws-url", "ws://localhost:8545", "Websocket Url")
+	wsUrl       = flag.String("ws-url", "ws://127.0.0.1:8545", "Websocket Url")
 	port        = flag.Int("port", 50051, "gRPC Server Port")
 	metricsPort = flag.Int("metrics-port", 6060, "Prometheus metrics http handler port. Defaults to port 6060")
 )

--- a/packages/services/cmd/faucet/main.go
+++ b/packages/services/cmd/faucet/main.go
@@ -55,7 +55,7 @@ import (
 
 var (
 	// General flags.
-	wsUrl = flag.String("ws-url", "ws://localhost:8545", "Websocket Url")
+	wsUrl = flag.String("ws-url", "ws://127.0.0.1:8545", "Websocket Url")
 	port  = flag.Int("port", 50081, "gRPC Server Port")
 	// Dev mode.
 	devMode = flag.Bool("dev", false, "Flag to run the faucet in dev mode, where verification is not required. Default to false")

--- a/packages/services/config.mode.yaml
+++ b/packages/services/config.mode.yaml
@@ -3,8 +3,8 @@ chains:
   - name: "localhost"
     id: "31337"
     rpc:
-      http: "http://localhost:8545"
-      ws: "ws://localhost:8545"
+      http: "http://127.0.0.1:8545"
+      ws: "ws://127.0.0.1:8545"
 db:
   name: "mode_ephemeral"
   host: "localhost"

--- a/templates/phaser/packages/client/package.json
+++ b/templates/phaser/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview",
     "test": "tsc --noEmit"
   },

--- a/templates/react/packages/client/package.json
+++ b/templates/react/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview",
     "test": "tsc --noEmit"
   },

--- a/templates/threejs/packages/client/package.json
+++ b/templates/threejs/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview",
     "test": "tsc --noEmit"
   },

--- a/templates/vanilla/packages/client/package.json
+++ b/templates/vanilla/packages/client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "wait-port localhost:8545 && vite",
+    "dev": "wait-port 127.0.0.1:8545 && vite",
     "preview": "vite preview",
     "test": "tsc --noEmit"
   },


### PR DESCRIPTION
We found `localhost` causing trouble in certain cases (e.g. using IPv6) where a service would listen on `127.0.0.1` but `localhost` resolves to something else.