### PR TITLE
refactor(store): use _keyTupleDefinition in encodeKeyTuple

### DIFF
--- a/e2e/packages/contracts/src/codegen/tables/Multi.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Multi.sol
@@ -240,12 +240,14 @@ library Multi {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 a, bool b, uint256 c, int120 d) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](4);
+  function encodeKeyTuple(uint32 a, bool b, uint256 c, int120 d) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](4);
     _keyTuple[0] = bytes32(uint256(a));
     _keyTuple[1] = _boolToBytes32(b);
     _keyTuple[2] = bytes32(uint256(c));
     _keyTuple[3] = bytes32(uint256(int256(d)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/e2e/packages/contracts/src/codegen/tables/Number.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Number.sol
@@ -105,9 +105,11 @@ library Number {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(key));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/e2e/packages/contracts/src/codegen/tables/NumberList.sol
+++ b/e2e/packages/contracts/src/codegen/tables/NumberList.sol
@@ -202,8 +202,10 @@ library NumberList {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/e2e/packages/contracts/src/codegen/tables/Vector.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Vector.sol
@@ -201,9 +201,11 @@ library Vector {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(uint32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(key));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/CounterTable.sol
@@ -100,8 +100,10 @@ library CounterTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/Inventory.sol
@@ -115,15 +115,13 @@ library Inventory {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(
-    address owner,
-    uint32 item,
-    uint32 itemVariant
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](3);
+  function encodeKeyTuple(address owner, uint32 item, uint32 itemVariant) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](3);
     _keyTuple[0] = bytes32(uint256(uint160(owner)));
     _keyTuple[1] = bytes32(uint256(item));
     _keyTuple[2] = bytes32(uint256(itemVariant));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
+++ b/examples/minimal/packages/contracts/src/codegen/tables/MessageTable.sol
@@ -92,7 +92,9 @@ library MessageTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -947,9 +947,11 @@ library Dynamics1 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -593,9 +593,11 @@ library Dynamics2 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -91,8 +91,10 @@ library Ephemeral {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -580,8 +580,10 @@ library Singleton {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -885,8 +885,8 @@ library Statics {
     bool k5,
     Enum1 k6,
     Enum2 k7
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](7);
+  ) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](7);
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
@@ -894,6 +894,8 @@ library Statics {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -224,9 +224,11 @@ library Callbacks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -224,9 +224,11 @@ library Hooks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -164,14 +164,16 @@ library KeyEncoding {
     address k4,
     bool k5,
     ExampleEnum k6
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](6);
+  ) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](6);
     _keyTuple[0] = bytes32(uint256(k1));
     _keyTuple[1] = bytes32(uint256(int256(k2)));
     _keyTuple[2] = bytes32(k3);
     _keyTuple[3] = bytes32(uint256(uint160(k4)));
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -519,9 +519,11 @@ library Mixed {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/StoreMetadata.sol
+++ b/packages/store/src/codegen/tables/StoreMetadata.sol
@@ -448,9 +448,11 @@ library StoreMetadata {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 tableId) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 tableId) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -201,9 +201,11 @@ library Vector2 {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -135,9 +135,9 @@ library ${libraryName} {
   }
   
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(${renderArguments([_typedKeyArgs])}) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](${keyTuple.length});
-    ${renderList(keyTuple, (key, index) => `_keyTuple[${index}] = ${renderValueTypeToBytes32(key.name, key)};`)}
+  function encodeKeyTuple(${renderArguments([_typedKeyArgs])}) internal pure returns (bytes32[] memory) {
+    ${_keyTupleDefinition}
+    return _keyTuple;
   }
 
   ${

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -240,9 +240,11 @@ library FunctionSelectors {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -108,9 +108,11 @@ library ResourceType {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -224,9 +224,11 @@ library SystemHooks {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -105,9 +105,11 @@ library SystemRegistry {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(address system) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(address system) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -186,9 +186,11 @@ library Systems {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -961,9 +961,11 @@ library KeysInTable {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -199,10 +199,12 @@ library UsedKeysIndex {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -225,9 +225,11 @@ library KeysWithValue {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -97,8 +97,10 @@ library UniqueEntity {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -179,13 +179,12 @@ library InstalledModules {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(
-    bytes16 moduleName,
-    bytes32 argumentsHash
-  ) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes16 moduleName, bytes32 argumentsHash) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -105,9 +105,11 @@ library NamespaceOwner {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -110,10 +110,12 @@ library ResourceAccess {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](2);
+  function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -221,9 +221,11 @@ library AddressArray {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -97,8 +97,10 @@ library Bool {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/phaser/packages/contracts/src/codegen/tables/Counter.sol
@@ -100,8 +100,10 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/templates/react/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/react/packages/contracts/src/codegen/tables/Counter.sol
@@ -100,8 +100,10 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -240,9 +240,11 @@ library Position {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](1);
+  function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */

--- a/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
+++ b/templates/vanilla/packages/contracts/src/codegen/tables/Counter.sol
@@ -100,8 +100,10 @@ library Counter {
   }
 
   /** Encode keys as a bytes32 array using this table's schema */
-  function encodeKeyTuple() internal pure returns (bytes32[] memory _keyTuple) {
-    _keyTuple = new bytes32[](0);
+  function encodeKeyTuple() internal pure returns (bytes32[] memory) {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    return _keyTuple;
   }
 
   /* Delete all data for given keys */


### PR DESCRIPTION
originally `_keyTupleDefinition` rendered a call to `encodeKeyTuple`, but now `_keyTupleDefinition` is inlined and so `encodeKeyTuple` should use it instead