### PR TITLE
test: only start up indexer for online tests

### DIFF
--- a/e2e/packages/sync-test/indexerSync.test.ts
+++ b/e2e/packages/sync-test/indexerSync.test.ts
@@ -29,8 +29,6 @@ describe("Sync from indexer", async () => {
   let webserver: ViteDevServer;
   let browser: Browser;
   let page: Page;
-  let indexerIteration = 1;
-  let indexer: ReturnType<typeof startIndexer>;
 
   beforeEach(async () => {
     await deployContracts(rpcHttpUrl);
@@ -40,67 +38,75 @@ describe("Sync from indexer", async () => {
     const browserAndPage = await startBrowserAndPage(asyncErrorHandler.reportError);
     browser = browserAndPage.browser;
     page = browserAndPage.page;
-
-    // Start indexer
-    const port = 3000 + indexerIteration++;
-    indexer = startIndexer(port, path.join(__dirname, `anvil-${port}.db`), rpcHttpUrl, asyncErrorHandler.reportError);
-    await indexer.doneSyncing;
   });
 
   afterEach(async () => {
     await browser.close();
     await webserver.close();
-    await indexer.kill();
     asyncErrorHandler.resetErrors();
   });
 
-  test("should sync test data", async () => {
-    await openClientWithRootAccount(page, { indexerUrl: indexer.url });
-    await waitForInitialSync(page);
-
-    // Write data to the contracts, expect the client to be synced
-    await setContractData(page, testData1);
-    await expectClientData(page, testData1);
-
-    // Write more data to the contracts, expect client to update
-    await setContractData(page, testData2);
-    await expectClientData(page, mergeTestData(testData1, testData2));
-
-    // Reload the page, expect all data to still be set
-    await page.reload();
-    await waitForInitialSync(page);
-    await expectClientData(page, mergeTestData(testData1, testData2));
-
-    asyncErrorHandler.expectNoAsyncErrors();
-  });
-
-  test("should log error if indexer is down", async () => {
-    await indexer.kill();
-
-    await openClientWithRootAccount(page, { indexerUrl: indexer.url });
+  test("should log error if indexer is offline", async () => {
+    await openClientWithRootAccount(page, { indexerUrl: `http://127.0.0.1:9999/trpc` });
     await waitForInitialSync(page);
 
     expect(asyncErrorHandler.getErrors()).toHaveLength(1);
     expect(asyncErrorHandler.getErrors()[0]).toContain("couldn't get initial state from indexer");
   });
 
-  test("should sync number list modified via system", async () => {
-    await openClientWithRootAccount(page, { indexerUrl: indexer.url });
-    await waitForInitialSync(page);
+  describe("indexer online", () => {
+    let indexerIteration = 1;
+    let indexer: ReturnType<typeof startIndexer>;
 
-    // Push one element to the array
-    await push(page, 42);
-    await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42] } }] });
+    beforeEach(async () => {
+      // Start indexer
+      const port = 3000 + indexerIteration++;
+      indexer = startIndexer(port, path.join(__dirname, `anvil-${port}.db`), rpcHttpUrl, asyncErrorHandler.reportError);
+      await indexer.doneSyncing;
+    });
 
-    // Push 5000 elements to the array
-    await pushRange(page, 0, 5000);
-    await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(5000, 1, 0)] } }] });
+    afterEach(async () => {
+      await indexer.kill();
+    });
 
-    // Pop one element from the array
-    await pop(page);
-    await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(4999, 1, 0)] } }] });
+    test("should sync test data", async () => {
+      await openClientWithRootAccount(page, { indexerUrl: indexer.url });
+      await waitForInitialSync(page);
 
-    // Should not have thrown errors
-    asyncErrorHandler.expectNoAsyncErrors();
+      // Write data to the contracts, expect the client to be synced
+      await setContractData(page, testData1);
+      await expectClientData(page, testData1);
+
+      // Write more data to the contracts, expect client to update
+      await setContractData(page, testData2);
+      await expectClientData(page, mergeTestData(testData1, testData2));
+
+      // Reload the page, expect all data to still be set
+      await page.reload();
+      await waitForInitialSync(page);
+      await expectClientData(page, mergeTestData(testData1, testData2));
+
+      asyncErrorHandler.expectNoAsyncErrors();
+    });
+
+    test("should sync number list modified via system", async () => {
+      await openClientWithRootAccount(page, { indexerUrl: indexer.url });
+      await waitForInitialSync(page);
+
+      // Push one element to the array
+      await push(page, 42);
+      await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42] } }] });
+
+      // Push 5000 elements to the array
+      await pushRange(page, 0, 5000);
+      await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(5000, 1, 0)] } }] });
+
+      // Pop one element from the array
+      await pop(page);
+      await expectClientData(page, { NumberList: [{ key: {}, value: { value: [42, ...range(4999, 1, 0)] } }] });
+
+      // Should not have thrown errors
+      asyncErrorHandler.expectNoAsyncErrors();
+    });
   });
 });


### PR DESCRIPTION
CI is flaky when attempting to start then immediately kill the indexer. This updates tests to only start the indexer when we actually want to use it.