### PR TITLE
feat(cli,world): batch register function selectors

### DIFF
--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -242,8 +242,7 @@ export async function deploy(
               [toBytes16(namespace), toBytes16(name), worldFunctionSelectors, systemFunctionSelectors],
               confirmations
             );
-            // await fastTxExecute(WorldContract, "registerRootFunctionSelectors", [], confirmations);
-            console.log(chalk.green(`Registered root functions`));
+            console.log(chalk.green(`Registered root functions at ${name} ${namespace}`));
           }
 
           if (nonRootFunctionNames.length) {
@@ -254,7 +253,7 @@ export async function deploy(
               [toBytes16(namespace), toBytes16(name), nonRootFunctionNames, nonRootFunctionArguments],
               confirmations
             );
-            console.log(chalk.green(`Registered non-root functions`));
+            console.log(chalk.green(`Registered non-root functions at ${name} ${namespace}}`));
           }
         }
       }

--- a/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
+++ b/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
@@ -353,6 +353,34 @@
     "inputs": [
       {
         "internalType": "bytes16",
+        "name": "namespaces",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "names",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionName",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionArguments",
+        "type": "string[]"
+      }
+    ],
+    "name": "registerFunctionSelectors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
         "name": "namespace",
         "type": "bytes16"
       },
@@ -416,6 +444,34 @@
         "type": "bytes4"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
+        "name": "namespace",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "name",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "worldFunctionSelectors",
+        "type": "bytes4[]"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "systemFunctionSelectors",
+        "type": "bytes4[]"
+      }
+    ],
+    "name": "registerRootFunctionSelectors",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
+++ b/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
@@ -353,17 +353,17 @@
     "inputs": [
       {
         "internalType": "bytes16",
-        "name": "namespaces",
+        "name": "namespace",
         "type": "bytes16"
       },
       {
         "internalType": "bytes16",
-        "name": "names",
+        "name": "name",
         "type": "bytes16"
       },
       {
         "internalType": "string[]",
-        "name": "systemFunctionName",
+        "name": "systemFunctionNames",
         "type": "string[]"
       },
       {

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
@@ -826,17 +826,17 @@
     "inputs": [
       {
         "internalType": "bytes16",
-        "name": "namespaces",
+        "name": "namespace",
         "type": "bytes16"
       },
       {
         "internalType": "bytes16",
-        "name": "names",
+        "name": "name",
         "type": "bytes16"
       },
       {
         "internalType": "string[]",
-        "name": "systemFunctionName",
+        "name": "systemFunctionNames",
         "type": "string[]"
       },
       {

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
@@ -826,6 +826,34 @@
     "inputs": [
       {
         "internalType": "bytes16",
+        "name": "namespaces",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "names",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionName",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionArguments",
+        "type": "string[]"
+      }
+    ],
+    "name": "registerFunctionSelectors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
         "name": "namespace",
         "type": "bytes16"
       },
@@ -889,6 +917,34 @@
         "type": "bytes4"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
+        "name": "namespace",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "name",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "worldFunctionSelectors",
+        "type": "bytes4[]"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "systemFunctionSelectors",
+        "type": "bytes4[]"
+      }
+    ],
+    "name": "registerRootFunctionSelectors",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/world/abi/IWorldRegistrationSystem.sol/IWorldRegistrationSystem.abi.json
+++ b/packages/world/abi/IWorldRegistrationSystem.sol/IWorldRegistrationSystem.abi.json
@@ -37,17 +37,17 @@
     "inputs": [
       {
         "internalType": "bytes16",
-        "name": "namespaces",
+        "name": "namespace",
         "type": "bytes16"
       },
       {
         "internalType": "bytes16",
-        "name": "names",
+        "name": "name",
         "type": "bytes16"
       },
       {
         "internalType": "string[]",
-        "name": "systemFunctionName",
+        "name": "systemFunctionNames",
         "type": "string[]"
       },
       {

--- a/packages/world/abi/IWorldRegistrationSystem.sol/IWorldRegistrationSystem.abi.json
+++ b/packages/world/abi/IWorldRegistrationSystem.sol/IWorldRegistrationSystem.abi.json
@@ -37,6 +37,34 @@
     "inputs": [
       {
         "internalType": "bytes16",
+        "name": "namespaces",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "names",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionName",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionArguments",
+        "type": "string[]"
+      }
+    ],
+    "name": "registerFunctionSelectors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
         "name": "namespace",
         "type": "bytes16"
       },
@@ -100,6 +128,34 @@
         "type": "bytes4"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
+        "name": "namespace",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "name",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "worldFunctionSelectors",
+        "type": "bytes4[]"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "systemFunctionSelectors",
+        "type": "bytes4[]"
+      }
+    ],
+    "name": "registerRootFunctionSelectors",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
@@ -236,6 +236,34 @@
     "inputs": [
       {
         "internalType": "bytes16",
+        "name": "namespaces",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "names",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionName",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "systemFunctionArguments",
+        "type": "string[]"
+      }
+    ],
+    "name": "registerFunctionSelectors",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
         "name": "namespace",
         "type": "bytes16"
       },
