### PR TITLE
refactor(common,store): optimize _keyTuple allocation

### DIFF
--- a/e2e/packages/contracts/src/codegen/tables/Multi.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Multi.sol
@@ -82,15 +82,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -103,15 +125,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -124,15 +168,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((num)));
   }
@@ -144,15 +210,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((num)));
   }
@@ -164,15 +252,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -185,15 +295,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -206,15 +338,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((value)));
   }
@@ -226,15 +380,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((value)));
   }
@@ -246,15 +422,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -267,15 +465,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -290,15 +510,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -312,15 +554,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -354,15 +618,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     return _keyTuple;
   }
@@ -374,15 +660,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -394,15 +702,37 @@ library Multi {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 160
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 160))
       // Store length
       mstore(_keyTuple, 4)
     }
-    _keyTuple[0] = bytes32(uint256(a));
-    _keyTuple[1] = _boolToBytes32(b);
-    _keyTuple[2] = bytes32(uint256(c));
-    _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(a));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = _boolToBytes32(b);
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(c));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(int256(d)));
+    assembly {
+      mstore(add(_keyTuple, 128), _keyTupleItem)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/e2e/packages/contracts/src/codegen/tables/Multi.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Multi.sol
@@ -77,7 +77,16 @@ library Multi {
 
   /** Get num */
   function getNum(uint32 a, bool b, uint256 c, int120 d) internal view returns (int256 num) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -89,7 +98,16 @@ library Multi {
 
   /** Get num (using the specified store) */
   function getNum(IStore _store, uint32 a, bool b, uint256 c, int120 d) internal view returns (int256 num) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -101,7 +119,16 @@ library Multi {
 
   /** Set num */
   function setNum(uint32 a, bool b, uint256 c, int120 d, int256 num) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -112,7 +139,16 @@ library Multi {
 
   /** Set num (using the specified store) */
   function setNum(IStore _store, uint32 a, bool b, uint256 c, int120 d, int256 num) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -123,7 +159,16 @@ library Multi {
 
   /** Get value */
   function getValue(uint32 a, bool b, uint256 c, int120 d) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -135,7 +180,16 @@ library Multi {
 
   /** Get value (using the specified store) */
   function getValue(IStore _store, uint32 a, bool b, uint256 c, int120 d) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -147,7 +201,16 @@ library Multi {
 
   /** Set value */
   function setValue(uint32 a, bool b, uint256 c, int120 d, bool value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -158,7 +221,16 @@ library Multi {
 
   /** Set value (using the specified store) */
   function setValue(IStore _store, uint32 a, bool b, uint256 c, int120 d, bool value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -169,7 +241,16 @@ library Multi {
 
   /** Get the full data */
   function get(uint32 a, bool b, uint256 c, int120 d) internal view returns (MultiData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -181,7 +262,16 @@ library Multi {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, uint32 a, bool b, uint256 c, int120 d) internal view returns (MultiData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -195,7 +285,16 @@ library Multi {
   function set(uint32 a, bool b, uint256 c, int120 d, int256 num, bool value) internal {
     bytes memory _data = encode(num, value);
 
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -208,7 +307,16 @@ library Multi {
   function set(IStore _store, uint32 a, bool b, uint256 c, int120 d, int256 num, bool value) internal {
     bytes memory _data = encode(num, value);
 
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -240,17 +348,37 @@ library Multi {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 a, bool b, uint256 c, int120 d) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](4);
+  function encodeKeyTuple(uint32 a, bool b, uint256 c, int120 d) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
     _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(uint32 a, bool b, uint256 c, int120 d) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
@@ -261,7 +389,16 @@ library Multi {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, uint32 a, bool b, uint256 c, int120 d) internal {
-    bytes32[] memory _keyTuple = new bytes32[](4);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 160
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 4)
+    }
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));

--- a/e2e/packages/contracts/src/codegen/tables/Number.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Number.sol
@@ -72,12 +72,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -90,12 +97,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -108,12 +122,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -125,12 +146,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -147,12 +175,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     return _keyTuple;
   }
@@ -164,12 +199,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -181,12 +223,19 @@ library Number {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/e2e/packages/contracts/src/codegen/tables/Number.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Number.sol
@@ -67,7 +67,16 @@ library Number {
 
   /** Get value */
   function get(uint32 key) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library Number {
 
   /** Get value (using the specified store) */
   function get(IStore _store, uint32 key) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library Number {
 
   /** Set value */
   function set(uint32 key, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
@@ -93,7 +120,16 @@ library Number {
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32 key, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
@@ -105,14 +141,34 @@ library Number {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(uint32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -120,7 +176,16 @@ library Number {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, uint32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/e2e/packages/contracts/src/codegen/tables/NumberList.sol
+++ b/e2e/packages/contracts/src/codegen/tables/NumberList.sol
@@ -71,8 +71,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -88,8 +87,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -105,8 +103,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -121,8 +118,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -137,8 +133,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -154,8 +149,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -171,8 +165,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -188,8 +181,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -205,8 +197,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -221,8 +212,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -237,8 +227,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -253,8 +242,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -269,8 +257,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -285,8 +272,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -310,8 +296,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -326,8 +311,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -342,8 +326,7 @@ library NumberList {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }

--- a/e2e/packages/contracts/src/codegen/tables/NumberList.sol
+++ b/e2e/packages/contracts/src/codegen/tables/NumberList.sol
@@ -66,7 +66,16 @@ library NumberList {
 
   /** Get value */
   function get() internal view returns (uint32[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -74,7 +83,16 @@ library NumberList {
 
   /** Get value (using the specified store) */
   function get(IStore _store) internal view returns (uint32[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -82,21 +100,48 @@ library NumberList {
 
   /** Set value */
   function set(uint32[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
 
   /** Get the length of value */
   function length() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 4;
@@ -104,7 +149,16 @@ library NumberList {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 4;
@@ -112,7 +166,16 @@ library NumberList {
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -120,7 +183,16 @@ library NumberList {
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -128,42 +200,96 @@ library NumberList {
 
   /** Push an element to value */
   function push(uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
 
   /** Pop an element from value */
   function pop() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 4);
   }
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 4);
   }
 
   /** Update an element of value at `_index` */
   function update(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 4, abi.encodePacked((_element)));
   }
@@ -178,20 +304,49 @@ library NumberList {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/e2e/packages/contracts/src/codegen/tables/Vector.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Vector.sol
@@ -74,7 +74,16 @@ library Vector {
 
   /** Get x */
   function getX(uint32 key) internal view returns (int32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -83,7 +92,16 @@ library Vector {
 
   /** Get x (using the specified store) */
   function getX(IStore _store, uint32 key) internal view returns (int32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -92,7 +110,16 @@ library Vector {
 
   /** Set x */
   function setX(uint32 key, int32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -100,7 +127,16 @@ library Vector {
 
   /** Set x (using the specified store) */
   function setX(IStore _store, uint32 key, int32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -108,7 +144,16 @@ library Vector {
 
   /** Get y */
   function getY(uint32 key) internal view returns (int32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -117,7 +162,16 @@ library Vector {
 
   /** Get y (using the specified store) */
   function getY(IStore _store, uint32 key) internal view returns (int32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -126,7 +180,16 @@ library Vector {
 
   /** Set y */
   function setY(uint32 key, int32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -134,7 +197,16 @@ library Vector {
 
   /** Set y (using the specified store) */
   function setY(IStore _store, uint32 key, int32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -142,7 +214,16 @@ library Vector {
 
   /** Get the full data */
   function get(uint32 key) internal view returns (VectorData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -151,7 +232,16 @@ library Vector {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, uint32 key) internal view returns (VectorData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -162,7 +252,16 @@ library Vector {
   function set(uint32 key, int32 x, int32 y) internal {
     bytes memory _data = encode(x, y);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -172,7 +271,16 @@ library Vector {
   function set(IStore _store, uint32 key, int32 x, int32 y) internal {
     bytes memory _data = encode(x, y);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -201,14 +309,34 @@ library Vector {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(uint32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -216,7 +344,16 @@ library Vector {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, uint32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(key));
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/e2e/packages/contracts/src/codegen/tables/Vector.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Vector.sol
@@ -79,12 +79,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -97,12 +104,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -115,12 +129,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -132,12 +153,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -149,12 +177,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -167,12 +202,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -185,12 +227,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -202,12 +251,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -219,12 +275,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -237,12 +300,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -257,12 +327,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -276,12 +353,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -315,12 +399,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     return _keyTuple;
   }
@@ -332,12 +423,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -349,12 +447,19 @@ library Vector {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(key));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(key));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -71,8 +71,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -88,8 +87,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -105,8 +103,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -121,8 +118,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -142,8 +138,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -158,8 +153,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -174,8 +168,7 @@ library CounterTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }

--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -66,7 +66,16 @@ library CounterTable {
 
   /** Get value */
   function get() internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -74,7 +83,16 @@ library CounterTable {
 
   /** Get value (using the specified store) */
   function get(IStore _store) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -82,14 +100,32 @@ library CounterTable {
 
   /** Set value */
   function set(uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -100,20 +136,49 @@ library CounterTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
@@ -74,14 +74,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -94,14 +111,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -114,14 +148,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((amount)));
   }
@@ -133,14 +184,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((amount)));
   }
@@ -157,14 +225,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     return _keyTuple;
   }
@@ -176,14 +261,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -195,14 +297,31 @@ library Inventory {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 128
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 128))
       // Store length
       mstore(_keyTuple, 3)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(owner)));
-    _keyTuple[1] = bytes32(uint256(item));
-    _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(uint160(owner)));
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(item));
+    assembly {
+      mstore(add(_keyTuple, 64), _keyTupleItem)
+    }
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = bytes32(uint256(itemVariant));
+    assembly {
+      mstore(add(_keyTuple, 96), _keyTupleItem)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
@@ -69,7 +69,16 @@ library Inventory {
 
   /** Get amount */
   function get(address owner, uint32 item, uint32 itemVariant) internal view returns (uint32 amount) {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
@@ -80,7 +89,16 @@ library Inventory {
 
   /** Get amount (using the specified store) */
   function get(IStore _store, address owner, uint32 item, uint32 itemVariant) internal view returns (uint32 amount) {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
@@ -91,7 +109,16 @@ library Inventory {
 
   /** Set amount */
   function set(address owner, uint32 item, uint32 itemVariant, uint32 amount) internal {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
@@ -101,7 +128,16 @@ library Inventory {
 
   /** Set amount (using the specified store) */
   function set(IStore _store, address owner, uint32 item, uint32 itemVariant, uint32 amount) internal {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
@@ -115,20 +151,36 @@ library Inventory {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(
-    address owner,
-    uint32 item,
-    uint32 itemVariant
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](3);
+  function encodeKeyTuple(address owner, uint32 item, uint32 itemVariant) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(address owner, uint32 item, uint32 itemVariant) internal {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
@@ -138,7 +190,16 @@ library Inventory {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, address owner, uint32 item, uint32 itemVariant) internal {
-    bytes32[] memory _keyTuple = new bytes32[](3);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 128
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 3)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));

--- a/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
@@ -73,8 +73,7 @@ library MessageTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -91,8 +90,7 @@ library MessageTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -116,8 +114,7 @@ library MessageTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }

--- a/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
@@ -68,7 +68,16 @@ library MessageTable {
   function emitEphemeral(string memory value) internal {
     bytes memory _data = encode(value);
 
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -77,7 +86,16 @@ library MessageTable {
   function emitEphemeral(IStore _store, string memory value) internal {
     bytes memory _data = encode(value);
 
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -92,7 +110,18 @@ library MessageTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -88,12 +88,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -106,12 +112,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -124,12 +136,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
@@ -141,12 +159,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
@@ -158,12 +182,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -176,12 +206,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -194,12 +230,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -212,12 +254,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -230,12 +278,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -247,12 +301,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -264,12 +324,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -281,12 +347,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -298,12 +370,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -315,12 +393,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -332,12 +416,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
@@ -350,12 +440,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
@@ -368,12 +464,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
@@ -385,12 +487,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
@@ -402,12 +510,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -420,12 +534,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -438,12 +558,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -456,12 +582,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -474,12 +606,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -491,12 +629,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -508,12 +652,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -525,12 +675,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -542,12 +698,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -559,12 +721,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -576,12 +744,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
@@ -594,12 +768,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
@@ -612,12 +792,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
@@ -629,12 +815,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
@@ -646,12 +838,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 16;
@@ -664,12 +862,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 16;
@@ -682,12 +886,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -700,12 +910,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -718,12 +934,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -735,12 +957,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -752,12 +980,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 16);
   }
@@ -769,12 +1003,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 2, 16);
   }
@@ -786,12 +1026,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
   }
@@ -803,12 +1049,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
   }
@@ -820,12 +1072,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -838,12 +1096,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -856,12 +1120,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
@@ -873,12 +1143,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
@@ -890,12 +1166,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 20;
@@ -908,12 +1190,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 20;
@@ -926,12 +1214,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -944,12 +1238,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -962,12 +1262,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -979,12 +1285,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -996,12 +1308,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 20);
   }
@@ -1013,12 +1331,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 3, 20);
   }
@@ -1030,12 +1354,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
   }
@@ -1047,12 +1377,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
   }
@@ -1064,12 +1400,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
@@ -1082,12 +1424,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
@@ -1100,12 +1448,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
@@ -1117,12 +1471,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
@@ -1134,12 +1494,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 1;
@@ -1152,12 +1518,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 1;
@@ -1170,12 +1542,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -1188,12 +1566,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -1206,12 +1590,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -1223,12 +1613,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -1240,12 +1636,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1);
   }
@@ -1257,12 +1659,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 4, 1);
   }
@@ -1274,12 +1682,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
   }
@@ -1291,12 +1705,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
   }
@@ -1308,12 +1728,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -1326,12 +1752,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -1353,12 +1785,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1380,12 +1818,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1467,12 +1911,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -1484,12 +1934,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -1501,12 +1957,18 @@ library Dynamics1 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -83,7 +83,16 @@ library Dynamics1 {
 
   /** Get staticB32 */
   function getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -92,7 +101,16 @@ library Dynamics1 {
 
   /** Get staticB32 (using the specified store) */
   function getStaticB32(IStore _store, bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -101,7 +119,16 @@ library Dynamics1 {
 
   /** Set staticB32 */
   function setStaticB32(bytes32 key, bytes32[1] memory staticB32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
@@ -109,7 +136,16 @@ library Dynamics1 {
 
   /** Set staticB32 (using the specified store) */
   function setStaticB32(IStore _store, bytes32 key, bytes32[1] memory staticB32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
@@ -117,7 +153,16 @@ library Dynamics1 {
 
   /** Get the length of staticB32 */
   function lengthStaticB32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -126,7 +171,16 @@ library Dynamics1 {
 
   /** Get the length of staticB32 (using the specified store) */
   function lengthStaticB32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -135,7 +189,16 @@ library Dynamics1 {
 
   /** Get an item of staticB32 (unchecked, returns invalid data if index overflows) */
   function getItemStaticB32(bytes32 key, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -144,7 +207,16 @@ library Dynamics1 {
 
   /** Get an item of staticB32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticB32(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -153,7 +225,16 @@ library Dynamics1 {
 
   /** Push an element to staticB32 */
   function pushStaticB32(bytes32 key, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -161,7 +242,16 @@ library Dynamics1 {
 
   /** Push an element to staticB32 (using the specified store) */
   function pushStaticB32(IStore _store, bytes32 key, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -169,7 +259,16 @@ library Dynamics1 {
 
   /** Pop an element from staticB32 */
   function popStaticB32(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -177,7 +276,16 @@ library Dynamics1 {
 
   /** Pop an element from staticB32 (using the specified store) */
   function popStaticB32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -185,7 +293,16 @@ library Dynamics1 {
 
   /** Update an element of staticB32 at `_index` */
   function updateStaticB32(bytes32 key, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -193,7 +310,16 @@ library Dynamics1 {
 
   /** Update an element of staticB32 (using the specified store) at `_index` */
   function updateStaticB32(IStore _store, bytes32 key, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -201,7 +327,16 @@ library Dynamics1 {
 
   /** Get staticI32 */
   function getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -210,7 +345,16 @@ library Dynamics1 {
 
   /** Get staticI32 (using the specified store) */
   function getStaticI32(IStore _store, bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -219,7 +363,16 @@ library Dynamics1 {
 
   /** Set staticI32 */
   function setStaticI32(bytes32 key, int32[2] memory staticI32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
@@ -227,7 +380,16 @@ library Dynamics1 {
 
   /** Set staticI32 (using the specified store) */
   function setStaticI32(IStore _store, bytes32 key, int32[2] memory staticI32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
@@ -235,7 +397,16 @@ library Dynamics1 {
 
   /** Get the length of staticI32 */
   function lengthStaticI32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -244,7 +415,16 @@ library Dynamics1 {
 
   /** Get the length of staticI32 (using the specified store) */
   function lengthStaticI32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -253,7 +433,16 @@ library Dynamics1 {
 
   /** Get an item of staticI32 (unchecked, returns invalid data if index overflows) */
   function getItemStaticI32(bytes32 key, uint256 _index) internal view returns (int32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
@@ -262,7 +451,16 @@ library Dynamics1 {
 
   /** Get an item of staticI32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticI32(IStore _store, bytes32 key, uint256 _index) internal view returns (int32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
@@ -271,7 +469,16 @@ library Dynamics1 {
 
   /** Push an element to staticI32 */
   function pushStaticI32(bytes32 key, int32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -279,7 +486,16 @@ library Dynamics1 {
 
   /** Push an element to staticI32 (using the specified store) */
   function pushStaticI32(IStore _store, bytes32 key, int32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -287,7 +503,16 @@ library Dynamics1 {
 
   /** Pop an element from staticI32 */
   function popStaticI32(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
@@ -295,7 +520,16 @@ library Dynamics1 {
 
   /** Pop an element from staticI32 (using the specified store) */
   function popStaticI32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
@@ -303,7 +537,16 @@ library Dynamics1 {
 
   /** Update an element of staticI32 at `_index` */
   function updateStaticI32(bytes32 key, uint256 _index, int32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
@@ -311,7 +554,16 @@ library Dynamics1 {
 
   /** Update an element of staticI32 (using the specified store) at `_index` */
   function updateStaticI32(IStore _store, bytes32 key, uint256 _index, int32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
@@ -319,7 +571,16 @@ library Dynamics1 {
 
   /** Get staticU128 */
   function getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -328,7 +589,16 @@ library Dynamics1 {
 
   /** Get staticU128 (using the specified store) */
   function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -337,7 +607,16 @@ library Dynamics1 {
 
   /** Set staticU128 */
   function setStaticU128(bytes32 key, uint128[3] memory staticU128) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
@@ -345,7 +624,16 @@ library Dynamics1 {
 
   /** Set staticU128 (using the specified store) */
   function setStaticU128(IStore _store, bytes32 key, uint128[3] memory staticU128) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
@@ -353,7 +641,16 @@ library Dynamics1 {
 
   /** Get the length of staticU128 */
   function lengthStaticU128(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -362,7 +659,16 @@ library Dynamics1 {
 
   /** Get the length of staticU128 (using the specified store) */
   function lengthStaticU128(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -371,7 +677,16 @@ library Dynamics1 {
 
   /** Get an item of staticU128 (unchecked, returns invalid data if index overflows) */
   function getItemStaticU128(bytes32 key, uint256 _index) internal view returns (uint128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
@@ -380,7 +695,16 @@ library Dynamics1 {
 
   /** Get an item of staticU128 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticU128(IStore _store, bytes32 key, uint256 _index) internal view returns (uint128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
@@ -389,7 +713,16 @@ library Dynamics1 {
 
   /** Push an element to staticU128 */
   function pushStaticU128(bytes32 key, uint128 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -397,7 +730,16 @@ library Dynamics1 {
 
   /** Push an element to staticU128 (using the specified store) */
   function pushStaticU128(IStore _store, bytes32 key, uint128 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -405,7 +747,16 @@ library Dynamics1 {
 
   /** Pop an element from staticU128 */
   function popStaticU128(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 16);
@@ -413,7 +764,16 @@ library Dynamics1 {
 
   /** Pop an element from staticU128 (using the specified store) */
   function popStaticU128(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 16);
@@ -421,7 +781,16 @@ library Dynamics1 {
 
   /** Update an element of staticU128 at `_index` */
   function updateStaticU128(bytes32 key, uint256 _index, uint128 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
@@ -429,7 +798,16 @@ library Dynamics1 {
 
   /** Update an element of staticU128 (using the specified store) at `_index` */
   function updateStaticU128(IStore _store, bytes32 key, uint256 _index, uint128 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
@@ -437,7 +815,16 @@ library Dynamics1 {
 
   /** Get staticAddrs */
   function getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -446,7 +833,16 @@ library Dynamics1 {
 
   /** Get staticAddrs (using the specified store) */
   function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -455,7 +851,16 @@ library Dynamics1 {
 
   /** Set staticAddrs */
   function setStaticAddrs(bytes32 key, address[4] memory staticAddrs) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
@@ -463,7 +868,16 @@ library Dynamics1 {
 
   /** Set staticAddrs (using the specified store) */
   function setStaticAddrs(IStore _store, bytes32 key, address[4] memory staticAddrs) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
@@ -471,7 +885,16 @@ library Dynamics1 {
 
   /** Get the length of staticAddrs */
   function lengthStaticAddrs(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -480,7 +903,16 @@ library Dynamics1 {
 
   /** Get the length of staticAddrs (using the specified store) */
   function lengthStaticAddrs(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -489,7 +921,16 @@ library Dynamics1 {
 
   /** Get an item of staticAddrs (unchecked, returns invalid data if index overflows) */
   function getItemStaticAddrs(bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
@@ -498,7 +939,16 @@ library Dynamics1 {
 
   /** Get an item of staticAddrs (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticAddrs(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
@@ -507,7 +957,16 @@ library Dynamics1 {
 
   /** Push an element to staticAddrs */
   function pushStaticAddrs(bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -515,7 +974,16 @@ library Dynamics1 {
 
   /** Push an element to staticAddrs (using the specified store) */
   function pushStaticAddrs(IStore _store, bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -523,7 +991,16 @@ library Dynamics1 {
 
   /** Pop an element from staticAddrs */
   function popStaticAddrs(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 20);
@@ -531,7 +1008,16 @@ library Dynamics1 {
 
   /** Pop an element from staticAddrs (using the specified store) */
   function popStaticAddrs(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 20);
@@ -539,7 +1025,16 @@ library Dynamics1 {
 
   /** Update an element of staticAddrs at `_index` */
   function updateStaticAddrs(bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
@@ -547,7 +1042,16 @@ library Dynamics1 {
 
   /** Update an element of staticAddrs (using the specified store) at `_index` */
   function updateStaticAddrs(IStore _store, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
@@ -555,7 +1059,16 @@ library Dynamics1 {
 
   /** Get staticBools */
   function getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
@@ -564,7 +1077,16 @@ library Dynamics1 {
 
   /** Get staticBools (using the specified store) */
   function getStaticBools(IStore _store, bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
@@ -573,7 +1095,16 @@ library Dynamics1 {
 
   /** Set staticBools */
   function setStaticBools(bytes32 key, bool[5] memory staticBools) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
@@ -581,7 +1112,16 @@ library Dynamics1 {
 
   /** Set staticBools (using the specified store) */
   function setStaticBools(IStore _store, bytes32 key, bool[5] memory staticBools) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
@@ -589,7 +1129,16 @@ library Dynamics1 {
 
   /** Get the length of staticBools */
   function lengthStaticBools(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -598,7 +1147,16 @@ library Dynamics1 {
 
   /** Get the length of staticBools (using the specified store) */
   function lengthStaticBools(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -607,7 +1165,16 @@ library Dynamics1 {
 
   /** Get an item of staticBools (unchecked, returns invalid data if index overflows) */
   function getItemStaticBools(bytes32 key, uint256 _index) internal view returns (bool) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
@@ -616,7 +1183,16 @@ library Dynamics1 {
 
   /** Get an item of staticBools (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStaticBools(IStore _store, bytes32 key, uint256 _index) internal view returns (bool) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
@@ -625,7 +1201,16 @@ library Dynamics1 {
 
   /** Push an element to staticBools */
   function pushStaticBools(bytes32 key, bool _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -633,7 +1218,16 @@ library Dynamics1 {
 
   /** Push an element to staticBools (using the specified store) */
   function pushStaticBools(IStore _store, bytes32 key, bool _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -641,7 +1235,16 @@ library Dynamics1 {
 
   /** Pop an element from staticBools */
   function popStaticBools(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1);
@@ -649,7 +1252,16 @@ library Dynamics1 {
 
   /** Pop an element from staticBools (using the specified store) */
   function popStaticBools(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 4, 1);
@@ -657,7 +1269,16 @@ library Dynamics1 {
 
   /** Update an element of staticBools at `_index` */
   function updateStaticBools(bytes32 key, uint256 _index, bool _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
@@ -665,7 +1286,16 @@ library Dynamics1 {
 
   /** Update an element of staticBools (using the specified store) at `_index` */
   function updateStaticBools(IStore _store, bytes32 key, uint256 _index, bool _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
@@ -673,7 +1303,16 @@ library Dynamics1 {
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (Dynamics1Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -682,7 +1321,16 @@ library Dynamics1 {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Dynamics1Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -700,7 +1348,16 @@ library Dynamics1 {
   ) internal {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -718,7 +1375,16 @@ library Dynamics1 {
   ) internal {
     bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -795,14 +1461,34 @@ library Dynamics1 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -810,7 +1496,16 @@ library Dynamics1 {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -93,12 +93,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -117,12 +118,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -141,12 +143,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
@@ -164,12 +167,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
@@ -187,12 +191,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -211,12 +216,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -235,12 +241,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -259,12 +266,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -283,12 +291,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -306,12 +315,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -329,12 +339,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -352,12 +363,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -375,12 +387,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -398,12 +411,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -421,12 +435,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -445,12 +460,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -469,12 +485,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
@@ -492,12 +509,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
@@ -515,12 +533,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -539,12 +558,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -563,12 +583,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
@@ -587,12 +608,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
@@ -611,12 +633,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -634,12 +657,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -657,12 +681,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
@@ -680,12 +705,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
@@ -703,12 +729,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
@@ -726,12 +753,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
@@ -749,12 +777,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -773,12 +802,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -797,12 +827,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
@@ -820,12 +851,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
@@ -843,12 +875,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -867,12 +900,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -891,12 +925,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
@@ -915,12 +950,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 16, (_index + 1) * 16);
@@ -939,12 +975,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -962,12 +999,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -985,12 +1023,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 16);
@@ -1008,12 +1047,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 2, 16);
@@ -1031,12 +1071,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
@@ -1054,12 +1095,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)));
@@ -1077,12 +1119,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -1101,12 +1144,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -1125,12 +1169,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
@@ -1148,12 +1193,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
@@ -1171,12 +1217,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -1195,12 +1242,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -1219,12 +1267,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
@@ -1243,12 +1292,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 20, (_index + 1) * 20);
@@ -1267,12 +1317,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -1290,12 +1341,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -1313,12 +1365,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 20);
@@ -1336,12 +1389,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 3, 20);
@@ -1359,12 +1413,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
@@ -1382,12 +1437,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)));
@@ -1405,12 +1461,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
@@ -1429,12 +1486,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
@@ -1453,12 +1511,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
@@ -1476,12 +1535,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
@@ -1499,12 +1559,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -1523,12 +1584,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -1547,12 +1609,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
@@ -1571,12 +1634,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 1, (_index + 1) * 1);
@@ -1595,12 +1659,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -1618,12 +1683,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -1641,12 +1707,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1);
@@ -1664,12 +1731,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 4, 1);
@@ -1687,12 +1755,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
@@ -1710,12 +1779,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)));
@@ -1733,12 +1803,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -1757,12 +1828,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -1790,12 +1862,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -1823,12 +1896,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -1916,12 +1990,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -1939,12 +2014,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -1962,12 +2038,13 @@ library Dynamics1 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -82,12 +82,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
@@ -100,12 +106,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
@@ -118,12 +130,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
   }
@@ -135,12 +153,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
   }
@@ -152,12 +176,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 8;
@@ -170,12 +200,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 8;
@@ -188,12 +224,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
     return (uint64(Bytes.slice8(_blob, 0)));
@@ -206,12 +248,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
     return (uint64(Bytes.slice8(_blob, 0)));
@@ -224,12 +272,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -241,12 +295,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -258,12 +318,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 8);
   }
@@ -275,12 +341,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 8);
   }
@@ -292,12 +364,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
   }
@@ -309,12 +387,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
   }
@@ -326,12 +410,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (string(_blob));
@@ -344,12 +434,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (string(_blob));
@@ -362,12 +458,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((str)));
   }
@@ -379,12 +481,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, bytes((str)));
   }
@@ -396,12 +504,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -414,12 +528,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -432,12 +552,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -450,12 +576,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -468,12 +600,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -485,12 +623,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -502,12 +646,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -519,12 +669,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -536,12 +692,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -553,12 +715,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -570,12 +738,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (bytes(_blob));
@@ -588,12 +762,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (bytes(_blob));
@@ -606,12 +786,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, bytes((b)));
   }
@@ -623,12 +809,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, bytes((b)));
   }
@@ -640,12 +832,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 1;
@@ -658,12 +856,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 1;
@@ -676,12 +880,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -694,12 +904,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -712,12 +928,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
   }
@@ -729,12 +951,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
   }
@@ -746,12 +974,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 1);
   }
@@ -763,12 +997,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 2, 1);
   }
@@ -780,12 +1020,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
   }
@@ -797,12 +1043,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
   }
@@ -814,12 +1066,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -832,12 +1090,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -852,12 +1116,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -871,12 +1141,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -934,12 +1210,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -951,12 +1233,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -968,12 +1256,18 @@ library Dynamics2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -77,7 +77,16 @@ library Dynamics2 {
 
   /** Get u64 */
   function getU64(bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -86,7 +95,16 @@ library Dynamics2 {
 
   /** Get u64 (using the specified store) */
   function getU64(IStore _store, bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -95,7 +113,16 @@ library Dynamics2 {
 
   /** Set u64 */
   function setU64(bytes32 key, uint64[] memory u64) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
@@ -103,7 +130,16 @@ library Dynamics2 {
 
   /** Set u64 (using the specified store) */
   function setU64(IStore _store, bytes32 key, uint64[] memory u64) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
@@ -111,7 +147,16 @@ library Dynamics2 {
 
   /** Get the length of u64 */
   function lengthU64(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -120,7 +165,16 @@ library Dynamics2 {
 
   /** Get the length of u64 (using the specified store) */
   function lengthU64(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -129,7 +183,16 @@ library Dynamics2 {
 
   /** Get an item of u64 (unchecked, returns invalid data if index overflows) */
   function getItemU64(bytes32 key, uint256 _index) internal view returns (uint64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
@@ -138,7 +201,16 @@ library Dynamics2 {
 
   /** Get an item of u64 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemU64(IStore _store, bytes32 key, uint256 _index) internal view returns (uint64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
@@ -147,7 +219,16 @@ library Dynamics2 {
 
   /** Push an element to u64 */
   function pushU64(bytes32 key, uint64 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -155,7 +236,16 @@ library Dynamics2 {
 
   /** Push an element to u64 (using the specified store) */
   function pushU64(IStore _store, bytes32 key, uint64 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -163,7 +253,16 @@ library Dynamics2 {
 
   /** Pop an element from u64 */
   function popU64(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 8);
@@ -171,7 +270,16 @@ library Dynamics2 {
 
   /** Pop an element from u64 (using the specified store) */
   function popU64(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 8);
@@ -179,7 +287,16 @@ library Dynamics2 {
 
   /** Update an element of u64 at `_index` */
   function updateU64(bytes32 key, uint256 _index, uint64 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
@@ -187,7 +304,16 @@ library Dynamics2 {
 
   /** Update an element of u64 (using the specified store) at `_index` */
   function updateU64(IStore _store, bytes32 key, uint256 _index, uint64 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
@@ -195,7 +321,16 @@ library Dynamics2 {
 
   /** Get str */
   function getStr(bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -204,7 +339,16 @@ library Dynamics2 {
 
   /** Get str (using the specified store) */
   function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -213,7 +357,16 @@ library Dynamics2 {
 
   /** Set str */
   function setStr(bytes32 key, string memory str) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((str)));
@@ -221,7 +374,16 @@ library Dynamics2 {
 
   /** Set str (using the specified store) */
   function setStr(IStore _store, bytes32 key, string memory str) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, bytes((str)));
@@ -229,7 +391,16 @@ library Dynamics2 {
 
   /** Get the length of str */
   function lengthStr(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -238,7 +409,16 @@ library Dynamics2 {
 
   /** Get the length of str (using the specified store) */
   function lengthStr(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -247,7 +427,16 @@ library Dynamics2 {
 
   /** Get an item of str (unchecked, returns invalid data if index overflows) */
   function getItemStr(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -256,7 +445,16 @@ library Dynamics2 {
 
   /** Get an item of str (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemStr(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -265,7 +463,16 @@ library Dynamics2 {
 
   /** Push a slice to str */
   function pushStr(bytes32 key, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -273,7 +480,16 @@ library Dynamics2 {
 
   /** Push a slice to str (using the specified store) */
   function pushStr(IStore _store, bytes32 key, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -281,7 +497,16 @@ library Dynamics2 {
 
   /** Pop a slice from str */
   function popStr(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
@@ -289,7 +514,16 @@ library Dynamics2 {
 
   /** Pop a slice from str (using the specified store) */
   function popStr(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
@@ -297,7 +531,16 @@ library Dynamics2 {
 
   /** Update a slice of str at `_index` */
   function updateStr(bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -305,7 +548,16 @@ library Dynamics2 {
 
   /** Update a slice of str (using the specified store) at `_index` */
   function updateStr(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -313,7 +565,16 @@ library Dynamics2 {
 
   /** Get b */
   function getB(bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -322,7 +583,16 @@ library Dynamics2 {
 
   /** Get b (using the specified store) */
   function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -331,7 +601,16 @@ library Dynamics2 {
 
   /** Set b */
   function setB(bytes32 key, bytes memory b) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, bytes((b)));
@@ -339,7 +618,16 @@ library Dynamics2 {
 
   /** Set b (using the specified store) */
   function setB(IStore _store, bytes32 key, bytes memory b) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, bytes((b)));
@@ -347,7 +635,16 @@ library Dynamics2 {
 
   /** Get the length of b */
   function lengthB(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -356,7 +653,16 @@ library Dynamics2 {
 
   /** Get the length of b (using the specified store) */
   function lengthB(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -365,7 +671,16 @@ library Dynamics2 {
 
   /** Get an item of b (unchecked, returns invalid data if index overflows) */
   function getItemB(bytes32 key, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
@@ -374,7 +689,16 @@ library Dynamics2 {
 
   /** Get an item of b (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemB(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
@@ -383,7 +707,16 @@ library Dynamics2 {
 
   /** Push a slice to b */
   function pushB(bytes32 key, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
@@ -391,7 +724,16 @@ library Dynamics2 {
 
   /** Push a slice to b (using the specified store) */
   function pushB(IStore _store, bytes32 key, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
@@ -399,7 +741,16 @@ library Dynamics2 {
 
   /** Pop a slice from b */
   function popB(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 1);
@@ -407,7 +758,16 @@ library Dynamics2 {
 
   /** Pop a slice from b (using the specified store) */
   function popB(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 1);
@@ -415,7 +775,16 @@ library Dynamics2 {
 
   /** Update a slice of b at `_index` */
   function updateB(bytes32 key, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
@@ -423,7 +792,16 @@ library Dynamics2 {
 
   /** Update a slice of b (using the specified store) at `_index` */
   function updateB(IStore _store, bytes32 key, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
@@ -431,7 +809,16 @@ library Dynamics2 {
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (Dynamics2Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -440,7 +827,16 @@ library Dynamics2 {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Dynamics2Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -451,7 +847,16 @@ library Dynamics2 {
   function set(bytes32 key, uint64[] memory u64, string memory str, bytes memory b) internal {
     bytes memory _data = encode(u64, str, b);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -461,7 +866,16 @@ library Dynamics2 {
   function set(IStore _store, bytes32 key, uint64[] memory u64, string memory str, bytes memory b) internal {
     bytes memory _data = encode(u64, str, b);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -514,14 +928,34 @@ library Dynamics2 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -529,7 +963,16 @@ library Dynamics2 {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -87,12 +87,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -111,12 +112,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -135,12 +137,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
@@ -158,12 +161,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)));
@@ -181,12 +185,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -205,12 +210,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -229,12 +235,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
@@ -253,12 +260,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 8, (_index + 1) * 8);
@@ -277,12 +285,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -300,12 +309,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -323,12 +333,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 8);
@@ -346,12 +357,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 8);
@@ -369,12 +381,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
@@ -392,12 +405,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)));
@@ -415,12 +429,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -439,12 +454,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -463,12 +479,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((str)));
@@ -486,12 +503,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, bytes((str)));
@@ -509,12 +527,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -533,12 +552,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -557,12 +577,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -581,12 +602,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -605,12 +627,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -628,12 +651,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -651,12 +675,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
@@ -674,12 +699,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
@@ -697,12 +723,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -720,12 +747,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -743,12 +771,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -767,12 +796,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -791,12 +821,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, bytes((b)));
@@ -814,12 +845,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, bytes((b)));
@@ -837,12 +869,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -861,12 +894,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -885,12 +919,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
@@ -909,12 +944,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 1, (_index + 1) * 1);
@@ -933,12 +969,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
@@ -956,12 +993,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 2, bytes((_slice)));
@@ -979,12 +1017,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 1);
@@ -1002,12 +1041,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 2, 1);
@@ -1025,12 +1065,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
@@ -1048,12 +1089,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)));
@@ -1071,12 +1113,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -1095,12 +1138,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -1121,12 +1165,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -1146,12 +1191,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -1215,12 +1261,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -1238,12 +1285,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -1261,12 +1309,13 @@ library Dynamics2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -69,7 +69,16 @@ library Ephemeral {
   function emitEphemeral(bytes32 key, uint256 value) internal {
     bytes memory _data = encode(value);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data);
@@ -79,7 +88,16 @@ library Ephemeral {
   function emitEphemeral(IStore _store, bytes32 key, uint256 value) internal {
     bytes memory _data = encode(value);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.emitEphemeralRecord(_tableId, _keyTuple, _data);
@@ -91,8 +109,19 @@ library Ephemeral {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -74,12 +74,18 @@ library Ephemeral {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -93,12 +99,18 @@ library Ephemeral {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.emitEphemeralRecord(_tableId, _keyTuple, _data);
   }
@@ -115,12 +127,18 @@ library Ephemeral {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -79,12 +79,13 @@ library Ephemeral {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data);
@@ -104,12 +105,13 @@ library Ephemeral {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.emitEphemeralRecord(_tableId, _keyTuple, _data);
@@ -132,12 +134,13 @@ library Ephemeral {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -82,8 +82,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
   }
@@ -99,8 +97,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -118,8 +114,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
@@ -135,8 +129,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
@@ -151,8 +143,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -170,8 +160,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
@@ -188,8 +176,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
@@ -205,8 +191,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
@@ -221,8 +205,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -240,8 +222,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
   }
@@ -257,8 +237,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -276,8 +254,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
@@ -294,8 +270,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
 
@@ -310,8 +284,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -328,8 +300,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
   }
 
@@ -344,8 +314,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -362,8 +330,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -379,8 +345,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -395,8 +359,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -414,8 +376,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
@@ -432,8 +392,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
@@ -449,8 +407,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
@@ -465,8 +421,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -484,8 +438,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
   }
@@ -501,8 +453,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -520,8 +470,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
@@ -538,8 +486,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
 
@@ -554,8 +500,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -572,8 +516,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
   }
 
@@ -588,8 +530,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -606,8 +546,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -623,8 +561,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -639,8 +575,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -658,8 +592,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
@@ -676,8 +608,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
@@ -693,8 +623,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
@@ -709,8 +637,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
@@ -728,8 +654,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
   }
@@ -745,8 +669,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -764,8 +686,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
   }
@@ -782,8 +702,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
 
@@ -798,8 +716,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -816,8 +732,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 4);
   }
 
@@ -832,8 +746,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 4);
   }
@@ -850,8 +762,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -867,8 +777,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     _store.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
 
@@ -883,8 +791,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -904,8 +810,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
   }
@@ -924,8 +828,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
 
@@ -942,8 +844,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1012,8 +912,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     return _keyTuple;
   }
 
@@ -1029,8 +927,6 @@ library Singleton {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
@@ -1045,8 +941,6 @@ library Singleton {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -72,7 +72,16 @@ library Singleton {
 
   /** Get v1 */
   function getV1() internal view returns (int256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -80,7 +89,16 @@ library Singleton {
 
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -88,21 +106,48 @@ library Singleton {
 
   /** Set v1 */
   function setV1(int256 v1) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
   /** Set v1 (using the specified store) */
   function setV1(IStore _store, int256 v1) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
   /** Get v2 */
   function getV2() internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -110,7 +155,16 @@ library Singleton {
 
   /** Get v2 (using the specified store) */
   function getV2(IStore _store) internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -118,21 +172,48 @@ library Singleton {
 
   /** Set v2 */
   function setV2(uint32[2] memory v2) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
   /** Set v2 (using the specified store) */
   function setV2(IStore _store, uint32[2] memory v2) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
   /** Get the length of v2 */
   function lengthV2() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -140,7 +221,16 @@ library Singleton {
 
   /** Get the length of v2 (using the specified store) */
   function lengthV2(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -148,7 +238,16 @@ library Singleton {
 
   /** Get an item of v2 (unchecked, returns invalid data if index overflows) */
   function getItemV2(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -156,7 +255,16 @@ library Singleton {
 
   /** Get an item of v2 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemV2(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -164,49 +272,112 @@ library Singleton {
 
   /** Push an element to v2 */
   function pushV2(uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
 
   /** Push an element to v2 (using the specified store) */
   function pushV2(IStore _store, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v2 */
   function popV2() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
   }
 
   /** Pop an element from v2 (using the specified store) */
   function popV2(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
   }
 
   /** Update an element of v2 at `_index` */
   function updateV2(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v2 (using the specified store) at `_index` */
   function updateV2(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get v3 */
   function getV3() internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -214,7 +385,16 @@ library Singleton {
 
   /** Get v3 (using the specified store) */
   function getV3(IStore _store) internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -222,21 +402,48 @@ library Singleton {
 
   /** Set v3 */
   function setV3(uint32[2] memory v3) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
   /** Set v3 (using the specified store) */
   function setV3(IStore _store, uint32[2] memory v3) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
   /** Get the length of v3 */
   function lengthV3() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -244,7 +451,16 @@ library Singleton {
 
   /** Get the length of v3 (using the specified store) */
   function lengthV3(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -252,7 +468,16 @@ library Singleton {
 
   /** Get an item of v3 (unchecked, returns invalid data if index overflows) */
   function getItemV3(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -260,7 +485,16 @@ library Singleton {
 
   /** Get an item of v3 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemV3(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -268,49 +502,112 @@ library Singleton {
 
   /** Push an element to v3 */
   function pushV3(uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
 
   /** Push an element to v3 (using the specified store) */
   function pushV3(IStore _store, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v3 */
   function popV3() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
   }
 
   /** Pop an element from v3 (using the specified store) */
   function popV3(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
   }
 
   /** Update an element of v3 at `_index` */
   function updateV3(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v3 (using the specified store) at `_index` */
   function updateV3(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get v4 */
   function getV4() internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -318,7 +615,16 @@ library Singleton {
 
   /** Get v4 (using the specified store) */
   function getV4(IStore _store) internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -326,21 +632,48 @@ library Singleton {
 
   /** Set v4 */
   function setV4(uint32[1] memory v4) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
   /** Set v4 (using the specified store) */
   function setV4(IStore _store, uint32[1] memory v4) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
   /** Get the length of v4 */
   function lengthV4() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
@@ -348,7 +681,16 @@ library Singleton {
 
   /** Get the length of v4 (using the specified store) */
   function lengthV4(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
@@ -356,7 +698,16 @@ library Singleton {
 
   /** Get an item of v4 (unchecked, returns invalid data if index overflows) */
   function getItemV4(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -364,7 +715,16 @@ library Singleton {
 
   /** Get an item of v4 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemV4(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -372,49 +732,112 @@ library Singleton {
 
   /** Push an element to v4 */
   function pushV4(uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
 
   /** Push an element to v4 (using the specified store) */
   function pushV4(IStore _store, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
 
   /** Pop an element from v4 */
   function popV4() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 4);
   }
 
   /** Pop an element from v4 (using the specified store) */
   function popV4(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 3, 4);
   }
 
   /** Update an element of v4 at `_index` */
   function updateV4(uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Update an element of v4 (using the specified store) at `_index` */
   function updateV4(IStore _store, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
 
   /** Get the full data */
   function get() internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -424,7 +847,16 @@ library Singleton {
   function get(
     IStore _store
   ) internal view returns (int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -434,7 +866,16 @@ library Singleton {
   function set(int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) internal {
     bytes memory _data = encode(v1, v2, v3, v4);
 
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -443,7 +884,16 @@ library Singleton {
   function set(IStore _store, int256 v1, uint32[2] memory v2, uint32[2] memory v3, uint32[1] memory v4) internal {
     bytes memory _data = encode(v1, v2, v3, v4);
 
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -501,20 +951,49 @@ library Singleton {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -77,11 +77,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -94,11 +95,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int256(uint256(Bytes.slice32(_blob, 0))));
@@ -111,11 +113,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
@@ -127,11 +130,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
@@ -143,11 +147,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -160,11 +165,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -177,11 +183,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
@@ -193,11 +200,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
@@ -209,11 +217,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -226,11 +235,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 4;
@@ -243,11 +253,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -260,11 +271,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -277,11 +289,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -293,11 +306,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -309,11 +323,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -325,11 +340,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 1, 4);
   }
@@ -341,11 +357,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -357,11 +374,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)));
   }
@@ -373,11 +391,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -390,11 +409,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -407,11 +427,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
@@ -423,11 +444,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
@@ -439,11 +461,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -456,11 +479,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -473,11 +497,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -490,11 +515,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -507,11 +533,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -523,11 +550,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -539,11 +567,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -555,11 +584,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -571,11 +601,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -587,11 +618,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -603,11 +635,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -620,11 +653,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -637,11 +671,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
@@ -653,11 +688,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
@@ -669,11 +705,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
@@ -686,11 +723,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 4;
@@ -703,11 +741,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -720,11 +759,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -737,11 +777,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -753,11 +794,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -769,11 +811,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 4);
   }
@@ -785,11 +828,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 4);
   }
@@ -801,11 +845,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
@@ -817,11 +862,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 4, abi.encodePacked((_element)));
   }
@@ -833,11 +879,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -852,11 +899,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -871,11 +919,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -889,11 +938,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -957,11 +1007,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     return _keyTuple;
   }
@@ -973,11 +1024,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -989,11 +1041,12 @@ library Singleton {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -106,7 +106,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -130,7 +139,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -145,7 +163,16 @@ library Statics {
 
   /** Set v1 */
   function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -169,7 +196,16 @@ library Statics {
     Enum2 k7,
     uint256 v1
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -191,7 +227,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -215,7 +260,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -230,7 +284,16 @@ library Statics {
 
   /** Set v2 */
   function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -254,7 +317,16 @@ library Statics {
     Enum2 k7,
     int32 v2
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -276,7 +348,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -300,7 +381,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -315,7 +405,16 @@ library Statics {
 
   /** Set v3 */
   function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -339,7 +438,16 @@ library Statics {
     Enum2 k7,
     bytes16 v3
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -361,7 +469,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -385,7 +502,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -400,7 +526,16 @@ library Statics {
 
   /** Set v4 */
   function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -424,7 +559,16 @@ library Statics {
     Enum2 k7,
     address v4
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -446,7 +590,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -470,7 +623,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -485,7 +647,16 @@ library Statics {
 
   /** Set v5 */
   function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -509,7 +680,16 @@ library Statics {
     Enum2 k7,
     bool v5
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -531,7 +711,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -555,7 +744,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -570,7 +768,16 @@ library Statics {
 
   /** Set v6 */
   function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -594,7 +801,16 @@ library Statics {
     Enum2 k7,
     Enum1 v6
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -616,7 +832,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -640,7 +865,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -655,7 +889,16 @@ library Statics {
 
   /** Set v7 */
   function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -679,7 +922,16 @@ library Statics {
     Enum2 k7,
     Enum2 v7
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -701,7 +953,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -725,7 +986,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (StaticsData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -757,7 +1027,16 @@ library Statics {
   ) internal {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
 
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -789,7 +1068,16 @@ library Statics {
   ) internal {
     bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
 
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -885,8 +1173,17 @@ library Statics {
     bool k5,
     Enum1 k6,
     Enum2 k7
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](7);
+  ) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -894,11 +1191,22 @@ library Statics {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -921,7 +1229,16 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](7);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 256
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 7)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -49,14 +49,13 @@ library Statics {
   }
 
   function getKeySchema() internal pure returns (Schema) {
-    SchemaType[] memory _schema = new SchemaType[](7);
+    SchemaType[] memory _schema = new SchemaType[](6);
     _schema[0] = SchemaType.UINT256;
     _schema[1] = SchemaType.INT32;
     _schema[2] = SchemaType.BYTES16;
     _schema[3] = SchemaType.ADDRESS;
     _schema[4] = SchemaType.BOOL;
     _schema[5] = SchemaType.UINT8;
-    _schema[6] = SchemaType.UINT8;
 
     return SchemaLib.encode(_schema);
   }
@@ -97,32 +96,54 @@ library Statics {
   }
 
   /** Get v1 */
-  function getV1(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (uint256 v1) {
+  function getV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (uint256 v1) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -136,114 +157,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (uint256 v1) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
   /** Set v1 */
-  function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
+  function setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, uint256 v1) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
   /** Set v1 (using the specified store) */
-  function setV1(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    uint256 v1
-  ) internal {
+  function setV1(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, uint256 v1) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
   }
 
   /** Get v2 */
-  function getV2(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (int32 v2) {
+  function getV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (int32 v2) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -257,114 +379,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (int32 v2) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
   }
 
   /** Set v2 */
-  function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
+  function setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, int32 v2) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)));
   }
 
   /** Set v2 (using the specified store) */
-  function setV2(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    int32 v2
-  ) internal {
+  function setV2(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, int32 v2) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)));
   }
 
   /** Get v3 */
-  function getV3(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (bytes16 v3) {
+  function getV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (bytes16 v3) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice16(_blob, 0));
@@ -378,114 +601,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (bytes16 v3) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice16(_blob, 0));
   }
 
   /** Set v3 */
-  function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
+  function setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, bytes16 v3) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)));
   }
 
   /** Set v3 (using the specified store) */
-  function setV3(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    bytes16 v3
-  ) internal {
+  function setV3(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, bytes16 v3) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)));
   }
 
   /** Get v4 */
-  function getV4(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (address v4) {
+  function getV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (address v4) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return (address(Bytes.slice20(_blob, 0)));
@@ -499,114 +823,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (address v4) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return (address(Bytes.slice20(_blob, 0)));
   }
 
   /** Set v4 */
-  function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
+  function setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, address v4) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)));
   }
 
   /** Set v4 (using the specified store) */
-  function setV4(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    address v4
-  ) internal {
+  function setV4(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, address v4) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)));
   }
 
   /** Get v5 */
-  function getV5(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (bool v5) {
+  function getV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (bool v5) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -620,114 +1045,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (bool v5) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
   /** Set v5 */
-  function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
+  function setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, bool v5) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)));
   }
 
   /** Set v5 (using the specified store) */
-  function setV5(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    bool v5
-  ) internal {
+  function setV5(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, bool v5) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)));
   }
 
   /** Get v6 */
-  function getV6(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (Enum1 v6) {
+  function getV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (Enum1 v6) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 5);
     return Enum1(uint8(Bytes.slice1(_blob, 0)));
@@ -741,114 +1267,215 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (Enum1 v6) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 5);
     return Enum1(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Set v6 */
-  function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
+  function setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum1 v6) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)));
   }
 
   /** Set v6 (using the specified store) */
-  function setV6(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    Enum1 v6
-  ) internal {
+  function setV6(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum1 v6) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)));
   }
 
   /** Get v7 */
-  function getV7(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal view returns (Enum2 v7) {
+  function getV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal view returns (Enum2 v7) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 6);
     return Enum2(uint8(Bytes.slice1(_blob, 0)));
@@ -862,83 +1489,162 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (Enum2 v7) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 6);
     return Enum2(uint8(Bytes.slice1(_blob, 0)));
   }
 
   /** Set v7 */
-  function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
+  function setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 v7) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)));
   }
 
   /** Set v7 (using the specified store) */
-  function setV7(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    Enum2 v7
-  ) internal {
+  function setV7(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 v7) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)));
   }
@@ -950,26 +1656,55 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (StaticsData memory _table) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -983,26 +1718,55 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal view returns (StaticsData memory _table) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -1016,7 +1780,6 @@ library Statics {
     address k4,
     bool k5,
     Enum1 k6,
-    Enum2 k7,
     uint256 v1,
     int32 v2,
     bytes16 v3,
@@ -1032,18 +1795,48 @@ library Statics {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1057,7 +1850,6 @@ library Statics {
     address k4,
     bool k5,
     Enum1 k6,
-    Enum2 k7,
     uint256 v1,
     int32 v2,
     bytes16 v3,
@@ -1073,34 +1865,55 @@ library Statics {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
 
   /** Set the full data using the data struct */
-  function set(
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7,
-    StaticsData memory _table
-  ) internal {
-    set(k1, k2, k3, k4, k5, k6, k7, _table.v1, _table.v2, _table.v3, _table.v4, _table.v5, _table.v6, _table.v7);
+  function set(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, StaticsData memory _table) internal {
+    set(k1, k2, k3, k4, k5, k6, _table.v1, _table.v2, _table.v3, _table.v4, _table.v5, _table.v6, _table.v7);
   }
 
   /** Set the full data using the data struct (using the specified store) */
@@ -1112,26 +1925,9 @@ library Statics {
     address k4,
     bool k5,
     Enum1 k6,
-    Enum2 k7,
     StaticsData memory _table
   ) internal {
-    set(
-      _store,
-      k1,
-      k2,
-      k3,
-      k4,
-      k5,
-      k6,
-      k7,
-      _table.v1,
-      _table.v2,
-      _table.v3,
-      _table.v4,
-      _table.v5,
-      _table.v6,
-      _table.v7
-    );
+    set(_store, k1, k2, k3, k4, k5, k6, _table.v1, _table.v2, _table.v3, _table.v4, _table.v5, _table.v6, _table.v7);
   }
 
   /** Decode the tightly packed blob using this table's schema */
@@ -1171,81 +1967,161 @@ library Statics {
     bytes16 k3,
     address k4,
     bool k5,
-    Enum1 k6,
-    Enum2 k7
+    Enum1 k6
   ) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     return _keyTuple;
   }
 
   /* Delete all data for given keys */
-  function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
+  function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
-  function deleteRecord(
-    IStore _store,
-    uint256 k1,
-    int32 k2,
-    bytes16 k3,
-    address k4,
-    bool k5,
-    Enum1 k6,
-    Enum2 k7
-  ) internal {
+  function deleteRecord(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6) internal {
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 256
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
-      mstore(_keyTuple, 7)
+      mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -107,42 +107,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -169,42 +170,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -223,42 +225,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
@@ -276,42 +279,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)));
@@ -329,42 +333,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -391,42 +396,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -445,42 +451,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)));
@@ -498,42 +505,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)));
@@ -551,42 +559,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -613,42 +622,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -667,42 +677,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)));
@@ -720,42 +731,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)));
@@ -773,42 +785,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -835,42 +848,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -889,42 +903,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)));
@@ -942,42 +957,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)));
@@ -995,42 +1011,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
@@ -1057,42 +1074,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
@@ -1111,42 +1129,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)));
@@ -1164,42 +1183,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)));
@@ -1217,42 +1237,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 5);
@@ -1279,42 +1300,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 5);
@@ -1333,42 +1355,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)));
@@ -1386,42 +1409,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)));
@@ -1439,42 +1463,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 6);
@@ -1501,42 +1526,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 6);
@@ -1555,42 +1581,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)));
@@ -1608,42 +1635,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)));
@@ -1668,42 +1696,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -1730,42 +1759,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -1800,42 +1830,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -1870,42 +1901,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -1979,42 +2011,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -2032,42 +2065,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -2085,42 +2119,43 @@ library Statics {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/cli/contracts/test/Tablegen.t.sol
+++ b/packages/cli/contracts/test/Tablegen.t.sol
@@ -18,14 +18,13 @@ contract TablegenTest is Test, StoreReadWithStubs {
     address k4 = address(123);
     bool k5 = true;
     Enum1 k6 = Enum1.E3;
-    Enum2 k7 = Enum2.E1;
 
-    Statics.setV1(k1, k2, k3, k4, k5, k6, k7, 4);
-    assertEq(Statics.getV1(k1, k2, k3, k4, k5, k6, k7), 4);
+    Statics.setV1(k1, k2, k3, k4, k5, k6, 4);
+    assertEq(Statics.getV1(k1, k2, k3, k4, k5, k6), 4);
 
     StaticsData memory data = StaticsData(4, -5, hex"06", address(456), false, Enum1.E2, Enum2.E1);
-    Statics.set(k1, k2, k3, k4, k5, k6, k7, data);
-    assertEq(abi.encode(Statics.get(k1, k2, k3, k4, k5, k6, k7)), abi.encode(data));
+    Statics.set(k1, k2, k3, k4, k5, k6, data);
+    assertEq(abi.encode(Statics.get(k1, k2, k3, k4, k5, k6)), abi.encode(data));
   }
 
   function testDynamicsSetAndGet() public {

--- a/packages/cli/scripts/generate-test-tables.ts
+++ b/packages/cli/scripts/generate-test-tables.ts
@@ -20,7 +20,6 @@ try {
           k4: "address",
           k5: "bool",
           k6: "Enum1",
-          k7: "Enum2",
         },
         schema: {
           v1: "uint256",

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -55,12 +55,22 @@ export function renderCommonData({
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := ${(keyTuple.length + 1) * 32}
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, ${(keyTuple.length + 1) * 32}))
       // Store length
       mstore(_keyTuple, ${keyTuple.length})
     }
-    ${renderList(keyTuple, (key, index) => `_keyTuple[${index}] = ${renderValueTypeToBytes32(key.name, key)};`)}
+
+    bytes32 _key;
+    ${renderList(
+      keyTuple,
+      (key, index) => `
+      /// @solidity memory-safe-assembly
+      _key = ${renderValueTypeToBytes32(key.name, key)};
+      assembly {
+        mstore(add(_keyTuple, ${(index + 1) * 32}), _key)
+      }
+    `
+    )}
   `;
 
   return {

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -49,7 +49,7 @@ export function renderCommonData({
   const _keyArgs = renderArguments(keyTuple.map(({ name }) => name));
   const _typedKeyArgs = renderArguments(keyTuple.map(({ name, typeWithLocation }) => `${typeWithLocation} ${name}`));
 
-  const _keyTupleDefinition = `
+  let _keyTupleDefinition = `
     bytes32[] memory _keyTuple;
     /// @solidity memory-safe-assembly
     assembly {
@@ -59,19 +59,24 @@ export function renderCommonData({
       // Store length
       mstore(_keyTuple, ${keyTuple.length})
     }
-
-    bytes32 _key;
-    ${renderList(
-      keyTuple,
-      (key, index) => `
-      /// @solidity memory-safe-assembly
-      _key = ${renderValueTypeToBytes32(key.name, key)};
-      assembly {
-        mstore(add(_keyTuple, ${(index + 1) * 32}), _key)
-      }
-    `
-    )}
   `;
+
+  if (keyTuple.length > 0) {
+    _keyTupleDefinition += `
+      // Store keys
+      bytes32 _keyTupleItem;
+      ${renderList(
+        keyTuple,
+        (key, index) => `
+          /// @solidity memory-safe-assembly
+          _keyTupleItem = ${renderValueTypeToBytes32(key.name, key)};
+          assembly {
+            mstore(add(_keyTuple, ${(index + 1) * 32}), _keyTupleItem)
+          }
+        `
+      )}
+    `;
+  }
 
   return {
     _tableId,

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -50,7 +50,16 @@ export function renderCommonData({
   const _typedKeyArgs = renderArguments(keyTuple.map(({ name, typeWithLocation }) => `${typeWithLocation} ${name}`));
 
   const _keyTupleDefinition = `
-    bytes32[] memory _keyTuple = new bytes32[](${keyTuple.length});
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := ${(keyTuple.length + 1) * 32}
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, ${keyTuple.length})
+    }
     ${renderList(keyTuple, (key, index) => `_keyTuple[${index}] = ${renderValueTypeToBytes32(key.name, key)};`)}
   `;
 

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -261,13 +261,13 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 110021
+    "gasUsed": 109921
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 12408
+    "gasUsed": 12347
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -483,25 +483,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30234
+    "gasUsed": 30184
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18289
+    "gasUsed": 18239
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 31984
+    "gasUsed": 31934
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 18039
+    "gasUsed": 17989
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -537,7 +537,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 10000
+    "gasUsed": 9950
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -555,61 +555,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 65852
+    "gasUsed": 65752
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 73501
+    "gasUsed": 73401
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 29436
+    "gasUsed": 29336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 22078
+    "gasUsed": 21978
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 65852
+    "gasUsed": 65752
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 166830
+    "gasUsed": 166730
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 32510
+    "gasUsed": 32410
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 23544
+    "gasUsed": 23444
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 15911
+    "gasUsed": 15861
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 38572
+    "gasUsed": 38522
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -633,7 +633,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 108618
+    "gasUsed": 108568
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -675,7 +675,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 38931
+    "gasUsed": 38881
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -687,7 +687,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 33878
+    "gasUsed": 33828
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -699,7 +699,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56358
+    "gasUsed": 56308
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -711,7 +711,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34491
+    "gasUsed": 34441
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -723,7 +723,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38393
+    "gasUsed": 38343
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -735,7 +735,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 60898
+    "gasUsed": 60848
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -747,31 +747,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 251738
+    "gasUsed": 251638
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15433
+    "gasUsed": 15383
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 16474
+    "gasUsed": 16424
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 250211
+    "gasUsed": 250111
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "get record from StoreMetadataTable",
-    "gasUsed": 11548
+    "gasUsed": 11490
   },
   {
     "file": "test/StoreSwitch.t.sol",
@@ -789,37 +789,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 61383
+    "gasUsed": 61283
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5051
+    "gasUsed": 5001
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39268
+    "gasUsed": 39168
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 63374
+    "gasUsed": 63274
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 5035
+    "gasUsed": 4985
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39259
+    "gasUsed": 39159
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -879,12 +879,12 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37212
+    "gasUsed": 37088
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4549
+    "gasUsed": 4485
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -261,13 +261,13 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 109921
+    "gasUsed": 109803
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 12347
+    "gasUsed": 12294
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -483,25 +483,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 30184
+    "gasUsed": 30125
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 18239
+    "gasUsed": 18180
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 31934
+    "gasUsed": 31875
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 17989
+    "gasUsed": 17930
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -537,7 +537,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 9950
+    "gasUsed": 9891
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -555,61 +555,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 65752
+    "gasUsed": 65640
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 73401
+    "gasUsed": 73283
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 29336
+    "gasUsed": 29222
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 21978
+    "gasUsed": 21860
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 65752
+    "gasUsed": 65640
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 166730
+    "gasUsed": 166612
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 32410
+    "gasUsed": 32292
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 23444
+    "gasUsed": 23326
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 15861
+    "gasUsed": 15802
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 38522
+    "gasUsed": 38463
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -633,7 +633,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 108568
+    "gasUsed": 108509
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -675,7 +675,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 38881
+    "gasUsed": 38822
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -687,7 +687,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 33828
+    "gasUsed": 33769
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -699,7 +699,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 56308
+    "gasUsed": 56249
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -711,7 +711,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 34441
+    "gasUsed": 34382
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -723,7 +723,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 38343
+    "gasUsed": 38284
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -735,7 +735,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 60848
+    "gasUsed": 60789
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -747,31 +747,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetMetadata",
     "name": "StoreCore: set table metadata",
-    "gasUsed": 251638
+    "gasUsed": 251520
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 15383
+    "gasUsed": 15324
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 16424
+    "gasUsed": 16365
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "set record in StoreMetadataTable",
-    "gasUsed": 250111
+    "gasUsed": 249993
   },
   {
     "file": "test/StoreMetadata.t.sol",
     "test": "testSetAndGet",
     "name": "get record from StoreMetadataTable",
-    "gasUsed": 11490
+    "gasUsed": 11443
   },
   {
     "file": "test/StoreSwitch.t.sol",
@@ -789,37 +789,37 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Callbacks",
-    "gasUsed": 61283
+    "gasUsed": 61168
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Callbacks (warm)",
-    "gasUsed": 5001
+    "gasUsed": 4939
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Callbacks",
-    "gasUsed": 39168
+    "gasUsed": 39053
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "set field in Hooks",
-    "gasUsed": 63274
+    "gasUsed": 63162
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "get field from Hooks (warm)",
-    "gasUsed": 4985
+    "gasUsed": 4926
   },
   {
     "file": "test/tables/Hooks.t.sol",
     "test": "testSetAndGet",
     "name": "push field to Hooks",
-    "gasUsed": 39159
+    "gasUsed": 39047
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -879,12 +879,12 @@
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 37088
+    "gasUsed": 36988
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4485
+    "gasUsed": 4435
   }
 ]

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -67,7 +67,16 @@ library Callbacks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library Callbacks {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library Callbacks {
 
   /** Set value */
   function set(bytes32 key, bytes24[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -93,7 +120,16 @@ library Callbacks {
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, bytes24[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -101,7 +137,16 @@ library Callbacks {
 
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -110,7 +155,16 @@ library Callbacks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -119,7 +173,16 @@ library Callbacks {
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 key, uint256 _index) internal view returns (bytes24) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
@@ -128,7 +191,16 @@ library Callbacks {
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes24) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
@@ -137,7 +209,16 @@ library Callbacks {
 
   /** Push an element to value */
   function push(bytes32 key, bytes24 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -145,7 +226,16 @@ library Callbacks {
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, bytes24 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -153,7 +243,16 @@ library Callbacks {
 
   /** Pop an element from value */
   function pop(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 24);
@@ -161,7 +260,16 @@ library Callbacks {
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 24);
@@ -169,7 +277,16 @@ library Callbacks {
 
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, bytes24 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
@@ -177,7 +294,16 @@ library Callbacks {
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, bytes24 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
@@ -193,14 +319,34 @@ library Callbacks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -208,7 +354,16 @@ library Callbacks {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -77,12 +77,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -101,12 +102,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -125,12 +127,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -148,12 +151,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -171,12 +175,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -195,12 +200,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -219,12 +225,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
@@ -243,12 +250,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
@@ -267,12 +275,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -290,12 +299,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -313,12 +323,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 24);
@@ -336,12 +347,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 24);
@@ -359,12 +371,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
@@ -382,12 +395,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
@@ -414,12 +428,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -437,12 +452,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -460,12 +476,13 @@ library Callbacks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -72,12 +72,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
@@ -90,12 +96,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
@@ -108,12 +120,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -125,12 +143,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -142,12 +166,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 24;
@@ -160,12 +190,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 24;
@@ -178,12 +214,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
     return (Bytes.slice24(_blob, 0));
@@ -196,12 +238,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 24, (_index + 1) * 24);
     return (Bytes.slice24(_blob, 0));
@@ -214,12 +262,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -231,12 +285,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -248,12 +308,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 24);
   }
@@ -265,12 +331,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 24);
   }
@@ -282,12 +354,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
   }
@@ -299,12 +377,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)));
   }
@@ -325,12 +409,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -342,12 +432,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -359,12 +455,18 @@ library Callbacks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -72,12 +72,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -90,12 +96,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -108,12 +120,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -125,12 +143,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -142,12 +166,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -160,12 +190,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -178,12 +214,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -196,12 +238,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -214,12 +262,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -231,12 +285,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -248,12 +308,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -265,12 +331,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -282,12 +354,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -299,12 +377,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -325,12 +409,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -342,12 +432,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -359,12 +455,18 @@ library Hooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -77,12 +77,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -101,12 +102,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -125,12 +127,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -148,12 +151,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -171,12 +175,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -195,12 +200,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -219,12 +225,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -243,12 +250,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -267,12 +275,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -290,12 +299,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -313,12 +323,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -336,12 +347,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -359,12 +371,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -382,12 +395,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -414,12 +428,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -437,12 +452,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -460,12 +476,13 @@ library Hooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -67,7 +67,16 @@ library Hooks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library Hooks {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library Hooks {
 
   /** Set value */
   function set(bytes32 key, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -93,7 +120,16 @@ library Hooks {
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -101,7 +137,16 @@ library Hooks {
 
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -110,7 +155,16 @@ library Hooks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -119,7 +173,16 @@ library Hooks {
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -128,7 +191,16 @@ library Hooks {
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -137,7 +209,16 @@ library Hooks {
 
   /** Push an element to value */
   function push(bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -145,7 +226,16 @@ library Hooks {
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -153,7 +243,16 @@ library Hooks {
 
   /** Pop an element from value */
   function pop(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -161,7 +260,16 @@ library Hooks {
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -169,7 +277,16 @@ library Hooks {
 
   /** Update an element of value at `_index` */
   function update(bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -177,7 +294,16 @@ library Hooks {
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -193,14 +319,34 @@ library Hooks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -208,7 +354,16 @@ library Hooks {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -92,42 +92,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -154,42 +155,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -208,42 +210,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
@@ -270,42 +273,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
@@ -335,42 +339,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -388,42 +393,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -441,42 +447,43 @@ library KeyEncoding {
       mstore(_keyTuple, 6)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(k1));
+    _keyTupleItem = bytes32(uint256(k1));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(int256(k2)));
+    _keyTupleItem = bytes32(uint256(int256(k2)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(k3);
+    _keyTupleItem = bytes32(k3);
     assembly {
-      mstore(add(_keyTuple, 96), _key)
+      mstore(add(_keyTuple, 96), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(k4)));
+    _keyTupleItem = bytes32(uint256(uint160(k4)));
     assembly {
-      mstore(add(_keyTuple, 128), _key)
+      mstore(add(_keyTuple, 128), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = _boolToBytes32(k5);
+    _keyTupleItem = _boolToBytes32(k5);
     assembly {
-      mstore(add(_keyTuple, 160), _key)
+      mstore(add(_keyTuple, 160), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint8(k6)));
+    _keyTupleItem = bytes32(uint256(uint8(k6)));
     assembly {
-      mstore(add(_keyTuple, 192), _key)
+      mstore(add(_keyTuple, 192), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -82,7 +82,16 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -104,7 +113,16 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -118,7 +136,16 @@ library KeyEncoding {
 
   /** Set value */
   function set(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, ExampleEnum k6, bool value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -140,7 +167,16 @@ library KeyEncoding {
     ExampleEnum k6,
     bool value
   ) internal {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -164,19 +200,39 @@ library KeyEncoding {
     address k4,
     bool k5,
     ExampleEnum k6
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](6);
+  ) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
     _keyTuple[3] = bytes32(uint256(uint160(k4)));
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, ExampleEnum k6) internal {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -189,7 +245,16 @@ library KeyEncoding {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, ExampleEnum k6) internal {
-    bytes32[] memory _keyTuple = new bytes32[](6);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 224
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 6)
+    }
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -87,17 +87,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -118,17 +149,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -141,17 +203,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -172,17 +265,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -206,17 +330,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     return _keyTuple;
   }
@@ -228,17 +383,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -250,17 +436,48 @@ library KeyEncoding {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 224
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 224))
       // Store length
       mstore(_keyTuple, 6)
     }
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(k1));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(int256(k2)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(k3);
+    assembly {
+      mstore(add(_keyTuple, 96), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(k4)));
+    assembly {
+      mstore(add(_keyTuple, 128), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = _boolToBytes32(k5);
+    assembly {
+      mstore(add(_keyTuple, 160), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint8(k6)));
+    assembly {
+      mstore(add(_keyTuple, 192), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -80,7 +80,16 @@ library Mixed {
 
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -89,7 +98,16 @@ library Mixed {
 
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -98,7 +116,16 @@ library Mixed {
 
   /** Set u32 */
   function setU32(bytes32 key, uint32 u32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
@@ -106,7 +133,16 @@ library Mixed {
 
   /** Set u32 (using the specified store) */
   function setU32(IStore _store, bytes32 key, uint32 u32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
@@ -114,7 +150,16 @@ library Mixed {
 
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -123,7 +168,16 @@ library Mixed {
 
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -132,7 +186,16 @@ library Mixed {
 
   /** Set u128 */
   function setU128(bytes32 key, uint128 u128) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
@@ -140,7 +203,16 @@ library Mixed {
 
   /** Set u128 (using the specified store) */
   function setU128(IStore _store, bytes32 key, uint128 u128) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
@@ -148,7 +220,16 @@ library Mixed {
 
   /** Get a32 */
   function getA32(bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -157,7 +238,16 @@ library Mixed {
 
   /** Get a32 (using the specified store) */
   function getA32(IStore _store, bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -166,7 +256,16 @@ library Mixed {
 
   /** Set a32 */
   function setA32(bytes32 key, uint32[] memory a32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
@@ -174,7 +273,16 @@ library Mixed {
 
   /** Set a32 (using the specified store) */
   function setA32(IStore _store, bytes32 key, uint32[] memory a32) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
@@ -182,7 +290,16 @@ library Mixed {
 
   /** Get the length of a32 */
   function lengthA32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -191,7 +308,16 @@ library Mixed {
 
   /** Get the length of a32 (using the specified store) */
   function lengthA32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -200,7 +326,16 @@ library Mixed {
 
   /** Get an item of a32 (unchecked, returns invalid data if index overflows) */
   function getItemA32(bytes32 key, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
@@ -209,7 +344,16 @@ library Mixed {
 
   /** Get an item of a32 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemA32(IStore _store, bytes32 key, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
@@ -218,7 +362,16 @@ library Mixed {
 
   /** Push an element to a32 */
   function pushA32(bytes32 key, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -226,7 +379,16 @@ library Mixed {
 
   /** Push an element to a32 (using the specified store) */
   function pushA32(IStore _store, bytes32 key, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -234,7 +396,16 @@ library Mixed {
 
   /** Pop an element from a32 */
   function popA32(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
@@ -242,7 +413,16 @@ library Mixed {
 
   /** Pop an element from a32 (using the specified store) */
   function popA32(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
@@ -250,7 +430,16 @@ library Mixed {
 
   /** Update an element of a32 at `_index` */
   function updateA32(bytes32 key, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
@@ -258,7 +447,16 @@ library Mixed {
 
   /** Update an element of a32 (using the specified store) at `_index` */
   function updateA32(IStore _store, bytes32 key, uint256 _index, uint32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
@@ -266,7 +464,16 @@ library Mixed {
 
   /** Get s */
   function getS(bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -275,7 +482,16 @@ library Mixed {
 
   /** Get s (using the specified store) */
   function getS(IStore _store, bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -284,7 +500,16 @@ library Mixed {
 
   /** Set s */
   function setS(bytes32 key, string memory s) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((s)));
@@ -292,7 +517,16 @@ library Mixed {
 
   /** Set s (using the specified store) */
   function setS(IStore _store, bytes32 key, string memory s) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 3, bytes((s)));
@@ -300,7 +534,16 @@ library Mixed {
 
   /** Get the length of s */
   function lengthS(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -309,7 +552,16 @@ library Mixed {
 
   /** Get the length of s (using the specified store) */
   function lengthS(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -318,7 +570,16 @@ library Mixed {
 
   /** Get an item of s (unchecked, returns invalid data if index overflows) */
   function getItemS(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
@@ -327,7 +588,16 @@ library Mixed {
 
   /** Get an item of s (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemS(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
@@ -336,7 +606,16 @@ library Mixed {
 
   /** Push a slice to s */
   function pushS(bytes32 key, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
@@ -344,7 +623,16 @@ library Mixed {
 
   /** Push a slice to s (using the specified store) */
   function pushS(IStore _store, bytes32 key, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
@@ -352,7 +640,16 @@ library Mixed {
 
   /** Pop a slice from s */
   function popS(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1);
@@ -360,7 +657,16 @@ library Mixed {
 
   /** Pop a slice from s (using the specified store) */
   function popS(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 3, 1);
@@ -368,7 +674,16 @@ library Mixed {
 
   /** Update a slice of s at `_index` */
   function updateS(bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
@@ -376,7 +691,16 @@ library Mixed {
 
   /** Update a slice of s (using the specified store) at `_index` */
   function updateS(IStore _store, bytes32 key, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
@@ -384,7 +708,16 @@ library Mixed {
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (MixedData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -393,7 +726,16 @@ library Mixed {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (MixedData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -404,7 +746,16 @@ library Mixed {
   function set(bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
     bytes memory _data = encode(u32, u128, a32, s);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -414,7 +765,16 @@ library Mixed {
   function set(IStore _store, bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
     bytes memory _data = encode(u32, u128, a32, s);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -466,14 +826,34 @@ library Mixed {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -481,7 +861,16 @@ library Mixed {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -85,12 +85,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -103,12 +109,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -121,12 +133,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
   }
@@ -138,12 +156,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
   }
@@ -155,12 +179,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -173,12 +203,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint128(Bytes.slice16(_blob, 0)));
@@ -191,12 +227,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
   }
@@ -208,12 +250,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
   }
@@ -225,12 +273,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -243,12 +297,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
@@ -261,12 +321,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
   }
@@ -278,12 +344,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
   }
@@ -295,12 +367,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -313,12 +391,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 4;
@@ -331,12 +415,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -349,12 +439,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -367,12 +463,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -384,12 +486,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -401,12 +509,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -418,12 +532,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
   }
@@ -435,12 +555,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -452,12 +578,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
   }
@@ -469,12 +601,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return (string(_blob));
@@ -487,12 +625,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return (string(_blob));
@@ -505,12 +649,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((s)));
   }
@@ -522,12 +672,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 3, bytes((s)));
   }
@@ -539,12 +695,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 1;
@@ -557,12 +719,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 1;
@@ -575,12 +743,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -593,12 +767,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -611,12 +791,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
   }
@@ -628,12 +814,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
   }
@@ -645,12 +837,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1);
   }
@@ -662,12 +860,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 3, 1);
   }
@@ -679,12 +883,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
   }
@@ -696,12 +906,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
   }
@@ -713,12 +929,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -731,12 +953,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -751,12 +979,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -770,12 +1004,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -832,12 +1072,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -849,12 +1095,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -866,12 +1118,18 @@ library Mixed {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -90,12 +90,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -114,12 +115,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -138,12 +140,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
@@ -161,12 +164,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)));
@@ -184,12 +188,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -208,12 +213,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -232,12 +238,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
@@ -255,12 +262,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)));
@@ -278,12 +286,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -302,12 +311,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -326,12 +336,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
@@ -349,12 +360,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)));
@@ -372,12 +384,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -396,12 +409,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -420,12 +434,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
@@ -444,12 +459,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 4, (_index + 1) * 4);
@@ -468,12 +484,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -491,12 +508,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -514,12 +532,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4);
@@ -537,12 +556,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 2, 4);
@@ -560,12 +580,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
@@ -583,12 +604,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)));
@@ -606,12 +628,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -630,12 +653,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -654,12 +678,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((s)));
@@ -677,12 +702,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 3, bytes((s)));
@@ -700,12 +726,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -724,12 +751,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -748,12 +776,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
@@ -772,12 +801,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 1, (_index + 1) * 1);
@@ -796,12 +826,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
@@ -819,12 +850,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 3, bytes((_slice)));
@@ -842,12 +874,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1);
@@ -865,12 +898,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 3, 1);
@@ -888,12 +922,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
@@ -911,12 +946,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)));
@@ -934,12 +970,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -958,12 +995,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -984,12 +1022,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -1009,12 +1048,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -1077,12 +1117,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -1100,12 +1141,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -1123,12 +1165,13 @@ library Mixed {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -74,7 +74,16 @@ library StoreMetadata {
 
   /** Get tableName */
   function getTableName(bytes32 tableId) internal view returns (string memory tableName) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -83,7 +92,16 @@ library StoreMetadata {
 
   /** Get tableName (using the specified store) */
   function getTableName(IStore _store, bytes32 tableId) internal view returns (string memory tableName) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -92,7 +110,16 @@ library StoreMetadata {
 
   /** Set tableName */
   function setTableName(bytes32 tableId, string memory tableName) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, bytes((tableName)));
@@ -100,7 +127,16 @@ library StoreMetadata {
 
   /** Set tableName (using the specified store) */
   function setTableName(IStore _store, bytes32 tableId, string memory tableName) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.setField(_tableId, _keyTuple, 0, bytes((tableName)));
@@ -108,7 +144,16 @@ library StoreMetadata {
 
   /** Get the length of tableName */
   function lengthTableName(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -117,7 +162,16 @@ library StoreMetadata {
 
   /** Get the length of tableName (using the specified store) */
   function lengthTableName(IStore _store, bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -126,7 +180,16 @@ library StoreMetadata {
 
   /** Get an item of tableName (unchecked, returns invalid data if index overflows) */
   function getItemTableName(bytes32 tableId, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
@@ -135,7 +198,16 @@ library StoreMetadata {
 
   /** Get an item of tableName (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemTableName(IStore _store, bytes32 tableId, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
@@ -144,7 +216,16 @@ library StoreMetadata {
 
   /** Push a slice to tableName */
   function pushTableName(bytes32 tableId, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
@@ -152,7 +233,16 @@ library StoreMetadata {
 
   /** Push a slice to tableName (using the specified store) */
   function pushTableName(IStore _store, bytes32 tableId, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
@@ -160,7 +250,16 @@ library StoreMetadata {
 
   /** Pop a slice from tableName */
   function popTableName(bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 1);
@@ -168,7 +267,16 @@ library StoreMetadata {
 
   /** Pop a slice from tableName (using the specified store) */
   function popTableName(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.popFromField(_tableId, _keyTuple, 0, 1);
@@ -176,7 +284,16 @@ library StoreMetadata {
 
   /** Update a slice of tableName at `_index` */
   function updateTableName(bytes32 tableId, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
@@ -184,7 +301,16 @@ library StoreMetadata {
 
   /** Update a slice of tableName (using the specified store) at `_index` */
   function updateTableName(IStore _store, bytes32 tableId, uint256 _index, string memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
@@ -192,7 +318,16 @@ library StoreMetadata {
 
   /** Get abiEncodedFieldNames */
   function getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -204,7 +339,16 @@ library StoreMetadata {
     IStore _store,
     bytes32 tableId
   ) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -213,7 +357,16 @@ library StoreMetadata {
 
   /** Set abiEncodedFieldNames */
   function setAbiEncodedFieldNames(bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
@@ -221,7 +374,16 @@ library StoreMetadata {
 
   /** Set abiEncodedFieldNames (using the specified store) */
   function setAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
@@ -229,7 +391,16 @@ library StoreMetadata {
 
   /** Get the length of abiEncodedFieldNames */
   function lengthAbiEncodedFieldNames(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -238,7 +409,16 @@ library StoreMetadata {
 
   /** Get the length of abiEncodedFieldNames (using the specified store) */
   function lengthAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -247,7 +427,16 @@ library StoreMetadata {
 
   /** Get an item of abiEncodedFieldNames (unchecked, returns invalid data if index overflows) */
   function getItemAbiEncodedFieldNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -260,7 +449,16 @@ library StoreMetadata {
     bytes32 tableId,
     uint256 _index
   ) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -269,7 +467,16 @@ library StoreMetadata {
 
   /** Push a slice to abiEncodedFieldNames */
   function pushAbiEncodedFieldNames(bytes32 tableId, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -277,7 +484,16 @@ library StoreMetadata {
 
   /** Push a slice to abiEncodedFieldNames (using the specified store) */
   function pushAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -285,7 +501,16 @@ library StoreMetadata {
 
   /** Pop a slice from abiEncodedFieldNames */
   function popAbiEncodedFieldNames(bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
@@ -293,7 +518,16 @@ library StoreMetadata {
 
   /** Pop a slice from abiEncodedFieldNames (using the specified store) */
   function popAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
@@ -301,7 +535,16 @@ library StoreMetadata {
 
   /** Update a slice of abiEncodedFieldNames at `_index` */
   function updateAbiEncodedFieldNames(bytes32 tableId, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -309,7 +552,16 @@ library StoreMetadata {
 
   /** Update a slice of abiEncodedFieldNames (using the specified store) at `_index` */
   function updateAbiEncodedFieldNames(IStore _store, bytes32 tableId, uint256 _index, bytes memory _slice) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -317,7 +569,16 @@ library StoreMetadata {
 
   /** Get the full data */
   function get(bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -326,7 +587,16 @@ library StoreMetadata {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 tableId) internal view returns (StoreMetadataData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -337,7 +607,16 @@ library StoreMetadata {
   function set(bytes32 tableId, string memory tableName, bytes memory abiEncodedFieldNames) internal {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -347,7 +626,16 @@ library StoreMetadata {
   function set(IStore _store, bytes32 tableId, string memory tableName, bytes memory abiEncodedFieldNames) internal {
     bytes memory _data = encode(tableName, abiEncodedFieldNames);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -395,14 +683,34 @@ library StoreMetadata {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 tableId) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 tableId) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -410,7 +718,16 @@ library StoreMetadata {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = tableId;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -79,12 +79,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (string(_blob));
@@ -97,12 +103,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (string(_blob));
@@ -115,12 +127,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, bytes((tableName)));
   }
@@ -132,12 +150,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, bytes((tableName)));
   }
@@ -149,12 +173,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 1;
@@ -167,12 +197,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 1;
@@ -185,12 +221,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -203,12 +245,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
     return (string(_blob));
@@ -221,12 +269,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
   }
@@ -238,12 +292,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
   }
@@ -255,12 +315,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 1);
   }
@@ -272,12 +338,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 1);
   }
@@ -289,12 +361,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
   }
@@ -306,12 +384,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
   }
@@ -323,12 +407,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (bytes(_blob));
@@ -344,12 +434,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (bytes(_blob));
@@ -362,12 +458,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
   }
@@ -379,12 +481,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
   }
@@ -396,12 +504,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -414,12 +528,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 1;
@@ -432,12 +552,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -454,12 +580,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
     return (bytes(_blob));
@@ -472,12 +604,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -489,12 +627,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
   }
@@ -506,12 +650,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -523,12 +673,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
   }
@@ -540,12 +696,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -557,12 +719,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
   }
@@ -574,12 +742,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -592,12 +766,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -612,12 +792,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -631,12 +817,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -689,12 +881,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -706,12 +904,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -723,12 +927,18 @@ library StoreMetadata {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = tableId;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = tableId;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -84,12 +84,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -108,12 +109,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -132,12 +134,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, bytes((tableName)));
@@ -155,12 +158,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, bytes((tableName)));
@@ -178,12 +182,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -202,12 +207,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -226,12 +232,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
@@ -250,12 +257,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 1, (_index + 1) * 1);
@@ -274,12 +282,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
@@ -297,12 +306,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, bytes((_slice)));
@@ -320,12 +330,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 1);
@@ -343,12 +354,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 1);
@@ -366,12 +378,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
@@ -389,12 +402,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 1, bytes((_slice)));
@@ -412,12 +426,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -439,12 +454,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -463,12 +479,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
@@ -486,12 +503,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, bytes((abiEncodedFieldNames)));
@@ -509,12 +527,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -533,12 +552,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -557,12 +577,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -585,12 +606,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 1, (_index + 1) * 1);
@@ -609,12 +631,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -632,12 +655,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 1, bytes((_slice)));
@@ -655,12 +679,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1);
@@ -678,12 +703,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 1, 1);
@@ -701,12 +727,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -724,12 +751,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)));
@@ -747,12 +775,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -771,12 +800,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -797,12 +827,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -822,12 +853,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -886,12 +918,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -909,12 +942,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -932,12 +966,13 @@ library StoreMetadata {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = tableId;
+    _keyTupleItem = tableId;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -84,12 +84,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -108,12 +109,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -132,12 +134,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -155,12 +158,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -178,12 +182,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -202,12 +207,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -226,12 +232,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -249,12 +256,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -272,12 +280,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -296,12 +305,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -322,12 +332,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -347,12 +358,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -392,12 +404,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -415,12 +428,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -438,12 +452,13 @@ library Vector2 {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -79,12 +79,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -97,12 +103,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -115,12 +127,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -132,12 +150,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -149,12 +173,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -167,12 +197,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -185,12 +221,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -202,12 +244,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -219,12 +267,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -237,12 +291,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -257,12 +317,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -276,12 +342,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -315,12 +387,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -332,12 +410,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -349,12 +433,18 @@ library Vector2 {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -74,7 +74,16 @@ library Vector2 {
 
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -83,7 +92,16 @@ library Vector2 {
 
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -92,7 +110,16 @@ library Vector2 {
 
   /** Set x */
   function setX(bytes32 key, uint32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -100,7 +127,16 @@ library Vector2 {
 
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, uint32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -108,7 +144,16 @@ library Vector2 {
 
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -117,7 +162,16 @@ library Vector2 {
 
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -126,7 +180,16 @@ library Vector2 {
 
   /** Set y */
   function setY(bytes32 key, uint32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -134,7 +197,16 @@ library Vector2 {
 
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, uint32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -142,7 +214,16 @@ library Vector2 {
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (Vector2Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -151,7 +232,16 @@ library Vector2 {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Vector2Data memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -162,7 +252,16 @@ library Vector2 {
   function set(bytes32 key, uint32 x, uint32 y) internal {
     bytes memory _data = encode(x, y);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -172,7 +271,16 @@ library Vector2 {
   function set(IStore _store, bytes32 key, uint32 x, uint32 y) internal {
     bytes memory _data = encode(x, y);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -201,14 +309,34 @@ library Vector2 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -216,7 +344,16 @@ library Vector2 {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -135,9 +135,9 @@ library ${libraryName} {
   }
   
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(${renderArguments([_typedKeyArgs])}) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](${keyTuple.length});
-    ${renderList(keyTuple, (key, index) => `_keyTuple[${index}] = ${renderValueTypeToBytes32(key.name, key)};`)}
+  function encodeKeyTuple(${renderArguments([_typedKeyArgs])}) internal pure returns (bytes32[] memory) {
+    ${_keyTupleDefinition}
+    return _keyTuple;
   }
 
   ${

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,73 +3,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1245509
+    "gasUsed": 1240728
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1245509
+    "gasUsed": 1240728
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 186376
+    "gasUsed": 184759
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1245509
+    "gasUsed": 1240728
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1245509
+    "gasUsed": 1240728
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 27582
+    "gasUsed": 27161
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 260336
+    "gasUsed": 255190
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1245509
+    "gasUsed": 1240728
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 26196
+    "gasUsed": 25775
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 136530
+    "gasUsed": 133704
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 600153
+    "gasUsed": 596950
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 7391
+    "gasUsed": 7294
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -81,240 +81,240 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 600153
+    "gasUsed": 596950
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 159235
+    "gasUsed": 157838
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 600153
+    "gasUsed": 596950
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 126246
+    "gasUsed": 124849
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 48933
+    "gasUsed": 48048
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 600153
+    "gasUsed": 596950
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 167383
+    "gasUsed": 165986
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 129641
+    "gasUsed": 128244
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 160409
+    "gasUsed": 158846
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 75186
+    "gasUsed": 74471
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 220085
+    "gasUsed": 217859
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 138370
+    "gasUsed": 136992
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 137230
+    "gasUsed": 135861
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 18902
+    "gasUsed": 18708
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 31224
+    "gasUsed": 30906
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 10687510
+    "gasUsed": 10581404
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 997013
+    "gasUsed": 986307
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 9128
+    "gasUsed": 9031
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 68780
+    "gasUsed": 68065
   },
   {
     "file": "test/SnapSyncModule.t.sol",
     "test": "testSnapSyncGas",
     "name": "Call snap sync on a table with 1 record",
-    "gasUsed": 38930
+    "gasUsed": 38512
   },
   {
     "file": "test/SnapSyncModule.t.sol",
     "test": "testSnapSyncGas",
     "name": "Call snap sync on a table with 2 records",
-    "gasUsed": 56007
+    "gasUsed": 55483
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 787858
+    "gasUsed": 782730
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 69647
+    "gasUsed": 69090
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 760163
+    "gasUsed": 755502
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 69647
+    "gasUsed": 69090
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 14446
+    "gasUsed": 14178
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 94564
+    "gasUsed": 94296
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 80165
+    "gasUsed": 79400
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 71345
+    "gasUsed": 70610
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 100756
+    "gasUsed": 99991
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 155574
+    "gasUsed": 154476
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 87260
+    "gasUsed": 86513
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 252927
+    "gasUsed": 251402
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 43035
+    "gasUsed": 42767
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetMetadata",
     "name": "Set metadata",
-    "gasUsed": 277799
+    "gasUsed": 277169
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 40890
+    "gasUsed": 40621
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 38107
+    "gasUsed": 37839
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 20897
+    "gasUsed": 20629
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 39827
+    "gasUsed": 39559
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 23032
+    "gasUsed": 22764
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -213,7 +213,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 69090
+    "gasUsed": 69080
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
@@ -225,7 +225,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 69090
+    "gasUsed": 69080
   },
   {
     "file": "test/World.t.sol",
@@ -267,7 +267,7 @@
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 86513
+    "gasUsed": 86525
   },
   {
     "file": "test/World.t.sol",
@@ -291,7 +291,7 @@
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 40621
+    "gasUsed": 40616
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -76,12 +76,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice16(_blob, 0));
@@ -94,12 +100,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice16(_blob, 0));
@@ -112,12 +124,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
   }
@@ -129,12 +147,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
   }
@@ -146,12 +170,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (Bytes.slice16(_blob, 0));
@@ -164,12 +194,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (Bytes.slice16(_blob, 0));
@@ -182,12 +218,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
   }
@@ -199,12 +241,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
   }
@@ -216,12 +264,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice4(_blob, 0));
@@ -237,12 +291,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (Bytes.slice4(_blob, 0));
@@ -255,12 +315,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
   }
@@ -272,12 +338,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
   }
@@ -291,12 +363,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -312,12 +390,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -332,12 +416,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -357,12 +447,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -390,12 +486,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -407,12 +509,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -424,12 +532,18 @@ library FunctionSelectors {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(functionSelector);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -81,12 +81,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -105,12 +106,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -129,12 +131,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
@@ -152,12 +155,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
@@ -175,12 +179,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -199,12 +204,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -223,12 +229,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
@@ -246,12 +253,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
@@ -269,12 +277,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -296,12 +305,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -320,12 +330,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
@@ -343,12 +354,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
@@ -368,12 +380,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -395,12 +408,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -421,12 +435,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -452,12 +467,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -491,12 +507,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -514,12 +531,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -537,12 +555,13 @@ library FunctionSelectors {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(functionSelector);
+    _keyTupleItem = bytes32(functionSelector);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -71,7 +71,16 @@ library FunctionSelectors {
 
   /** Get namespace */
   function getNamespace(bytes4 functionSelector) internal view returns (bytes16 namespace) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -80,7 +89,16 @@ library FunctionSelectors {
 
   /** Get namespace (using the specified store) */
   function getNamespace(IStore _store, bytes4 functionSelector) internal view returns (bytes16 namespace) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -89,7 +107,16 @@ library FunctionSelectors {
 
   /** Set namespace */
   function setNamespace(bytes4 functionSelector, bytes16 namespace) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
@@ -97,7 +124,16 @@ library FunctionSelectors {
 
   /** Set namespace (using the specified store) */
   function setNamespace(IStore _store, bytes4 functionSelector, bytes16 namespace) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((namespace)));
@@ -105,7 +141,16 @@ library FunctionSelectors {
 
   /** Get name */
   function getName(bytes4 functionSelector) internal view returns (bytes16 name) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -114,7 +159,16 @@ library FunctionSelectors {
 
   /** Get name (using the specified store) */
   function getName(IStore _store, bytes4 functionSelector) internal view returns (bytes16 name) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -123,7 +177,16 @@ library FunctionSelectors {
 
   /** Set name */
   function setName(bytes4 functionSelector, bytes16 name) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
@@ -131,7 +194,16 @@ library FunctionSelectors {
 
   /** Set name (using the specified store) */
   function setName(IStore _store, bytes4 functionSelector, bytes16 name) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((name)));
@@ -139,7 +211,16 @@ library FunctionSelectors {
 
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -151,7 +232,16 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -160,7 +250,16 @@ library FunctionSelectors {
 
   /** Set systemFunctionSelector */
   function setSystemFunctionSelector(bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
@@ -168,7 +267,16 @@ library FunctionSelectors {
 
   /** Set systemFunctionSelector (using the specified store) */
   function setSystemFunctionSelector(IStore _store, bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((systemFunctionSelector)));
@@ -178,7 +286,16 @@ library FunctionSelectors {
   function get(
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -190,7 +307,16 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -201,7 +327,16 @@ library FunctionSelectors {
   function set(bytes4 functionSelector, bytes16 namespace, bytes16 name, bytes4 systemFunctionSelector) internal {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -217,7 +352,16 @@ library FunctionSelectors {
   ) internal {
     bytes memory _data = encode(namespace, name, systemFunctionSelector);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -240,14 +384,34 @@ library FunctionSelectors {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes4 functionSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -255,7 +419,16 @@ library FunctionSelectors {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes4 functionSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(functionSelector);
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -75,12 +75,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
@@ -93,12 +99,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return Resource(uint8(Bytes.slice1(_blob, 0)));
@@ -111,12 +123,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
   }
@@ -128,12 +146,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
   }
@@ -150,12 +174,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -167,12 +197,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -184,12 +220,18 @@ library ResourceType {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -70,7 +70,16 @@ library ResourceType {
 
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -79,7 +88,16 @@ library ResourceType {
 
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -88,7 +106,16 @@ library ResourceType {
 
   /** Set resourceType */
   function set(bytes32 resourceSelector, Resource resourceType) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
@@ -96,7 +123,16 @@ library ResourceType {
 
   /** Set resourceType (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, Resource resourceType) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
@@ -108,14 +144,34 @@ library ResourceType {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -123,7 +179,16 @@ library ResourceType {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -80,12 +80,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -104,12 +105,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -128,12 +130,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
@@ -151,12 +154,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)));
@@ -179,12 +183,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -202,12 +207,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -225,12 +231,13 @@ library ResourceType {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -67,7 +67,16 @@ library SystemHooks {
 
   /** Get value */
   function get(bytes32 resourceSelector) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library SystemHooks {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library SystemHooks {
 
   /** Set value */
   function set(bytes32 resourceSelector, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -93,7 +120,16 @@ library SystemHooks {
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -101,7 +137,16 @@ library SystemHooks {
 
   /** Get the length of value */
   function length(bytes32 resourceSelector) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -110,7 +155,16 @@ library SystemHooks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 resourceSelector) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -119,7 +173,16 @@ library SystemHooks {
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 resourceSelector, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -128,7 +191,16 @@ library SystemHooks {
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 resourceSelector, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -137,7 +209,16 @@ library SystemHooks {
 
   /** Push an element to value */
   function push(bytes32 resourceSelector, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -145,7 +226,16 @@ library SystemHooks {
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 resourceSelector, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -153,7 +243,16 @@ library SystemHooks {
 
   /** Pop an element from value */
   function pop(bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -161,7 +260,16 @@ library SystemHooks {
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -169,7 +277,16 @@ library SystemHooks {
 
   /** Update an element of value at `_index` */
   function update(bytes32 resourceSelector, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -177,7 +294,16 @@ library SystemHooks {
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 resourceSelector, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -193,14 +319,34 @@ library SystemHooks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -208,7 +354,16 @@ library SystemHooks {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -77,12 +77,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -101,12 +102,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -125,12 +127,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -148,12 +151,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -171,12 +175,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -195,12 +200,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -219,12 +225,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -243,12 +250,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -267,12 +275,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -290,12 +299,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -313,12 +323,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -336,12 +347,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -359,12 +371,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -382,12 +395,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -414,12 +428,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -437,12 +452,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -460,12 +476,13 @@ library SystemHooks {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -72,12 +72,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -90,12 +96,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -108,12 +120,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -125,12 +143,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -142,12 +166,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -160,12 +190,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -178,12 +214,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -196,12 +238,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -214,12 +262,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -231,12 +285,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -248,12 +308,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -265,12 +331,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -282,12 +354,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -299,12 +377,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -325,12 +409,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -342,12 +432,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -359,12 +455,18 @@ library SystemHooks {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -77,12 +77,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -101,12 +102,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -125,12 +127,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
@@ -148,12 +151,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
@@ -176,12 +180,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -199,12 +204,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -222,12 +228,13 @@ library SystemRegistry {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(system)));
+    _keyTupleItem = bytes32(uint256(uint160(system)));
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -67,7 +67,16 @@ library SystemRegistry {
 
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library SystemRegistry {
 
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library SystemRegistry {
 
   /** Set resourceSelector */
   function set(address system, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
@@ -93,7 +120,16 @@ library SystemRegistry {
 
   /** Set resourceSelector (using the specified store) */
   function set(IStore _store, address system, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
@@ -105,14 +141,34 @@ library SystemRegistry {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(address system) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(address system) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(address system) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -120,7 +176,16 @@ library SystemRegistry {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, address system) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -72,12 +72,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice32(_blob, 0));
@@ -90,12 +96,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (Bytes.slice32(_blob, 0));
@@ -108,12 +120,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
   }
@@ -125,12 +143,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)));
   }
@@ -147,12 +171,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -164,12 +194,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -181,12 +217,18 @@ library SystemRegistry {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(system)));
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -69,7 +69,16 @@ library Systems {
 
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -78,7 +87,16 @@ library Systems {
 
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -87,7 +105,16 @@ library Systems {
 
   /** Set system */
   function setSystem(bytes32 resourceSelector, address system) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
@@ -95,7 +122,16 @@ library Systems {
 
   /** Set system (using the specified store) */
   function setSystem(IStore _store, bytes32 resourceSelector, address system) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
@@ -103,7 +139,16 @@ library Systems {
 
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -112,7 +157,16 @@ library Systems {
 
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -121,7 +175,16 @@ library Systems {
 
   /** Set publicAccess */
   function setPublicAccess(bytes32 resourceSelector, bool publicAccess) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
@@ -129,7 +192,16 @@ library Systems {
 
   /** Set publicAccess (using the specified store) */
   function setPublicAccess(IStore _store, bytes32 resourceSelector, bool publicAccess) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
@@ -137,7 +209,16 @@ library Systems {
 
   /** Get the full data */
   function get(bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -146,7 +227,16 @@ library Systems {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -157,7 +247,16 @@ library Systems {
   function set(bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -167,7 +266,16 @@ library Systems {
   function set(IStore _store, bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -186,14 +294,34 @@ library Systems {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -201,7 +329,16 @@ library Systems {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = resourceSelector;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -79,12 +79,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -103,12 +104,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -127,12 +129,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
@@ -150,12 +153,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
@@ -173,12 +177,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -197,12 +202,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -221,12 +227,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
@@ -244,12 +251,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
@@ -267,12 +275,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -291,12 +300,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -317,12 +327,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -342,12 +353,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -377,12 +389,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -400,12 +413,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -423,12 +437,13 @@ library Systems {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -74,12 +74,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -92,12 +98,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -110,12 +122,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
   }
@@ -127,12 +145,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)));
   }
@@ -144,12 +168,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -162,12 +192,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -180,12 +216,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
   }
@@ -197,12 +239,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)));
   }
@@ -214,12 +262,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -232,12 +286,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -252,12 +312,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -271,12 +337,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -300,12 +372,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -317,12 +395,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -334,12 +418,18 @@ library Systems {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = resourceSelector;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -88,12 +88,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -106,12 +112,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -124,12 +136,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
@@ -141,12 +159,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
   }
@@ -158,12 +182,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -176,12 +206,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -194,12 +230,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -212,12 +254,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -230,12 +278,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -247,12 +301,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -264,12 +324,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -281,12 +347,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -298,12 +370,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -315,12 +393,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -332,12 +416,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -350,12 +440,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -368,12 +464,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
   }
@@ -385,12 +487,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
   }
@@ -402,12 +510,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 32;
@@ -420,12 +534,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
     return _byteLength / 32;
@@ -438,12 +558,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -456,12 +582,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -474,12 +606,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -491,12 +629,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
   }
@@ -508,12 +652,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32);
   }
@@ -525,12 +675,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 1, 32);
   }
@@ -542,12 +698,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
   }
@@ -559,12 +721,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
   }
@@ -576,12 +744,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -594,12 +768,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -612,12 +792,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
   }
@@ -629,12 +815,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
   }
@@ -646,12 +838,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 32;
@@ -664,12 +862,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
     return _byteLength / 32;
@@ -682,12 +886,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -700,12 +910,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -718,12 +934,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -735,12 +957,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
   }
@@ -752,12 +980,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32);
   }
@@ -769,12 +1003,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 2, 32);
   }
@@ -786,12 +1026,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
   }
@@ -803,12 +1049,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
   }
@@ -820,12 +1072,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -838,12 +1096,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -856,12 +1120,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
   }
@@ -873,12 +1143,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
   }
@@ -890,12 +1166,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 32;
@@ -908,12 +1190,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
     return _byteLength / 32;
@@ -926,12 +1214,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -944,12 +1238,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -962,12 +1262,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -979,12 +1285,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
   }
@@ -996,12 +1308,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32);
   }
@@ -1013,12 +1331,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 3, 32);
   }
@@ -1030,12 +1354,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
   }
@@ -1047,12 +1377,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
   }
@@ -1064,12 +1400,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -1082,12 +1424,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -1100,12 +1448,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
   }
@@ -1117,12 +1471,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
   }
@@ -1134,12 +1494,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 32;
@@ -1152,12 +1518,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
     return _byteLength / 32;
@@ -1170,12 +1542,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -1188,12 +1566,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -1206,12 +1590,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -1223,12 +1613,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
   }
@@ -1240,12 +1636,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32);
   }
@@ -1257,12 +1659,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 4, 32);
   }
@@ -1274,12 +1682,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
   }
@@ -1291,12 +1705,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
   }
@@ -1308,12 +1728,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -1326,12 +1752,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -1353,12 +1785,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1380,12 +1818,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -1467,12 +1911,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -1484,12 +1934,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -1501,12 +1957,18 @@ library KeysInTable {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = sourceTable;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -93,12 +93,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -117,12 +118,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -141,12 +143,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
@@ -164,12 +167,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
@@ -187,12 +191,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -211,12 +216,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -235,12 +241,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -259,12 +266,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -283,12 +291,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -306,12 +315,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -329,12 +339,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -352,12 +363,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -375,12 +387,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -398,12 +411,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -421,12 +435,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -445,12 +460,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -469,12 +485,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
@@ -492,12 +509,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
@@ -515,12 +533,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -539,12 +558,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -563,12 +583,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
@@ -587,12 +608,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
@@ -611,12 +633,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -634,12 +657,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -657,12 +681,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32);
@@ -680,12 +705,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 1, 32);
@@ -703,12 +729,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
@@ -726,12 +753,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
@@ -749,12 +777,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -773,12 +802,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -797,12 +827,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
@@ -820,12 +851,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
@@ -843,12 +875,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -867,12 +900,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -891,12 +925,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
@@ -915,12 +950,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
@@ -939,12 +975,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -962,12 +999,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -985,12 +1023,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32);
@@ -1008,12 +1047,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 2, 32);
@@ -1031,12 +1071,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
@@ -1054,12 +1095,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
@@ -1077,12 +1119,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -1101,12 +1144,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -1125,12 +1169,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
@@ -1148,12 +1193,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
@@ -1171,12 +1217,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -1195,12 +1242,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -1219,12 +1267,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
@@ -1243,12 +1292,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
@@ -1267,12 +1317,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -1290,12 +1341,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -1313,12 +1365,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32);
@@ -1336,12 +1389,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 3, 32);
@@ -1359,12 +1413,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
@@ -1382,12 +1437,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
@@ -1405,12 +1461,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
@@ -1429,12 +1486,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
@@ -1453,12 +1511,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
@@ -1476,12 +1535,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
@@ -1499,12 +1559,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -1523,12 +1584,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -1547,12 +1609,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
@@ -1571,12 +1634,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
@@ -1595,12 +1659,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -1618,12 +1683,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -1641,12 +1707,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32);
@@ -1664,12 +1731,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 4, 32);
@@ -1687,12 +1755,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
@@ -1710,12 +1779,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
@@ -1733,12 +1803,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -1757,12 +1828,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -1790,12 +1862,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -1823,12 +1896,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -1916,12 +1990,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -1939,12 +2014,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -1962,12 +2038,13 @@ library KeysInTable {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -83,7 +83,16 @@ library KeysInTable {
 
   /** Get keys0 */
   function getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -92,7 +101,16 @@ library KeysInTable {
 
   /** Get keys0 (using the specified store) */
   function getKeys0(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -101,7 +119,16 @@ library KeysInTable {
 
   /** Set keys0 */
   function setKeys0(bytes32 sourceTable, bytes32[] memory keys0) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
@@ -109,7 +136,16 @@ library KeysInTable {
 
   /** Set keys0 (using the specified store) */
   function setKeys0(IStore _store, bytes32 sourceTable, bytes32[] memory keys0) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)));
@@ -117,7 +153,16 @@ library KeysInTable {
 
   /** Get the length of keys0 */
   function lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -126,7 +171,16 @@ library KeysInTable {
 
   /** Get the length of keys0 (using the specified store) */
   function lengthKeys0(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -135,7 +189,16 @@ library KeysInTable {
 
   /** Get an item of keys0 (unchecked, returns invalid data if index overflows) */
   function getItemKeys0(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -144,7 +207,16 @@ library KeysInTable {
 
   /** Get an item of keys0 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys0(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -153,7 +225,16 @@ library KeysInTable {
 
   /** Push an element to keys0 */
   function pushKeys0(bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -161,7 +242,16 @@ library KeysInTable {
 
   /** Push an element to keys0 (using the specified store) */
   function pushKeys0(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -169,7 +259,16 @@ library KeysInTable {
 
   /** Pop an element from keys0 */
   function popKeys0(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -177,7 +276,16 @@ library KeysInTable {
 
   /** Pop an element from keys0 (using the specified store) */
   function popKeys0(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -185,7 +293,16 @@ library KeysInTable {
 
   /** Update an element of keys0 at `_index` */
   function updateKeys0(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -193,7 +310,16 @@ library KeysInTable {
 
   /** Update an element of keys0 (using the specified store) at `_index` */
   function updateKeys0(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -201,7 +327,16 @@ library KeysInTable {
 
   /** Get keys1 */
   function getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -210,7 +345,16 @@ library KeysInTable {
 
   /** Get keys1 (using the specified store) */
   function getKeys1(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -219,7 +363,16 @@ library KeysInTable {
 
   /** Set keys1 */
   function setKeys1(bytes32 sourceTable, bytes32[] memory keys1) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
@@ -227,7 +380,16 @@ library KeysInTable {
 
   /** Set keys1 (using the specified store) */
   function setKeys1(IStore _store, bytes32 sourceTable, bytes32[] memory keys1) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)));
@@ -235,7 +397,16 @@ library KeysInTable {
 
   /** Get the length of keys1 */
   function lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -244,7 +415,16 @@ library KeysInTable {
 
   /** Get the length of keys1 (using the specified store) */
   function lengthKeys1(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getSchema());
@@ -253,7 +433,16 @@ library KeysInTable {
 
   /** Get an item of keys1 (unchecked, returns invalid data if index overflows) */
   function getItemKeys1(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
@@ -262,7 +451,16 @@ library KeysInTable {
 
   /** Get an item of keys1 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys1(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getSchema(), _index * 32, (_index + 1) * 32);
@@ -271,7 +469,16 @@ library KeysInTable {
 
   /** Push an element to keys1 */
   function pushKeys1(bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -279,7 +486,16 @@ library KeysInTable {
 
   /** Push an element to keys1 (using the specified store) */
   function pushKeys1(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)));
@@ -287,7 +503,16 @@ library KeysInTable {
 
   /** Pop an element from keys1 */
   function popKeys1(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32);
@@ -295,7 +520,16 @@ library KeysInTable {
 
   /** Pop an element from keys1 (using the specified store) */
   function popKeys1(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 1, 32);
@@ -303,7 +537,16 @@ library KeysInTable {
 
   /** Update an element of keys1 at `_index` */
   function updateKeys1(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
@@ -311,7 +554,16 @@ library KeysInTable {
 
   /** Update an element of keys1 (using the specified store) at `_index` */
   function updateKeys1(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)));
@@ -319,7 +571,16 @@ library KeysInTable {
 
   /** Get keys2 */
   function getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -328,7 +589,16 @@ library KeysInTable {
 
   /** Get keys2 (using the specified store) */
   function getKeys2(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -337,7 +607,16 @@ library KeysInTable {
 
   /** Set keys2 */
   function setKeys2(bytes32 sourceTable, bytes32[] memory keys2) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
@@ -345,7 +624,16 @@ library KeysInTable {
 
   /** Set keys2 (using the specified store) */
   function setKeys2(IStore _store, bytes32 sourceTable, bytes32[] memory keys2) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)));
@@ -353,7 +641,16 @@ library KeysInTable {
 
   /** Get the length of keys2 */
   function lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -362,7 +659,16 @@ library KeysInTable {
 
   /** Get the length of keys2 (using the specified store) */
   function lengthKeys2(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getSchema());
@@ -371,7 +677,16 @@ library KeysInTable {
 
   /** Get an item of keys2 (unchecked, returns invalid data if index overflows) */
   function getItemKeys2(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
@@ -380,7 +695,16 @@ library KeysInTable {
 
   /** Get an item of keys2 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys2(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getSchema(), _index * 32, (_index + 1) * 32);
@@ -389,7 +713,16 @@ library KeysInTable {
 
   /** Push an element to keys2 */
   function pushKeys2(bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -397,7 +730,16 @@ library KeysInTable {
 
   /** Push an element to keys2 (using the specified store) */
   function pushKeys2(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)));
@@ -405,7 +747,16 @@ library KeysInTable {
 
   /** Pop an element from keys2 */
   function popKeys2(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32);
@@ -413,7 +764,16 @@ library KeysInTable {
 
   /** Pop an element from keys2 (using the specified store) */
   function popKeys2(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 2, 32);
@@ -421,7 +781,16 @@ library KeysInTable {
 
   /** Update an element of keys2 at `_index` */
   function updateKeys2(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
@@ -429,7 +798,16 @@ library KeysInTable {
 
   /** Update an element of keys2 (using the specified store) at `_index` */
   function updateKeys2(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)));
@@ -437,7 +815,16 @@ library KeysInTable {
 
   /** Get keys3 */
   function getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3);
@@ -446,7 +833,16 @@ library KeysInTable {
 
   /** Get keys3 (using the specified store) */
   function getKeys3(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 3);
@@ -455,7 +851,16 @@ library KeysInTable {
 
   /** Set keys3 */
   function setKeys3(bytes32 sourceTable, bytes32[] memory keys3) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
@@ -463,7 +868,16 @@ library KeysInTable {
 
   /** Set keys3 (using the specified store) */
   function setKeys3(IStore _store, bytes32 sourceTable, bytes32[] memory keys3) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)));
@@ -471,7 +885,16 @@ library KeysInTable {
 
   /** Get the length of keys3 */
   function lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -480,7 +903,16 @@ library KeysInTable {
 
   /** Get the length of keys3 (using the specified store) */
   function lengthKeys3(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getSchema());
@@ -489,7 +921,16 @@ library KeysInTable {
 
   /** Get an item of keys3 (unchecked, returns invalid data if index overflows) */
   function getItemKeys3(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
@@ -498,7 +939,16 @@ library KeysInTable {
 
   /** Get an item of keys3 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys3(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getSchema(), _index * 32, (_index + 1) * 32);
@@ -507,7 +957,16 @@ library KeysInTable {
 
   /** Push an element to keys3 */
   function pushKeys3(bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -515,7 +974,16 @@ library KeysInTable {
 
   /** Push an element to keys3 (using the specified store) */
   function pushKeys3(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)));
@@ -523,7 +991,16 @@ library KeysInTable {
 
   /** Pop an element from keys3 */
   function popKeys3(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32);
@@ -531,7 +1008,16 @@ library KeysInTable {
 
   /** Pop an element from keys3 (using the specified store) */
   function popKeys3(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 3, 32);
@@ -539,7 +1025,16 @@ library KeysInTable {
 
   /** Update an element of keys3 at `_index` */
   function updateKeys3(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
@@ -547,7 +1042,16 @@ library KeysInTable {
 
   /** Update an element of keys3 (using the specified store) at `_index` */
   function updateKeys3(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)));
@@ -555,7 +1059,16 @@ library KeysInTable {
 
   /** Get keys4 */
   function getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4);
@@ -564,7 +1077,16 @@ library KeysInTable {
 
   /** Get keys4 (using the specified store) */
   function getKeys4(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 4);
@@ -573,7 +1095,16 @@ library KeysInTable {
 
   /** Set keys4 */
   function setKeys4(bytes32 sourceTable, bytes32[] memory keys4) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
@@ -581,7 +1112,16 @@ library KeysInTable {
 
   /** Set keys4 (using the specified store) */
   function setKeys4(IStore _store, bytes32 sourceTable, bytes32[] memory keys4) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)));
@@ -589,7 +1129,16 @@ library KeysInTable {
 
   /** Get the length of keys4 */
   function lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -598,7 +1147,16 @@ library KeysInTable {
 
   /** Get the length of keys4 (using the specified store) */
   function lengthKeys4(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getSchema());
@@ -607,7 +1165,16 @@ library KeysInTable {
 
   /** Get an item of keys4 (unchecked, returns invalid data if index overflows) */
   function getItemKeys4(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
@@ -616,7 +1183,16 @@ library KeysInTable {
 
   /** Get an item of keys4 (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItemKeys4(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getSchema(), _index * 32, (_index + 1) * 32);
@@ -625,7 +1201,16 @@ library KeysInTable {
 
   /** Push an element to keys4 */
   function pushKeys4(bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -633,7 +1218,16 @@ library KeysInTable {
 
   /** Push an element to keys4 (using the specified store) */
   function pushKeys4(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)));
@@ -641,7 +1235,16 @@ library KeysInTable {
 
   /** Pop an element from keys4 */
   function popKeys4(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32);
@@ -649,7 +1252,16 @@ library KeysInTable {
 
   /** Pop an element from keys4 (using the specified store) */
   function popKeys4(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.popFromField(_tableId, _keyTuple, 4, 32);
@@ -657,7 +1269,16 @@ library KeysInTable {
 
   /** Update an element of keys4 at `_index` */
   function updateKeys4(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
@@ -665,7 +1286,16 @@ library KeysInTable {
 
   /** Update an element of keys4 (using the specified store) at `_index` */
   function updateKeys4(IStore _store, bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)));
@@ -673,7 +1303,16 @@ library KeysInTable {
 
   /** Get the full data */
   function get(bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -682,7 +1321,16 @@ library KeysInTable {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -700,7 +1348,16 @@ library KeysInTable {
   ) internal {
     bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -718,7 +1375,16 @@ library KeysInTable {
   ) internal {
     bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -795,14 +1461,34 @@ library KeysInTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -810,7 +1496,16 @@ library KeysInTable {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 sourceTable) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = sourceTable;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -80,18 +80,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -110,18 +111,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -140,18 +142,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
@@ -169,18 +172,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
@@ -198,18 +202,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -228,18 +233,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -258,18 +264,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
@@ -287,18 +294,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
@@ -316,18 +324,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -346,18 +355,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -378,18 +388,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -409,18 +420,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -450,18 +462,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -479,18 +492,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -508,18 +522,19 @@ library UsedKeysIndex {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = sourceTable;
+    _keyTupleItem = sourceTable;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = keysHash;
+    _keyTupleItem = keysHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -75,13 +75,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -94,13 +105,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -113,13 +135,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
   }
@@ -131,13 +164,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)));
   }
@@ -149,13 +193,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (uint40(Bytes.slice5(_blob, 0)));
@@ -168,13 +223,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (uint40(Bytes.slice5(_blob, 0)));
@@ -187,13 +253,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
   }
@@ -205,13 +282,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)));
   }
@@ -223,13 +311,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -242,13 +341,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -263,13 +373,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -283,13 +404,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -313,13 +445,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     return _keyTuple;
   }
@@ -331,13 +474,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -349,13 +503,24 @@ library UsedKeysIndex {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = sourceTable;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = keysHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -70,7 +70,16 @@ library UsedKeysIndex {
 
   /** Get has */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -80,7 +89,16 @@ library UsedKeysIndex {
 
   /** Get has (using the specified store) */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -90,7 +108,16 @@ library UsedKeysIndex {
 
   /** Set has */
   function setHas(bytes32 sourceTable, bytes32 keysHash, bool has) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -99,7 +126,16 @@ library UsedKeysIndex {
 
   /** Set has (using the specified store) */
   function setHas(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -108,7 +144,16 @@ library UsedKeysIndex {
 
   /** Get index */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -118,7 +163,16 @@ library UsedKeysIndex {
 
   /** Get index (using the specified store) */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -128,7 +182,16 @@ library UsedKeysIndex {
 
   /** Set index */
   function setIndex(bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -137,7 +200,16 @@ library UsedKeysIndex {
 
   /** Set index (using the specified store) */
   function setIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -146,7 +218,16 @@ library UsedKeysIndex {
 
   /** Get the full data */
   function get(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -156,7 +237,16 @@ library UsedKeysIndex {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -168,7 +258,16 @@ library UsedKeysIndex {
   function set(bytes32 sourceTable, bytes32 keysHash, bool has, uint40 index) internal {
     bytes memory _data = encode(has, index);
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -179,7 +278,16 @@ library UsedKeysIndex {
   function set(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has, uint40 index) internal {
     bytes memory _data = encode(has, index);
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -199,15 +307,35 @@ library UsedKeysIndex {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 sourceTable, bytes32 keysHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
@@ -216,7 +344,16 @@ library UsedKeysIndex {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -74,12 +74,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -102,12 +103,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -126,12 +128,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
@@ -149,12 +152,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
@@ -172,12 +176,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -196,12 +201,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -220,12 +226,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -244,12 +251,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -268,12 +276,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -291,12 +300,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -314,12 +324,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -337,12 +348,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -360,12 +372,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -383,12 +396,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -415,12 +429,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -438,12 +453,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -461,12 +477,13 @@ library KeysWithValue {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = valueHash;
+    _keyTupleItem = valueHash;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -69,12 +69,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -91,12 +97,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
@@ -109,12 +121,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
   }
@@ -126,12 +144,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
   }
@@ -143,12 +167,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -161,12 +191,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 32;
@@ -179,12 +215,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -197,12 +239,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
     return (Bytes.slice32(_blob, 0));
@@ -215,12 +263,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -232,12 +286,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -249,12 +309,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -266,12 +332,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
   }
@@ -283,12 +355,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -300,12 +378,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
   }
@@ -326,12 +410,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -343,12 +433,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -360,12 +456,18 @@ library KeysWithValue {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = valueHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = valueHash;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -64,7 +64,16 @@ library KeysWithValue {
 
   /** Get keysWithValue */
   function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -77,7 +86,16 @@ library KeysWithValue {
     bytes32 _tableId,
     bytes32 valueHash
   ) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -86,7 +104,16 @@ library KeysWithValue {
 
   /** Set keysWithValue */
   function set(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
@@ -94,7 +121,16 @@ library KeysWithValue {
 
   /** Set keysWithValue (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)));
@@ -102,7 +138,16 @@ library KeysWithValue {
 
   /** Get the length of keysWithValue */
   function length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -111,7 +156,16 @@ library KeysWithValue {
 
   /** Get the length of keysWithValue (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -120,7 +174,16 @@ library KeysWithValue {
 
   /** Get an item of keysWithValue (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -129,7 +192,16 @@ library KeysWithValue {
 
   /** Get an item of keysWithValue (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 32, (_index + 1) * 32);
@@ -138,7 +210,16 @@ library KeysWithValue {
 
   /** Push an element to keysWithValue */
   function push(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -146,7 +227,16 @@ library KeysWithValue {
 
   /** Push an element to keysWithValue (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -154,7 +244,16 @@ library KeysWithValue {
 
   /** Pop an element from keysWithValue */
   function pop(bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32);
@@ -162,7 +261,16 @@ library KeysWithValue {
 
   /** Pop an element from keysWithValue (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     _store.popFromField(_tableId, _keyTuple, 0, 32);
@@ -170,7 +278,16 @@ library KeysWithValue {
 
   /** Update an element of keysWithValue at `_index` */
   function update(bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -178,7 +295,16 @@ library KeysWithValue {
 
   /** Update an element of keysWithValue (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index, bytes32 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)));
@@ -194,14 +320,34 @@ library KeysWithValue {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -209,7 +355,16 @@ library KeysWithValue {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = valueHash;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -63,7 +63,16 @@ library UniqueEntity {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -71,7 +80,16 @@ library UniqueEntity {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -79,14 +97,32 @@ library UniqueEntity {
 
   /** Set value */
   function set(bytes32 _tableId, uint256 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -97,20 +133,49 @@ library UniqueEntity {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -73,8 +73,6 @@ library UniqueEntity {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
   }
@@ -90,8 +88,6 @@ library UniqueEntity {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -109,8 +105,6 @@ library UniqueEntity {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
@@ -125,8 +119,6 @@ library UniqueEntity {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -148,8 +140,6 @@ library UniqueEntity {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     return _keyTuple;
   }
 
@@ -165,8 +155,6 @@ library UniqueEntity {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
@@ -181,8 +169,6 @@ library UniqueEntity {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -68,11 +68,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -85,11 +86,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint256(Bytes.slice32(_blob, 0)));
@@ -102,11 +104,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -118,11 +121,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -139,11 +143,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     return _keyTuple;
   }
@@ -155,11 +160,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -171,11 +177,12 @@ library UniqueEntity {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -82,18 +82,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -116,18 +117,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -146,18 +148,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
@@ -175,18 +178,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
@@ -204,18 +208,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -238,18 +243,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -270,18 +276,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -301,18 +308,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -350,18 +358,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -379,18 +388,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -408,18 +418,19 @@ library InstalledModules {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(moduleName);
+    _keyTupleItem = bytes32(moduleName);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = argumentsHash;
+    _keyTupleItem = argumentsHash;
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -77,13 +77,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -100,13 +111,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -119,13 +141,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
   }
@@ -137,13 +170,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)));
   }
@@ -155,13 +199,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -178,13 +233,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -199,13 +265,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -219,13 +296,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -257,13 +345,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     return _keyTuple;
   }
@@ -275,13 +374,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -293,13 +403,24 @@ library InstalledModules {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(moduleName);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = argumentsHash;
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -72,7 +72,16 @@ library InstalledModules {
 
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -86,7 +95,16 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -96,7 +114,16 @@ library InstalledModules {
 
   /** Set moduleAddress */
   function setModuleAddress(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -105,7 +132,16 @@ library InstalledModules {
 
   /** Set moduleAddress (using the specified store) */
   function setModuleAddress(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -114,7 +150,16 @@ library InstalledModules {
 
   /** Get the full data */
   function get(bytes16 moduleName, bytes32 argumentsHash) internal view returns (InstalledModulesData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -128,7 +173,16 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (InstalledModulesData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -140,7 +194,16 @@ library InstalledModules {
   function set(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -151,7 +214,16 @@ library InstalledModules {
   function set(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
 
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -179,18 +251,35 @@ library InstalledModules {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(
-    bytes16 moduleName,
-    bytes32 argumentsHash
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes16 moduleName, bytes32 argumentsHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes16 moduleName, bytes32 argumentsHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
@@ -199,7 +288,16 @@ library InstalledModules {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 moduleName, bytes32 argumentsHash) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -67,7 +67,16 @@ library NamespaceOwner {
 
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -76,7 +85,16 @@ library NamespaceOwner {
 
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -85,7 +103,16 @@ library NamespaceOwner {
 
   /** Set owner */
   function set(bytes16 namespace, address owner) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
@@ -93,7 +120,16 @@ library NamespaceOwner {
 
   /** Set owner (using the specified store) */
   function set(IStore _store, bytes16 namespace, address owner) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
@@ -105,14 +141,34 @@ library NamespaceOwner {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes16 namespace) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -120,7 +176,16 @@ library NamespaceOwner {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes16 namespace) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = bytes32(namespace);
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -77,12 +77,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -101,12 +102,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -125,12 +127,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
@@ -148,12 +151,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
@@ -176,12 +180,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -199,12 +204,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -222,12 +228,13 @@ library NamespaceOwner {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(namespace);
+    _keyTupleItem = bytes32(namespace);
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -72,12 +72,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -90,12 +96,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (address(Bytes.slice20(_blob, 0)));
@@ -108,12 +120,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
   }
@@ -125,12 +143,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)));
   }
@@ -147,12 +171,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -164,12 +194,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -181,12 +217,18 @@ library NamespaceOwner {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = bytes32(namespace);
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(namespace);
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -78,18 +78,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -108,18 +109,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -138,18 +140,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
@@ -167,18 +170,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
@@ -201,18 +205,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -230,18 +235,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -259,18 +265,19 @@ library ResourceAccess {
       mstore(_keyTuple, 2)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = resourceSelector;
+    _keyTupleItem = resourceSelector;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     /// @solidity memory-safe-assembly
-    _key = bytes32(uint256(uint160(caller)));
+    _keyTupleItem = bytes32(uint256(uint160(caller)));
     assembly {
-      mstore(add(_keyTuple, 64), _key)
+      mstore(add(_keyTuple, 64), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -68,7 +68,16 @@ library ResourceAccess {
 
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
@@ -78,7 +87,16 @@ library ResourceAccess {
 
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
@@ -88,7 +106,16 @@ library ResourceAccess {
 
   /** Set access */
   function set(bytes32 resourceSelector, address caller, bool access) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
@@ -97,7 +124,16 @@ library ResourceAccess {
 
   /** Set access (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, address caller, bool access) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
@@ -110,15 +146,35 @@ library ResourceAccess {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 resourceSelector, address caller) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
@@ -127,7 +183,16 @@ library ResourceAccess {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 resourceSelector, address caller) internal {
-    bytes32[] memory _keyTuple = new bytes32[](2);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 96
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 2)
+    }
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -73,13 +73,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -92,13 +103,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -111,13 +133,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
   }
@@ -129,13 +162,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)));
   }
@@ -152,13 +196,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     return _keyTuple;
   }
@@ -170,13 +225,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -188,13 +254,24 @@ library ResourceAccess {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 96
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 96))
       // Store length
       mstore(_keyTuple, 2)
     }
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = resourceSelector;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
+
+    /// @solidity memory-safe-assembly
+    _key = bytes32(uint256(uint160(caller)));
+    assembly {
+      mstore(add(_keyTuple, 64), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -64,7 +64,16 @@ library AddressArray {
 
   /** Get value */
   function get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -73,7 +82,16 @@ library AddressArray {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -82,7 +100,16 @@ library AddressArray {
 
   /** Set value */
   function set(bytes32 _tableId, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -90,7 +117,16 @@ library AddressArray {
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 key, address[] memory value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -98,7 +134,16 @@ library AddressArray {
 
   /** Get the length of value */
   function length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -107,7 +152,16 @@ library AddressArray {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -116,7 +170,16 @@ library AddressArray {
 
   /** Get an item of value (unchecked, returns invalid data if index overflows) */
   function getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -125,7 +188,16 @@ library AddressArray {
 
   /** Get an item of value (using the specified store) (unchecked, returns invalid data if index overflows) */
   function getItem(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -134,7 +206,16 @@ library AddressArray {
 
   /** Push an element to value */
   function push(bytes32 _tableId, bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -142,7 +223,16 @@ library AddressArray {
 
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 key, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -150,7 +240,16 @@ library AddressArray {
 
   /** Pop an element from value */
   function pop(bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -158,7 +257,16 @@ library AddressArray {
 
   /** Pop an element from value (using the specified store) */
   function pop(IStore _store, bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -166,7 +274,16 @@ library AddressArray {
 
   /** Update an element of value at `_index` */
   function update(bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -174,7 +291,16 @@ library AddressArray {
 
   /** Update an element of value (using the specified store) at `_index` */
   function update(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -190,14 +316,34 @@ library AddressArray {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -205,7 +351,16 @@ library AddressArray {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -74,12 +74,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -98,12 +99,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -122,12 +124,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -145,12 +148,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
@@ -168,12 +172,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -192,12 +197,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
@@ -216,12 +222,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -240,12 +247,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
@@ -264,12 +272,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -287,12 +296,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
@@ -310,12 +320,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
@@ -333,12 +344,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
@@ -356,12 +368,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -379,12 +392,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
@@ -411,12 +425,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     return _keyTuple;
@@ -434,12 +449,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -457,12 +473,13 @@ library AddressArray {
       mstore(_keyTuple, 1)
     }
 
-    bytes32 _key;
+    // Store keys
+    bytes32 _keyTupleItem;
 
     /// @solidity memory-safe-assembly
-    _key = key;
+    _keyTupleItem = key;
     assembly {
-      mstore(add(_keyTuple, 32), _key)
+      mstore(add(_keyTuple, 32), _keyTupleItem)
     }
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -69,12 +69,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -87,12 +93,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
@@ -105,12 +117,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -122,12 +140,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)));
   }
@@ -139,12 +163,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -157,12 +187,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getSchema());
     return _byteLength / 20;
@@ -175,12 +211,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = StoreSwitch.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -193,12 +235,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getSchema(), _index * 20, (_index + 1) * 20);
     return (address(Bytes.slice20(_blob, 0)));
@@ -211,12 +259,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -228,12 +282,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
   }
@@ -245,12 +305,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -262,12 +328,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.popFromField(_tableId, _keyTuple, 0, 20);
   }
@@ -279,12 +351,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -296,12 +374,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)));
   }
@@ -322,12 +406,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     return _keyTuple;
   }
@@ -339,12 +429,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -356,12 +452,18 @@ library AddressArray {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    bytes32 _key;
+
+    /// @solidity memory-safe-assembly
+    _key = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _key)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -63,7 +63,16 @@ library Bool {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -71,7 +80,16 @@ library Bool {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -79,14 +97,32 @@ library Bool {
 
   /** Set value */
   function set(bytes32 _tableId, bool value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bool value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -97,20 +133,49 @@ library Bool {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 _tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 _tableId) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -73,8 +73,6 @@ library Bool {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
@@ -90,8 +88,6 @@ library Bool {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -109,8 +105,6 @@ library Bool {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
@@ -125,8 +119,6 @@ library Bool {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -148,8 +140,6 @@ library Bool {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     return _keyTuple;
   }
 
@@ -165,8 +155,6 @@ library Bool {
       mstore(_keyTuple, 0)
     }
 
-    bytes32 _key;
-
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
@@ -181,8 +169,6 @@ library Bool {
       // Store length
       mstore(_keyTuple, 0)
     }
-
-    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -68,11 +68,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -85,11 +86,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
@@ -102,11 +104,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -118,11 +121,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -139,11 +143,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     return _keyTuple;
   }
@@ -155,11 +160,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -171,11 +177,12 @@ library Bool {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
+
+    bytes32 _key;
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
@@ -66,7 +66,16 @@ library Counter {
 
   /** Get value */
   function get() internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -74,7 +83,16 @@ library Counter {
 
   /** Get value (using the specified store) */
   function get(IStore _store) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -82,14 +100,32 @@ library Counter {
 
   /** Set value */
   function set(uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -100,20 +136,49 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
@@ -71,8 +71,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -88,8 +87,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -105,8 +103,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -121,8 +118,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -142,8 +138,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -158,8 +153,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -174,8 +168,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }

--- a/templates/react/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/react/packages/contracts/src/codegen/tables/Counter.sol
@@ -66,7 +66,16 @@ library Counter {
 
   /** Get value */
   function get() internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -74,7 +83,16 @@ library Counter {
 
   /** Get value (using the specified store) */
   function get(IStore _store) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -82,14 +100,32 @@ library Counter {
 
   /** Set value */
   function set(uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -100,20 +136,49 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/react/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/react/packages/contracts/src/codegen/tables/Counter.sol
@@ -71,8 +71,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -88,8 +87,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -105,8 +103,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -121,8 +118,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -142,8 +138,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -158,8 +153,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -174,8 +168,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -77,7 +77,16 @@ library Position {
 
   /** Get x */
   function getX(bytes32 key) internal view returns (int32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
@@ -86,7 +95,16 @@ library Position {
 
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (int32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
@@ -95,7 +113,16 @@ library Position {
 
   /** Set x */
   function setX(bytes32 key, int32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -103,7 +130,16 @@ library Position {
 
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, int32 x) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
@@ -111,7 +147,16 @@ library Position {
 
   /** Get y */
   function getY(bytes32 key) internal view returns (int32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
@@ -120,7 +165,16 @@ library Position {
 
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (int32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
@@ -129,7 +183,16 @@ library Position {
 
   /** Set y */
   function setY(bytes32 key, int32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -137,7 +200,16 @@ library Position {
 
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, int32 y) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
@@ -145,7 +217,16 @@ library Position {
 
   /** Get z */
   function getZ(bytes32 key) internal view returns (int32 z) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
@@ -154,7 +235,16 @@ library Position {
 
   /** Get z (using the specified store) */
   function getZ(IStore _store, bytes32 key) internal view returns (int32 z) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
@@ -163,7 +253,16 @@ library Position {
 
   /** Set z */
   function setZ(bytes32 key, int32 z) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
@@ -171,7 +270,16 @@ library Position {
 
   /** Set z (using the specified store) */
   function setZ(IStore _store, bytes32 key, int32 z) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
@@ -179,7 +287,16 @@ library Position {
 
   /** Get the full data */
   function get(bytes32 key) internal view returns (PositionData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
@@ -188,7 +305,16 @@ library Position {
 
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (PositionData memory _table) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
@@ -199,7 +325,16 @@ library Position {
   function set(bytes32 key, int32 x, int32 y, int32 z) internal {
     bytes memory _data = encode(x, y, z);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
@@ -209,7 +344,16 @@ library Position {
   function set(IStore _store, bytes32 key, int32 x, int32 y, int32 z) internal {
     bytes memory _data = encode(x, y, z);
 
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.setRecord(_tableId, _keyTuple, _data);
@@ -240,14 +384,34 @@ library Position {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord(bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
@@ -255,7 +419,16 @@ library Position {
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store, bytes32 key) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 64
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 1)
+    }
     _keyTuple[0] = key;
 
     _store.deleteRecord(_tableId, _keyTuple);

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -82,12 +82,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -100,12 +107,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -118,12 +132,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -135,12 +156,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)));
   }
@@ -152,12 +180,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -170,12 +205,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 1);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -188,12 +230,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -205,12 +254,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)));
   }
@@ -222,12 +278,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -240,12 +303,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 2);
     return (int32(uint32(Bytes.slice4(_blob, 0))));
@@ -258,12 +328,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
   }
@@ -275,12 +352,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((z)));
   }
@@ -292,12 +376,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -310,12 +401,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     bytes memory _blob = _store.getRecord(_tableId, _keyTuple, getSchema());
     return decode(_blob);
@@ -330,12 +428,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data);
   }
@@ -349,12 +454,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.setRecord(_tableId, _keyTuple, _data);
   }
@@ -390,12 +502,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     return _keyTuple;
   }
@@ -407,12 +526,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
@@ -424,12 +550,19 @@ library Position {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 64
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 64))
       // Store length
       mstore(_keyTuple, 1)
     }
-    _keyTuple[0] = key;
+
+    // Store keys
+    bytes32 _keyTupleItem;
+
+    /// @solidity memory-safe-assembly
+    _keyTupleItem = key;
+    assembly {
+      mstore(add(_keyTuple, 32), _keyTupleItem)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
@@ -66,7 +66,16 @@ library Counter {
 
   /** Get value */
   function get() internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -74,7 +83,16 @@ library Counter {
 
   /** Get value (using the specified store) */
   function get(IStore _store) internal view returns (uint32 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     bytes memory _blob = _store.getField(_tableId, _keyTuple, 0);
     return (uint32(Bytes.slice4(_blob, 0)));
@@ -82,14 +100,32 @@ library Counter {
 
   /** Set value */
   function set(uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, uint32 value) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)));
   }
@@ -100,20 +136,49 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */
   function deleteRecord() internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple);
   }
 
   /* Delete all data for given keys (using the specified store) */
   function deleteRecord(IStore _store) internal {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32[] memory _keyTuple;
+    /// @solidity memory-safe-assembly
+    assembly {
+      // Allocate memory
+      _keyTuple := mload(0x40)
+      let _keyTupleLength := 32
+      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      // Store length
+      mstore(_keyTuple, 0)
+    }
 
     _store.deleteRecord(_tableId, _keyTuple);
   }

--- a/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
@@ -71,8 +71,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -88,8 +87,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -105,8 +103,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -121,8 +118,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -142,8 +138,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -158,8 +153,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }
@@ -174,8 +168,7 @@ library Counter {
     assembly {
       // Allocate memory
       _keyTuple := mload(0x40)
-      let _keyTupleLength := 32
-      mstore(0x40, add(_keyTuple, _keyTupleLength))
+      mstore(0x40, add(_keyTuple, 32))
       // Store length
       mstore(_keyTuple, 0)
     }


### PR DESCRIPTION
Some experiments with keyTuple optimization, not very significant gas reduction, but significant code bloat (codegen'd assembly, though not nearly as bad as https://github.com/latticexyz/mud/pull/1183 imo)
Not sure if it's worth it, defer to @alvrs 

`commont.ts` is the main change, `renderTable.ts` is a minor one that can be extracted