### PR TITLE
feat(common): remove need for tx queue in `createContract`

### DIFF
--- a/.changeset/fluffy-moles-march.md
+++ b/.changeset/fluffy-moles-march.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+- Remove need for tx queue in `createContract`

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -62,7 +62,6 @@
     "chalk": "^5.2.0",
     "debug": "^4.3.4",
     "execa": "^7.0.0",
-    "p-queue": "^7.3.4",
     "p-retry": "^5.1.2",
     "prettier": "^2.8.4",
     "prettier-plugin-solidity": "^1.1.2",

--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -5,7 +5,6 @@ import {
   Chain,
   GetContractParameters,
   GetContractReturnType,
-  Hex,
   PublicClient,
   SimulateContractParameters,
   Transport,
@@ -13,7 +12,6 @@ import {
   WriteContractParameters,
   getContract,
 } from "viem";
-import pQueue from "p-queue";
 import pRetry from "p-retry";
 import { createNonceManager } from "./createNonceManager";
 import { debug as parentDebug } from "./debug";
@@ -62,11 +60,6 @@ export function createContract<
       address: walletClient.account.address,
     });
 
-    // Concurrency of one means transactions will be queued and inserted into the mem pool synchronously and in order.
-    // Although increasing this will allow for more parallel requests/transactions and nonce errors will get automatically retried,
-    // we can't guarantee local nonce accurancy due to needing async operations (simulate) before incrementing the nonce.
-    const queue = new pQueue({ concurrency: 1 });
-
     // Replace write calls with our own proxy. Implemented ~the same as viem, but adds better handling of nonces (via queue + retries).
     contract.write = new Proxy(
       {},
@@ -80,34 +73,31 @@ export function createContract<
               }
             >getFunctionParameters(parameters as any);
 
-            async function write(): Promise<Hex> {
-              if (!nonceManager.hasNonce()) {
-                await nonceManager.resetNonce();
-              }
+            // Temporarily override base fee for our default anvil config
+            // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
+            // TODO: more specific mud foundry check? or can we safely assume anvil+mud will be block fee zero for now?
+            if (
+              walletClient.chain.id === 31337 &&
+              options.maxFeePerGas == null &&
+              options.maxPriorityFeePerGas == null
+            ) {
+              debug("assuming zero base fee for anvil chain");
+              options.maxFeePerGas = 0n;
+              options.maxPriorityFeePerGas = 0n;
+            }
 
-              // Temporarily override base fee for our default anvil config
-              // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
-              // TODO: more specific mud foundry check? or can we safely assume anvil+mud will be block fee zero for now?
-              if (
-                walletClient.chain.id === 31337 &&
-                options.maxFeePerGas == null &&
-                options.maxPriorityFeePerGas == null
-              ) {
-                options.maxFeePerGas = 0n;
-                options.maxPriorityFeePerGas = 0n;
-              }
-
+            async function prepareWrite(): Promise<
+              WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>
+            > {
               if (options.gas) {
-                const nonce = nonceManager.nextNonce();
-                debug("gas provided, skipping simulate and calling write function with nonce", nonce, options);
-                return await walletClient.writeContract({
+                debug("gas provided, skipping simulate", functionName, args, options);
+                return {
                   address,
                   abi,
                   functionName,
                   args,
-                  nonce,
                   ...options,
-                } as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>);
+                } as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>;
               }
 
               debug("simulating write", functionName, args, options);
@@ -120,29 +110,37 @@ export function createContract<
                 account: options.account ?? walletClient.account,
               } as unknown as SimulateContractParameters<TAbi, typeof functionName, TChain>);
 
-              const nonce = nonceManager.nextNonce();
-              debug("calling write function with nonce", nonce, request);
-              return await walletClient.writeContract({
-                nonce,
-                ...request,
-              } as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>);
+              return request as unknown as WriteContractParameters<TAbi, typeof functionName, TChain, TAccount>;
             }
 
-            return await queue.add(
-              () =>
-                pRetry(write, {
-                  retries: 3,
-                  onFailedAttempt: async (error) => {
-                    // On nonce errors, reset the nonce and retry
-                    if (nonceManager.shouldResetNonce(error)) {
-                      debug("got nonce error, retrying", error);
-                      await nonceManager.resetNonce();
-                      return;
-                    }
-                    throw error;
-                  },
-                }),
-              { throwOnTimeout: true }
+            const preparedWrite = await prepareWrite();
+
+            return await pRetry(
+              async () => {
+                if (!nonceManager.hasNonce()) {
+                  await nonceManager.resetNonce();
+                }
+
+                const nonce = nonceManager.nextNonce();
+                debug("calling write function with nonce", nonce, preparedWrite);
+                return await walletClient.writeContract({
+                  nonce,
+                  ...preparedWrite,
+                });
+              },
+              {
+                retries: 3,
+                onFailedAttempt: async (error) => {
+                  // On nonce errors, reset the nonce and retry
+                  if (nonceManager.shouldResetNonce(error)) {
+                    debug("got nonce error, retrying", error);
+                    await nonceManager.resetNonce();
+                    return;
+                  }
+                  // TODO: prepareWrite again if there are gas errors?
+                  throw error;
+                },
+              }
             );
           };
         },

--- a/packages/common/src/createContract.ts
+++ b/packages/common/src/createContract.ts
@@ -74,7 +74,7 @@ export function createContract<
             >getFunctionParameters(parameters as any);
 
             // Temporarily override base fee for our default anvil config
-            // TODO: remove once https://github.com/wagmi-dev/viem/pull/963 is fixed
+            // TODO: replace with https://github.com/wagmi-dev/viem/pull/1006 once merged
             // TODO: more specific mud foundry check? or can we safely assume anvil+mud will be block fee zero for now?
             if (
               walletClient.chain.id === 31337 &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,6 @@ importers:
       execa:
         specifier: ^7.0.0
         version: 7.0.0
-      p-queue:
-        specifier: ^7.3.4
-        version: 7.3.4
       p-retry:
         specifier: ^5.1.2
         version: 5.1.2
@@ -8976,25 +8973,12 @@ packages:
       aggregate-error: 3.1.0
     dev: true
 
-  /p-queue@7.3.4:
-    resolution: {integrity: sha512-esox8CWt0j9EZECFvkFl2WNPat8LN4t7WWeXq73D9ha0V96qPRufApZi4ZhPwXAln1uVVal429HVVKPa2X0yQg==}
-    engines: {node: '>=12'}
-    dependencies:
-      eventemitter3: 4.0.7
-      p-timeout: 5.1.0
-    dev: false
-
   /p-retry@5.1.2:
     resolution: {integrity: sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       '@types/retry': 0.12.1
       retry: 0.13.1
-    dev: false
-
-  /p-timeout@5.1.0:
-    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
-    engines: {node: '>=12'}
     dev: false
 
   /p-try@1.0.0:


### PR DESCRIPTION
closes #1263

I initially thought we needed a queue to handle nonces. But once I separated the transaction simulation (to determine gas) from the nonce handling (incrementing before writing to the mem pool), I discovered we don't even need the queue anymore.

I tried this locally against our testnet and couldn't get nonce issues to appear.

We could improve this further by handling [other mem pool cases](https://github.com/ethereum/go-ethereum/blob/e13fa32cea3497aa311226c62daf21c5847c8e4f/core/txpool/validation.go) and re-simulating as needed (would be nice for failures due to gas price increases).