@@ -299,6 +327,34 @@
         "type": "bytes4"
       }
     ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes16",
+        "name": "namespace",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes16",
+        "name": "name",
+        "type": "bytes16"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "worldFunctionSelectors",
+        "type": "bytes4[]"
+      },
+      {
+        "internalType": "bytes4[]",
+        "name": "systemFunctionSelectors",
+        "type": "bytes4[]"
+      }
+    ],
+    "name": "registerRootFunctionSelectors",
+    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
@@ -236,17 +236,17 @@
     "inputs": [
       {
         "internalType": "bytes16",
-        "name": "namespaces",
+        "name": "namespace",
         "type": "bytes16"
       },
       {
         "internalType": "bytes16",
-        "name": "names",
+        "name": "name",
         "type": "bytes16"
       },
       {
         "internalType": "string[]",
-        "name": "systemFunctionName",
+        "name": "systemFunctionNames",
         "type": "string[]"
       },
       {

--- a/packages/world/src/interfaces/IWorldRegistrationSystem.sol
+++ b/packages/world/src/interfaces/IWorldRegistrationSystem.sol
@@ -45,10 +45,24 @@ interface IWorldRegistrationSystem {
     string memory systemFunctionArguments
   ) external returns (bytes4 worldFunctionSelector);
 
+  function registerFunctionSelectors(
+    bytes16 namespaces,
+    bytes16 names,
+    string[] calldata systemFunctionName,
+    string[] calldata systemFunctionArguments
+  ) external;
+
   function registerRootFunctionSelector(
     bytes16 namespace,
     bytes16 name,
     bytes4 worldFunctionSelector,
     bytes4 systemFunctionSelector
   ) external returns (bytes4);
+
+  function registerRootFunctionSelectors(
+    bytes16 namespace,
+    bytes16 name,
+    bytes4[] calldata worldFunctionSelectors,
+    bytes4[] calldata systemFunctionSelectors
+  ) external;
 }

--- a/packages/world/src/interfaces/IWorldRegistrationSystem.sol
+++ b/packages/world/src/interfaces/IWorldRegistrationSystem.sol
@@ -46,9 +46,9 @@ interface IWorldRegistrationSystem {
   ) external returns (bytes4 worldFunctionSelector);
 
   function registerFunctionSelectors(
-    bytes16 namespaces,
-    bytes16 names,
-    string[] calldata systemFunctionName,
+    bytes16 namespace,
+    bytes16 name,
+    string[] calldata systemFunctionNames,
     string[] calldata systemFunctionArguments
   ) external;
 

--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -107,7 +107,7 @@ contract CoreModule is IModule, WorldContext {
    * Register function selectors for all CoreSystem functions in the World
    */
   function _registerFunctionSelectors() internal {
-    bytes4[17] memory functionSelectors = [
+    bytes4[19] memory functionSelectors = [
       // --- WorldRegistrationSystem ---
       WorldRegistrationSystem.registerNamespace.selector,
       WorldRegistrationSystem.registerTable.selector,
@@ -117,7 +117,9 @@ contract CoreModule is IModule, WorldContext {
       WorldRegistrationSystem.registerSystemHook.selector,
       WorldRegistrationSystem.registerSystem.selector,
       WorldRegistrationSystem.registerFunctionSelector.selector,
+      WorldRegistrationSystem.registerFunctionSelectors.selector,
       WorldRegistrationSystem.registerRootFunctionSelector.selector,
+      WorldRegistrationSystem.registerRootFunctionSelectors.selector,
       // --- StoreRegistrationSystem ---
       StoreRegistrationSystem.registerSchema.selector,
       StoreRegistrationSystem.setMetadata.selector,

--- a/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
+++ b/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
@@ -219,13 +219,13 @@ contract WorldRegistrationSystem is System, IWorldErrors {
    * Register World function selectors in batch for the given namespace, name and system function.
    */
   function registerFunctionSelectors(
-    bytes16 namespaces,
-    bytes16 names,
-    string[] calldata systemFunctionName,
+    bytes16 namespace,
+    bytes16 name,
+    string[] calldata systemFunctionNames,
     string[] calldata systemFunctionArguments
   ) public {
-    for (uint256 i = 0; i < systemFunctionName.length; i++) {
-      registerFunctionSelector(namespaces[i], names[i], systemFunctionName[i], systemFunctionArguments[i]);
+    for (uint256 i = 0; i < systemFunctionNames.length; i++) {
+      registerFunctionSelector(namespace, name, systemFunctionNames[i], systemFunctionArguments[i]);
     }
   }
 

--- a/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
+++ b/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
@@ -216,6 +216,20 @@ contract WorldRegistrationSystem is System, IWorldErrors {
   }
 
   /**
+   * Register World function selectors in batch for the given namespace, name and system function.
+   */
+  function registerFunctionSelectors(
+    bytes16 namespaces,
+    bytes16 names,
+    string[] calldata systemFunctionName,
+    string[] calldata systemFunctionArguments
+  ) public {
+    for (uint256 i = 0; i < systemFunctionName.length; i++) {
+      registerFunctionSelector(namespaces[i], names[i], systemFunctionName[i], systemFunctionArguments[i]);
+    }
+  }
+
+  /**
    * Register a root World function selector (without namespace / name prefix).
    * Requires the caller to own the root namespace.
    * TODO: instead of mapping to a resource, the function selector could map direcly to a system function,
@@ -241,5 +255,21 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     FunctionSelectors.set(worldFunctionSelector, namespace, name, systemFunctionSelector);
 
     return worldFunctionSelector;
+  }
+
+  /**
+   * Register root World function selectors in batch (without namespace / name prefix).
+   * Requires the caller to own the root namespace.
+   */
+  function registerRootFunctionSelectors(
+    bytes16 namespace,
+    bytes16 name,
+    bytes4[] calldata worldFunctionSelectors,
+    bytes4[] calldata systemFunctionSelectors
+  ) public {
+    // Register the function selectors
+    for (uint256 i = 0; i < worldFunctionSelectors.length; i++) {
+      registerRootFunctionSelector(namespace, name, worldFunctionSelectors[i], systemFunctionSelectors[i]);
+    }
   }
 }


### PR DESCRIPTION
Optimized the process of function registration in the deploy phase by changing from individual transaction registration per function to batch registration per system.

Prior to the optimization, each public function within a system required a separate transaction for registration. This led to a significant number of transactions during actual production deployment, resulting in excessive gas fees and an increased risk of failure. In the testing environment, function registration also constituted a major time-consuming aspect of deploying complex on-chain applications.

After this optimization, functions with the same namespace and system are grouped together for registration, reducing the number of transactions required for function registration to match the number of systems. This decrease in transaction count reduces both the gas fee and deployment time needed.

An assumption here is that the number of functions within a single system will not surpass the gas limit of an individual transaction. Hence, automatic transaction batch splitting hasn't been implemented. Take the root functions as an example, with each additional function, there's an increase in parameter size by 8 bytes (4 + 4), storage writes by 40 bytes (4 + 4 + 16 + 16), two storage reads, and relevant logical operations (including simple type conversions and conditional checks). Gas consumption can be estimated as follows: in a hypothetical extreme scenario where a single system contract contains 400 functions, it would consume approximately 12,000,000 Gas – calldata writes: 51,200 Gas (16 * 8 * 400), storage writes: 10,000,000 Gas (400 * 40 / 32 * 20000), storage reads: 1,680,000 Gas (2100 * 2 * 200). Logical calculations are negligible. This totals to about 12,000,000 Gas. The current Block Gas Limit of mainstream EVM chains, such as 30,000,000, exceeds the consumption of 400 functions within a single system, thus avoiding any issues of exceeding the Gas Limit and preventing transaction submission. Therefore, transaction splitting has not been implemented for now. As for the non root functions, system contracts should not contains that much functions too.

If this implementation approach for optimization is acceptable, the PR for batch optimization related to system and table registration can proceed.

fix #1280