### PR TITLE
Update getting-started.mdx

### DIFF
--- a/docs/pages/tutorials/emojimon/getting-started.mdx
+++ b/docs/pages/tutorials/emojimon/getting-started.mdx
@@ -4,7 +4,7 @@
 
 1. git ([download](https://git-scm.com/downloads))
 2. foundry (forge, anvil, cast) ([download](https://book.getfoundry.sh/getting-started/installation), make sure to `foundryup` at least once)
-3. node.js (v16+) ([download](https://nodejs.org/en/download/))
+3. node.js (v17+) ([download](https://nodejs.org/en/download/))
 4. pnpm (`npm install pnpm --global` after installing node)
 
 ## Setup


### PR DESCRIPTION
Updated the Emojimon getting started instructions to use node v17+ since earlier versions of node do not support direct json imports and would result in the following error

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".json"
```