### PR TITLE
`forge fmt`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "solidity.monoRepoSupport": true
+  "solidity.monoRepoSupport": true,
+  "solidity.formatter": "forge",
+  "[solidity]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "JuanBlanco.solidity"
+  }
 }

--- a/e2e/packages/contracts/foundry.toml
+++ b/e2e/packages/contracts/foundry.toml
@@ -23,6 +23,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/e2e/packages/contracts/foundry.toml
+++ b/e2e/packages/contracts/foundry.toml
@@ -20,5 +20,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/examples/minimal/packages/contracts/foundry.toml
+++ b/examples/minimal/packages/contracts/foundry.toml
@@ -23,6 +23,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/examples/minimal/packages/contracts/foundry.toml
+++ b/examples/minimal/packages/contracts/foundry.toml
@@ -20,5 +20,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/packages/cli/foundry.toml
+++ b/packages/cli/foundry.toml
@@ -14,3 +14,4 @@ test = "contracts/test"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/cli/foundry.toml
+++ b/packages/cli/foundry.toml
@@ -10,3 +10,7 @@ allow_paths = ["../../node_modules", "../"]
 src = "contracts/src"
 out = "contracts/out"
 test = "contracts/test"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/gas-report/foundry.toml
+++ b/packages/gas-report/foundry.toml
@@ -9,3 +9,7 @@ allow_paths= ["../../node_modules"]
 src = "src"
 out = "out"
 bytecode_hash = "none"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/gas-report/foundry.toml
+++ b/packages/gas-report/foundry.toml
@@ -13,3 +13,4 @@ bytecode_hash = "none"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/noise/contracts/Perlin.sol
+++ b/packages/noise/contracts/Perlin.sol
@@ -165,21 +165,24 @@ library Perlin {
 
   /**
    * Computes t * t * t * (t * (t * 6 - 15) + 10)
-   **/
+   *
+   */
   function fade(int128 t) internal pure returns (int128) {
     return Math.mul(t, Math.mul(t, Math.mul(t, (Math.add(Math.mul(t, (Math.sub(Math.mul(t, _6), _15))), _10)))));
   }
 
   /**
    * Computes a + t * (b - a)
-   **/
+   *
+   */
   function lerp(int128 t, int128 a, int128 b) internal pure returns (int128) {
     return Math.add(a, Math.mul(t, (Math.sub(b, a))));
   }
 
   /**
    * Modified from original perlin paper based on http://riven8192.blogspot.com/2010/08/calculate-perlinnoise-twice-as-fast.html
-   **/
+   *
+   */
   function grad(int16 _hash, int128 x, int128 y, int128 z) internal pure returns (int128) {
     // Convert lower 4 bits to hash code into 12 gradient directions
     int16 h = _hash & 0xF;
@@ -225,7 +228,8 @@ library Perlin {
 
   /**
    * Modified from original perlin paper based on http://riven8192.blogspot.com/2010/08/calculate-perlinnoise-twice-as-fast.html
-   **/
+   *
+   */
   function grad2d(int16 _hash, int128 x, int128 y) internal pure returns (int128) {
     // Convert lower 4 bits to hash code into 12 gradient directions
     int16 h = _hash & 0xF;

--- a/packages/noise/foundry.toml
+++ b/packages/noise/foundry.toml
@@ -12,3 +12,4 @@ out = "out"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/noise/foundry.toml
+++ b/packages/noise/foundry.toml
@@ -8,3 +8,7 @@ verbosity = 2
 allow_paths = ["../../node_modules"]
 src = "contracts"
 out = "out"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/schema-type/foundry.toml
+++ b/packages/schema-type/foundry.toml
@@ -13,3 +13,4 @@ test = "test/solidity"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/schema-type/foundry.toml
+++ b/packages/schema-type/foundry.toml
@@ -9,3 +9,7 @@ allow_paths = ["../../node_modules"]
 src = "src/solidity"
 out = "out/solidity"
 test = "test/solidity"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/solecs/foundry.toml
+++ b/packages/solecs/foundry.toml
@@ -8,3 +8,7 @@ verbosity = 2
 allow_paths = ["../../node_modules"]
 src = "src"
 out = "out"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/solecs/foundry.toml
+++ b/packages/solecs/foundry.toml
@@ -12,3 +12,4 @@ out = "out"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/solecs/src/BareComponent.sol
+++ b/packages/solecs/src/BareComponent.sol
@@ -20,13 +20,19 @@ import { OwnableWritable } from "./OwnableWritable.sol";
 abstract contract BareComponent is IComponent, OwnableWritable {
   error BareComponent__NotImplemented();
 
-  /** Reference to the World contract this component is registered in */
+  /**
+   * Reference to the World contract this component is registered in
+   */
   address public world;
 
-  /** Mapping from entity id to value in this component */
+  /**
+   * Mapping from entity id to value in this component
+   */
   mapping(uint256 => bytes) internal entityToValue;
 
-  /** Public identifier of this component */
+  /**
+   * Public identifier of this component
+   */
   uint256 public id;
 
   constructor(address _world, uint256 _id) {
@@ -81,17 +87,23 @@ abstract contract BareComponent is IComponent, OwnableWritable {
     return entityToValue[entity];
   }
 
-  /** Not implemented in BareComponent */
+  /**
+   * Not implemented in BareComponent
+   */
   function getEntities() public view virtual override returns (uint256[] memory) {
     revert BareComponent__NotImplemented();
   }
 
-  /** Not implemented in BareComponent */
+  /**
+   * Not implemented in BareComponent
+   */
   function getEntitiesWithValue(bytes memory) public view virtual override returns (uint256[] memory) {
     revert BareComponent__NotImplemented();
   }
 
-  /** Not implemented in BareComponent */
+  /**
+   * Not implemented in BareComponent
+   */
   function registerIndexer(address) external virtual override {
     revert BareComponent__NotImplemented();
   }

--- a/packages/solecs/src/Component.sol
+++ b/packages/solecs/src/Component.sol
@@ -17,13 +17,19 @@ import { LibTypes } from "./LibTypes.sol";
  * Everyone has read access.
  */
 abstract contract Component is BareComponent {
-  /** Set of entities with values in this component */
+  /**
+   * Set of entities with values in this component
+   */
   Set internal entities;
 
-  /** Reverse mapping from value to set of entities */
+  /**
+   * Reverse mapping from value to set of entities
+   */
   MapSet internal valueToEntities;
 
-  /** List of indexers to be updated when a component value changes */
+  /**
+   * List of indexers to be updated when a component value changes
+   */
   IEntityIndexer[] internal indexers;
 
   constructor(address _world, uint256 _id) BareComponent(_world, _id) {

--- a/packages/solecs/src/OwnableWritable.sol
+++ b/packages/solecs/src/OwnableWritable.sol
@@ -12,12 +12,16 @@ import { OwnableWritableStorage } from "./OwnableWritableStorage.sol";
 abstract contract OwnableWritable is IOwnableWritable, Ownable {
   error OwnableWritable__NotWriter();
 
-  /** Whether given operator has write access */
+  /**
+   * Whether given operator has write access
+   */
   function writeAccess(address operator) public view virtual returns (bool) {
     return OwnableWritableStorage.layout().writeAccess[operator] || operator == owner();
   }
 
-  /** Revert if caller does not have write access to this component */
+  /**
+   * Revert if caller does not have write access to this component
+   */
   modifier onlyWriter() {
     if (!writeAccess(msg.sender)) {
       revert OwnableWritable__NotWriter();

--- a/packages/solecs/src/OwnableWritableStorage.sol
+++ b/packages/solecs/src/OwnableWritableStorage.sol
@@ -3,7 +3,9 @@ pragma solidity >=0.8.0;
 
 library OwnableWritableStorage {
   struct Layout {
-    /** Addresses with write access */
+    /**
+     * Addresses with write access
+     */
     mapping(address => bool) writeAccess;
   }
 

--- a/packages/solecs/src/SystemStorage.sol
+++ b/packages/solecs/src/SystemStorage.sol
@@ -13,13 +13,17 @@ import { getSystemAddressById, getAddressById } from "./utils.sol";
  * The intialization is done automatically for any contract inheriting System or MudTest.
  */
 library SystemStorage {
-  /** Data that the system stores */
+  /**
+   * Data that the system stores
+   */
   struct Layout {
     IUint256Component components;
     IWorld world;
   }
 
-  /** Location in memory where the Layout struct will be stored */
+  /**
+   * Location in memory where the Layout struct will be stored
+   */
   bytes32 internal constant STORAGE_SLOT = keccak256("solecs.contracts.storage.System");
 
   /**

--- a/packages/solecs/src/World.sol
+++ b/packages/solecs/src/World.sol
@@ -141,17 +141,23 @@ contract World is IWorld {
     emit ComponentValueRemoved(getIdByAddress(_components, msg.sender), msg.sender, entity);
   }
 
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
+  /**
+   * Deprecated, but left here for backward compatibility. TODO: refactor all consumers.
+   */
   function getComponent(uint256 id) external view returns (address) {
     return getAddressById(_components, id);
   }
 
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
+  /**
+   * Deprecated, but left here for backward compatibility. TODO: refactor all consumers.
+   */
   function getComponentIdFromAddress(address componentAddr) external view returns (uint256) {
     return getIdByAddress(_components, componentAddr);
   }
 
-  /** Deprecated, but left here for backward compatibility. TODO: refactor all consumers. */
+  /**
+   * Deprecated, but left here for backward compatibility. TODO: refactor all consumers.
+   */
   function getSystemAddress(uint256 systemId) external view returns (address) {
     return getAddressById(_systems, systemId);
   }

--- a/packages/solecs/src/interfaces/IComponent.sol
+++ b/packages/solecs/src/interfaces/IComponent.sol
@@ -5,7 +5,9 @@ import { IOwnableWritable } from "./IOwnableWritable.sol";
 import { LibTypes } from "../LibTypes.sol";
 
 interface IComponent is IOwnableWritable {
-  /** Return the keys and value types of the schema of this component. */
+  /**
+   * Return the keys and value types of the schema of this component.
+   */
   function getSchema() external pure returns (string[] memory keys, LibTypes.SchemaValue[] memory values);
 
   function set(uint256 entity, bytes memory value) external;

--- a/packages/solecs/src/test/Component.t.sol
+++ b/packages/solecs/src/test/Component.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";

--- a/packages/solecs/src/test/components/DamageComponent.sol
+++ b/packages/solecs/src/test/components/DamageComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 

--- a/packages/solecs/src/test/components/FromPrototypeComponent.sol
+++ b/packages/solecs/src/test/components/FromPrototypeComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 

--- a/packages/solecs/src/test/components/OwnedByEntityComponent.sol
+++ b/packages/solecs/src/test/components/OwnedByEntityComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 

--- a/packages/solecs/src/test/components/PrototypeTagComponent.sol
+++ b/packages/solecs/src/test/components/PrototypeTagComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 

--- a/packages/solecs/src/test/components/TestComponent.sol
+++ b/packages/solecs/src/test/components/TestComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "../../Component.sol";
 import { LibTypes } from "../../LibTypes.sol";
 

--- a/packages/solecs/src/utils.sol
+++ b/packages/solecs/src/utils.sol
@@ -6,30 +6,40 @@ import { IComponent } from "./interfaces/IComponent.sol";
 import { ISystem } from "./interfaces/ISystem.sol";
 import { systemsComponentId } from "./constants.sol";
 
-/** Turn an entity ID into its corresponding Ethereum address. */
+/**
+ * Turn an entity ID into its corresponding Ethereum address.
+ */
 function entityToAddress(uint256 entity) pure returns (address) {
   return address(uint160(entity));
 }
 
-/** Turn an Ethereum address into its corresponding entity ID. */
+/**
+ * Turn an Ethereum address into its corresponding entity ID.
+ */
 function addressToEntity(address addr) pure returns (uint256) {
   return uint256(uint160(addr));
 }
 
-/** Get an Ethereum address from an address/id registry component (like _components/_systems in World.sol) */
+/**
+ * Get an Ethereum address from an address/id registry component (like _components/_systems in World.sol)
+ */
 function getAddressById(IUint256Component registry, uint256 id) view returns (address) {
   uint256[] memory entities = registry.getEntitiesWithValue(id);
   require(entities.length != 0, "id not registered");
   return entityToAddress(entities[0]);
 }
 
-/** Get an entity id from an address/id registry component (like _components/_systems in World.sol) */
+/**
+ * Get an entity id from an address/id registry component (like _components/_systems in World.sol)
+ */
 function getIdByAddress(IUint256Component registry, address addr) view returns (uint256) {
   require(registry.has(addressToEntity(addr)), "address not registered");
   return registry.getValue(addressToEntity(addr));
 }
 
-/** Get a Component from an address/id registry component (like _components in World.sol) */
+/**
+ * Get a Component from an address/id registry component (like _components in World.sol)
+ */
 function getComponentById(IUint256Component components, uint256 id) view returns (IComponent) {
   return IComponent(getAddressById(components, id));
 }
@@ -51,7 +61,9 @@ function getSystemById(IUint256Component components, uint256 id) view returns (I
   return ISystem(getSystemAddressById(components, id));
 }
 
-/** Split a single bytes blob into an array of bytes of the given length */
+/**
+ * Split a single bytes blob into an array of bytes of the given length
+ */
 function split(bytes memory data, uint8[] memory lengths) pure returns (bytes[] memory) {
   bytes[] memory unpacked = new bytes[](lengths.length);
   uint256 sum = 0;

--- a/packages/std-contracts/foundry.toml
+++ b/packages/std-contracts/foundry.toml
@@ -8,3 +8,7 @@ verbosity = 2
 allow_paths = ["../../node_modules", "../solecs"]
 src = "src"
 out = "out"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/std-contracts/foundry.toml
+++ b/packages/std-contracts/foundry.toml
@@ -12,3 +12,4 @@ out = "out"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/std-contracts/src/components/AddressBareComponent.sol
+++ b/packages/std-contracts/src/components/AddressBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract AddressBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/AddressComponent.sol
+++ b/packages/std-contracts/src/components/AddressComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract AddressComponent is Component {

--- a/packages/std-contracts/src/components/BoolBareComponent.sol
+++ b/packages/std-contracts/src/components/BoolBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract BoolBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/BoolComponent.sol
+++ b/packages/std-contracts/src/components/BoolComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract BoolComponent is Component {

--- a/packages/std-contracts/src/components/CoordBareComponent.sol
+++ b/packages/std-contracts/src/components/CoordBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 struct Coord {

--- a/packages/std-contracts/src/components/CoordComponent.sol
+++ b/packages/std-contracts/src/components/CoordComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 struct Coord {

--- a/packages/std-contracts/src/components/FunctionBareComponent.sol
+++ b/packages/std-contracts/src/components/FunctionBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 struct FunctionSelector {

--- a/packages/std-contracts/src/components/FunctionComponent.sol
+++ b/packages/std-contracts/src/components/FunctionComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 struct FunctionSelector {

--- a/packages/std-contracts/src/components/Int32BareComponent.sol
+++ b/packages/std-contracts/src/components/Int32BareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract Int32BareComponent is BareComponent {

--- a/packages/std-contracts/src/components/Int32Component.sol
+++ b/packages/std-contracts/src/components/Int32Component.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract Int32Component is Component {

--- a/packages/std-contracts/src/components/StringArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract StringArrayBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/StringArrayComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract StringArrayComponent is Component {

--- a/packages/std-contracts/src/components/StringBareComponent.sol
+++ b/packages/std-contracts/src/components/StringBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract StringBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/StringComponent.sol
+++ b/packages/std-contracts/src/components/StringComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract StringComponent is Component {

--- a/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract Uint256ArrayBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/Uint256ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract Uint256ArrayComponent is Component {

--- a/packages/std-contracts/src/components/Uint256BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256BareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 /**

--- a/packages/std-contracts/src/components/Uint256Component.sol
+++ b/packages/std-contracts/src/components/Uint256Component.sol
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/components/Uint256Component.sol";

--- a/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract Uint32ArrayBareComponent is BareComponent {

--- a/packages/std-contracts/src/components/Uint32ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract Uint32ArrayComponent is Component {

--- a/packages/std-contracts/src/components/Uint32BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32BareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 contract Uint32BareComponent is BareComponent {

--- a/packages/std-contracts/src/components/Uint32Component.sol
+++ b/packages/std-contracts/src/components/Uint32Component.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 contract Uint32Component is Component {

--- a/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/BareComponent.sol";
 
 struct VoxelCoord {

--- a/packages/std-contracts/src/components/VoxelCoordComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/Component.sol";
 
 struct VoxelCoord {

--- a/packages/std-contracts/src/libraries/LibUtils.sol
+++ b/packages/std-contracts/src/libraries/LibUtils.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
+
 import { World, WorldQueryFragment } from "solecs/World.sol";
 import { QueryFragment, QueryType, LibQuery } from "solecs/LibQuery.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";

--- a/packages/std-contracts/src/systems/BulkSetStateSystem.sol
+++ b/packages/std-contracts/src/systems/BulkSetStateSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/System.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";

--- a/packages/std-contracts/src/systems/ComponentDevSystem.sol
+++ b/packages/std-contracts/src/systems/ComponentDevSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/System.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { IUint256Component } from "solecs/interfaces/IUint256Component.sol";

--- a/packages/std-contracts/src/systems/UpgradableSystem.sol
+++ b/packages/std-contracts/src/systems/UpgradableSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import "solecs/PayableSystem.sol";
 import { IWorld } from "solecs/interfaces/IWorld.sol";
 import { IComponent } from "solecs/interfaces/IComponent.sol";

--- a/packages/std-contracts/src/test/TestBareComponent.sol
+++ b/packages/std-contracts/src/test/TestBareComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { BareComponent } from "solecs/BareComponent.sol";
 import { LibTypes } from "solecs/LibTypes.sol";
 

--- a/packages/std-contracts/src/test/TestComponent.sol
+++ b/packages/std-contracts/src/test/TestComponent.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { Component } from "solecs/Component.sol";
 import { LibTypes } from "solecs/LibTypes.sol";
 

--- a/packages/std-contracts/test/ComponentGas.t.sol
+++ b/packages/std-contracts/test/ComponentGas.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { DSTestPlus } from "solmate/test/utils/DSTestPlus.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";

--- a/packages/store/foundry.toml
+++ b/packages/store/foundry.toml
@@ -9,3 +9,7 @@ allow_paths= ["../../node_modules"]
 src = "src"
 out = "out"
 bytecode_hash = "none"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/store/foundry.toml
+++ b/packages/store/foundry.toml
@@ -13,3 +13,4 @@ bytecode_hash = "none"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -15,11 +15,13 @@ library Bytes {
     }
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    UTILS
    *
-   ************************************************************************/
+   *
+   */
 
   function equals(bytes memory a, bytes memory b) internal pure returns (bool) {
     if (a.length != b.length) {
@@ -38,11 +40,13 @@ library Bytes {
     return input;
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    SET
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Overwrite a single byte of a `bytes32` value and return the new value.
@@ -123,13 +127,17 @@ library Bytes {
     return output;
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    SLICE
    *
-   ************************************************************************/
+   *
+   */
 
-  /** Slice bytes to bytes1 without copying data */
+  /**
+   * Slice bytes to bytes1 without copying data
+   */
   function slice1(bytes memory data, uint256 start) internal pure returns (bytes1) {
     bytes1 output;
     assembly {
@@ -146,7 +154,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes2 without copying data */
+  /**
+   * Slice bytes to bytes2 without copying data
+   */
   function slice2(bytes memory data, uint256 start) internal pure returns (bytes2) {
     bytes2 output;
     assembly {
@@ -163,7 +173,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes3 without copying data */
+  /**
+   * Slice bytes to bytes3 without copying data
+   */
   function slice3(bytes memory data, uint256 start) internal pure returns (bytes3) {
     bytes3 output;
     assembly {
@@ -172,7 +184,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes4 without copying data */
+  /**
+   * Slice bytes to bytes4 without copying data
+   */
   function slice4(bytes memory data, uint256 start) internal pure returns (bytes4) {
     bytes4 output;
     assembly {
@@ -189,7 +203,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes5 without copying data */
+  /**
+   * Slice bytes to bytes5 without copying data
+   */
   function slice5(bytes memory data, uint256 start) internal pure returns (bytes5) {
     bytes5 output;
     assembly {
@@ -206,7 +222,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes6 without copying data */
+  /**
+   * Slice bytes to bytes6 without copying data
+   */
   function slice6(bytes memory data, uint256 start) internal pure returns (bytes6) {
     bytes6 output;
     assembly {
@@ -215,7 +233,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes7 without copying data */
+  /**
+   * Slice bytes to bytes7 without copying data
+   */
   function slice7(bytes memory data, uint256 start) internal pure returns (bytes7) {
     bytes7 output;
     assembly {
@@ -224,7 +244,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes8 without copying data */
+  /**
+   * Slice bytes to bytes8 without copying data
+   */
   function slice8(bytes memory data, uint256 start) internal pure returns (bytes8) {
     bytes8 output;
     assembly {
@@ -233,7 +255,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes9 without copying data */
+  /**
+   * Slice bytes to bytes9 without copying data
+   */
   function slice9(bytes memory data, uint256 start) internal pure returns (bytes9) {
     bytes9 output;
     assembly {
@@ -242,7 +266,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes10 without copying data */
+  /**
+   * Slice bytes to bytes10 without copying data
+   */
   function slice10(bytes memory data, uint256 start) internal pure returns (bytes10) {
     bytes10 output;
     assembly {
@@ -251,7 +277,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes11 without copying data */
+  /**
+   * Slice bytes to bytes11 without copying data
+   */
   function slice11(bytes memory data, uint256 start) internal pure returns (bytes11) {
     bytes11 output;
     assembly {
@@ -260,7 +288,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes12 without copying data */
+  /**
+   * Slice bytes to bytes12 without copying data
+   */
   function slice12(bytes memory data, uint256 start) internal pure returns (bytes12) {
     bytes12 output;
     assembly {
@@ -269,7 +299,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes13 without copying data */
+  /**
+   * Slice bytes to bytes13 without copying data
+   */
   function slice13(bytes memory data, uint256 start) internal pure returns (bytes13) {
     bytes13 output;
     assembly {
@@ -278,7 +310,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes14 without copying data */
+  /**
+   * Slice bytes to bytes14 without copying data
+   */
   function slice14(bytes memory data, uint256 start) internal pure returns (bytes14) {
     bytes14 output;
     assembly {
@@ -287,7 +321,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes15 without copying data */
+  /**
+   * Slice bytes to bytes15 without copying data
+   */
   function slice15(bytes memory data, uint256 start) internal pure returns (bytes15) {
     bytes15 output;
     assembly {
@@ -296,7 +332,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes16 without copying data */
+  /**
+   * Slice bytes to bytes16 without copying data
+   */
   function slice16(bytes memory data, uint256 start) internal pure returns (bytes16) {
     bytes16 output;
     assembly {
@@ -305,7 +343,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes17 without copying data */
+  /**
+   * Slice bytes to bytes17 without copying data
+   */
   function slice17(bytes memory data, uint256 start) internal pure returns (bytes17) {
     bytes17 output;
     assembly {
@@ -314,7 +354,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes18 without copying data */
+  /**
+   * Slice bytes to bytes18 without copying data
+   */
   function slice18(bytes memory data, uint256 start) internal pure returns (bytes18) {
     bytes18 output;
     assembly {
@@ -323,7 +365,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes19 without copying data */
+  /**
+   * Slice bytes to bytes19 without copying data
+   */
   function slice19(bytes memory data, uint256 start) internal pure returns (bytes19) {
     bytes19 output;
     assembly {
@@ -332,7 +376,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes20 without copying data */
+  /**
+   * Slice bytes to bytes20 without copying data
+   */
   function slice20(bytes memory data, uint256 start) internal pure returns (bytes20) {
     bytes20 output;
     assembly {
@@ -341,7 +387,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes21 without copying data */
+  /**
+   * Slice bytes to bytes21 without copying data
+   */
   function slice21(bytes memory data, uint256 start) internal pure returns (bytes21) {
     bytes21 output;
     assembly {
@@ -350,7 +398,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes22 without copying data */
+  /**
+   * Slice bytes to bytes22 without copying data
+   */
   function slice22(bytes memory data, uint256 start) internal pure returns (bytes22) {
     bytes22 output;
     assembly {
@@ -359,7 +409,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes23 without copying data */
+  /**
+   * Slice bytes to bytes23 without copying data
+   */
   function slice23(bytes memory data, uint256 start) internal pure returns (bytes23) {
     bytes23 output;
     assembly {
@@ -368,7 +420,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes24 without copying data */
+  /**
+   * Slice bytes to bytes24 without copying data
+   */
   function slice24(bytes memory data, uint256 start) internal pure returns (bytes24) {
     bytes24 output;
     assembly {
@@ -377,7 +431,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes25 without copying data */
+  /**
+   * Slice bytes to bytes25 without copying data
+   */
   function slice25(bytes memory data, uint256 start) internal pure returns (bytes25) {
     bytes25 output;
     assembly {
@@ -386,7 +442,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes26 without copying data */
+  /**
+   * Slice bytes to bytes26 without copying data
+   */
   function slice26(bytes memory data, uint256 start) internal pure returns (bytes26) {
     bytes26 output;
     assembly {
@@ -395,7 +453,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes27 without copying data */
+  /**
+   * Slice bytes to bytes27 without copying data
+   */
   function slice27(bytes memory data, uint256 start) internal pure returns (bytes27) {
     bytes27 output;
     assembly {
@@ -404,7 +464,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes28 without copying data */
+  /**
+   * Slice bytes to bytes28 without copying data
+   */
   function slice28(bytes memory data, uint256 start) internal pure returns (bytes28) {
     bytes28 output;
     assembly {
@@ -413,7 +475,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes29 without copying data */
+  /**
+   * Slice bytes to bytes29 without copying data
+   */
   function slice29(bytes memory data, uint256 start) internal pure returns (bytes29) {
     bytes29 output;
     assembly {
@@ -422,7 +486,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes30 without copying data */
+  /**
+   * Slice bytes to bytes30 without copying data
+   */
   function slice30(bytes memory data, uint256 start) internal pure returns (bytes30) {
     bytes30 output;
     assembly {
@@ -431,7 +497,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes31 without copying data */
+  /**
+   * Slice bytes to bytes31 without copying data
+   */
   function slice31(bytes memory data, uint256 start) internal pure returns (bytes31) {
     bytes31 output;
     assembly {
@@ -440,7 +508,9 @@ library Bytes {
     return output;
   }
 
-  /** Slice bytes to bytes32 without copying data */
+  /**
+   * Slice bytes to bytes32 without copying data
+   */
   function slice32(bytes memory data, uint256 start) internal pure returns (bytes32) {
     bytes32 output;
     assembly {

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -37,11 +37,13 @@ library StoreCore {
     Hooks.register();
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    SCHEMA
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Get the schema for the given tableId
@@ -110,11 +112,13 @@ library StoreCore {
     );
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    REGISTER HOOKS
    *
-   ************************************************************************/
+   *
+   */
 
   /*
    * Register hooks to be called when a record or field is set or deleted
@@ -123,11 +127,13 @@ library StoreCore {
     Hooks.push(tableId, address(hook));
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    SET DATA
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Set full data record for the given tableId and key tuple and schema
@@ -375,11 +381,13 @@ library StoreCore {
     }
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    EPHEMERAL SET DATA
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Emit the ephemeral event without modifying storage for the full data of the given tableId and key tuple
@@ -399,11 +407,13 @@ library StoreCore {
     }
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    GET DATA
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Get full record (all fields, static and dynamic data) for the given tableId and key tuple, with the given value schema
@@ -520,11 +530,13 @@ library StoreCore {
 library StoreCoreInternal {
   bytes32 internal constant SLOT = keccak256("mud.store");
 
-  /************************************************************************
+  /**
+   *
    *
    *    SET DATA
    *
-   ************************************************************************/
+   *
+   */
 
   function _setStaticField(
     bytes32 tableId,
@@ -624,11 +636,13 @@ library StoreCoreInternal {
     _setPartialDynamicData(tableId, key, dynamicSchemaIndex, startByteIndex, dataToSet);
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    GET DATA
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Get full static data for the given tableId and key tuple, with the given static length
@@ -678,11 +692,13 @@ library StoreCoreInternal {
     return Storage.load({ storagePointer: location, length: dataLength, offset: 0 });
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    HELPER FUNCTIONS
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Verify static data length + dynamic data length matches the given data

--- a/packages/world/foundry.toml
+++ b/packages/world/foundry.toml
@@ -13,3 +13,4 @@ bytecode_hash = "none"
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']

--- a/packages/world/foundry.toml
+++ b/packages/world/foundry.toml
@@ -9,3 +9,7 @@ allow_paths = ["../../node_modules", "../"]
 src = "src"
 out = "out"
 bytecode_hash = "none"
+
+[fmt]
+tab_width = 2
+bracket_spacing = true

--- a/packages/world/src/ResourceSelector.sol
+++ b/packages/world/src/ResourceSelector.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { ROOT_NAMESPACE, ROOT_NAME } from "./constants.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 
@@ -59,7 +60,9 @@ library ResourceSelector {
    */
   function toTrimmedString(bytes16 selector) internal pure returns (string memory) {
     uint256 length;
-    for (; length < 16; length++) if (Bytes.slice1(selector, length) == 0) break;
+    for (; length < 16; length++) {
+      if (Bytes.slice1(selector, length) == 0) break;
+    }
     bytes memory packedSelector = abi.encodePacked(selector);
     return string(Bytes.setLength(packedSelector, length));
   }

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -59,11 +59,13 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     InstalledModules.set(module.getName(), keccak256(args), address(module));
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    WORLD STORE METHODS
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Write a record in the table at the given tableId.
@@ -162,11 +164,13 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     StoreCore.deleteRecord(tableId, key, valueSchema);
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    SYSTEM CALLS
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Call the system at the given resourceSelector.
@@ -222,11 +226,13 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     }
   }
 
-  /************************************************************************
+  /**
+   *
    *
    *    DYNAMIC FUNCTION SELECTORS
    *
-   ************************************************************************/
+   *
+   */
 
   /**
    * Allow the World to receive ETH

--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -33,7 +33,7 @@ import { EphemeralRecordSystem } from "./implementations/EphemeralRecordSystem.s
 
 /**
  * The CoreModule registers internal World tables, the CoreSystem, and its function selectors.
-
+ *
  * Note:
  * This module is required to be delegatecalled (via `World.registerRootSystem`),
  * because it needs to install root tables, systems and function selectors.

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Funct
 bytes32 constant FunctionSelectorsTableId = _tableId;
 
 library FunctionSelectors {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES4;
@@ -29,7 +31,9 @@ library FunctionSelectors {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.BYTES32;
@@ -38,30 +42,40 @@ library FunctionSelectors {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "functionSelector";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](2);
     fieldNames[0] = "resourceSelector";
     fieldNames[1] = "systemFunctionSelector";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get resourceSelector */
+  /**
+   * Get resourceSelector
+   */
   function getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -70,7 +84,9 @@ library FunctionSelectors {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Get resourceSelector (using the specified store) */
+  /**
+   * Get resourceSelector (using the specified store)
+   */
   function getResourceSelector(
     IStore _store,
     bytes4 functionSelector
@@ -82,7 +98,9 @@ library FunctionSelectors {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Set resourceSelector */
+  /**
+   * Set resourceSelector
+   */
   function setResourceSelector(bytes4 functionSelector, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -90,7 +108,9 @@ library FunctionSelectors {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getValueSchema());
   }
 
-  /** Set resourceSelector (using the specified store) */
+  /**
+   * Set resourceSelector (using the specified store)
+   */
   function setResourceSelector(IStore _store, bytes4 functionSelector, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -98,7 +118,9 @@ library FunctionSelectors {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getValueSchema());
   }
 
-  /** Get systemFunctionSelector */
+  /**
+   * Get systemFunctionSelector
+   */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -107,7 +129,9 @@ library FunctionSelectors {
     return (Bytes.slice4(_blob, 0));
   }
 
-  /** Get systemFunctionSelector (using the specified store) */
+  /**
+   * Get systemFunctionSelector (using the specified store)
+   */
   function getSystemFunctionSelector(
     IStore _store,
     bytes4 functionSelector
@@ -119,7 +143,9 @@ library FunctionSelectors {
     return (Bytes.slice4(_blob, 0));
   }
 
-  /** Set systemFunctionSelector */
+  /**
+   * Set systemFunctionSelector
+   */
   function setSystemFunctionSelector(bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -127,7 +153,9 @@ library FunctionSelectors {
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((systemFunctionSelector)), getValueSchema());
   }
 
-  /** Set systemFunctionSelector (using the specified store) */
+  /**
+   * Set systemFunctionSelector (using the specified store)
+   */
   function setSystemFunctionSelector(IStore _store, bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
@@ -135,7 +163,9 @@ library FunctionSelectors {
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((systemFunctionSelector)), getValueSchema());
   }
 
-  /** Get the full data */
+  /**
+   * Get the full data
+   */
   function get(
     bytes4 functionSelector
   ) internal view returns (bytes32 resourceSelector, bytes4 systemFunctionSelector) {
@@ -146,7 +176,9 @@ library FunctionSelectors {
     return decode(_blob);
   }
 
-  /** Get the full data (using the specified store) */
+  /**
+   * Get the full data (using the specified store)
+   */
   function get(
     IStore _store,
     bytes4 functionSelector
@@ -158,7 +190,9 @@ library FunctionSelectors {
     return decode(_blob);
   }
 
-  /** Set the full data using individual values */
+  /**
+   * Set the full data using individual values
+   */
   function set(bytes4 functionSelector, bytes32 resourceSelector, bytes4 systemFunctionSelector) internal {
     bytes memory _data = encode(resourceSelector, systemFunctionSelector);
 
@@ -168,7 +202,9 @@ library FunctionSelectors {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using individual values (using the specified store) */
+  /**
+   * Set the full data using individual values (using the specified store)
+   */
   function set(
     IStore _store,
     bytes4 functionSelector,
@@ -183,19 +219,25 @@ library FunctionSelectors {
     _store.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Decode the tightly packed blob using this table's schema */
+  /**
+   * Decode the tightly packed blob using this table's schema
+   */
   function decode(bytes memory _blob) internal pure returns (bytes32 resourceSelector, bytes4 systemFunctionSelector) {
     resourceSelector = (Bytes.slice32(_blob, 0));
 
     systemFunctionSelector = (Bytes.slice4(_blob, 32));
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bytes32 resourceSelector, bytes4 systemFunctionSelector) internal pure returns (bytes memory) {
     return abi.encodePacked(resourceSelector, systemFunctionSelector);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes4 functionSelector) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -24,7 +24,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Resou
 bytes32 constant ResourceTypeTableId = _tableId;
 
 library ResourceType {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -32,7 +34,9 @@ library ResourceType {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.UINT8;
@@ -40,29 +44,39 @@ library ResourceType {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "resourceSelector";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "resourceType";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get resourceType */
+  /**
+   * Get resourceType
+   */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -71,7 +85,9 @@ library ResourceType {
     return Resource(uint8(Bytes.slice1(_blob, 0)));
   }
 
-  /** Get resourceType (using the specified store) */
+  /**
+   * Get resourceType (using the specified store)
+   */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -80,7 +96,9 @@ library ResourceType {
     return Resource(uint8(Bytes.slice1(_blob, 0)));
   }
 
-  /** Set resourceType */
+  /**
+   * Set resourceType
+   */
   function set(bytes32 resourceSelector, Resource resourceType) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -88,7 +106,9 @@ library ResourceType {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)), getValueSchema());
   }
 
-  /** Set resourceType (using the specified store) */
+  /**
+   * Set resourceType (using the specified store)
+   */
   function set(IStore _store, bytes32 resourceSelector, Resource resourceType) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -96,12 +116,16 @@ library ResourceType {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked(uint8(resourceType)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(Resource resourceType) internal pure returns (bytes memory) {
     return abi.encodePacked(resourceType);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Syste
 bytes32 constant SystemHooksTableId = _tableId;
 
 library SystemHooks {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -29,7 +31,9 @@ library SystemHooks {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.ADDRESS_ARRAY;
@@ -37,29 +41,39 @@ library SystemHooks {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "resourceSelector";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "value";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get value */
+  /**
+   * Get value
+   */
   function get(bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -68,7 +82,9 @@ library SystemHooks {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
-  /** Get value (using the specified store) */
+  /**
+   * Get value (using the specified store)
+   */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -77,7 +93,9 @@ library SystemHooks {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
-  /** Set value */
+  /**
+   * Set value
+   */
   function set(bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -85,7 +103,9 @@ library SystemHooks {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getValueSchema());
   }
 
-  /** Set value (using the specified store) */
+  /**
+   * Set value (using the specified store)
+   */
   function set(IStore _store, bytes32 resourceSelector, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -93,7 +113,9 @@ library SystemHooks {
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getValueSchema());
   }
 
-  /** Get the length of value */
+  /**
+   * Get the length of value
+   */
   function length(bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -104,7 +126,9 @@ library SystemHooks {
     }
   }
 
-  /** Get the length of value (using the specified store) */
+  /**
+   * Get the length of value (using the specified store)
+   */
   function length(IStore _store, bytes32 resourceSelector) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -157,7 +181,9 @@ library SystemHooks {
     }
   }
 
-  /** Push an element to value */
+  /**
+   * Push an element to value
+   */
   function push(bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -165,7 +191,9 @@ library SystemHooks {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to value (using the specified store) */
+  /**
+   * Push an element to value (using the specified store)
+   */
   function push(IStore _store, bytes32 resourceSelector, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -173,7 +201,9 @@ library SystemHooks {
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from value */
+  /**
+   * Pop an element from value
+   */
   function pop(bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -181,7 +211,9 @@ library SystemHooks {
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20, getValueSchema());
   }
 
-  /** Pop an element from value (using the specified store) */
+  /**
+   * Pop an element from value (using the specified store)
+   */
   function pop(IStore _store, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -215,7 +247,9 @@ library SystemHooks {
     }
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(address[] memory value) internal pure returns (bytes memory) {
     PackedCounter _encodedLengths;
     // Lengths are effectively checked during copy by 2**40 bytes exceeding gas limits
@@ -226,7 +260,9 @@ library SystemHooks {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Syste
 bytes32 constant SystemRegistryTableId = _tableId;
 
 library SystemRegistry {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.ADDRESS;
@@ -29,7 +31,9 @@ library SystemRegistry {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -37,29 +41,39 @@ library SystemRegistry {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "system";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "resourceSelector";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get resourceSelector */
+  /**
+   * Get resourceSelector
+   */
   function get(address system) internal view returns (bytes32 resourceSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
@@ -68,7 +82,9 @@ library SystemRegistry {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Get resourceSelector (using the specified store) */
+  /**
+   * Get resourceSelector (using the specified store)
+   */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
@@ -77,7 +93,9 @@ library SystemRegistry {
     return (Bytes.slice32(_blob, 0));
   }
 
-  /** Set resourceSelector */
+  /**
+   * Set resourceSelector
+   */
   function set(address system, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
@@ -85,7 +103,9 @@ library SystemRegistry {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getValueSchema());
   }
 
-  /** Set resourceSelector (using the specified store) */
+  /**
+   * Set resourceSelector (using the specified store)
+   */
   function set(IStore _store, address system, bytes32 resourceSelector) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
@@ -93,12 +113,16 @@ library SystemRegistry {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bytes32 resourceSelector) internal pure returns (bytes memory) {
     return abi.encodePacked(resourceSelector);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(address system) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Syste
 bytes32 constant SystemsTableId = _tableId;
 
 library Systems {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -29,7 +31,9 @@ library Systems {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.ADDRESS;
@@ -38,30 +42,40 @@ library Systems {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "resourceSelector";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](2);
     fieldNames[0] = "system";
     fieldNames[1] = "publicAccess";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get system */
+  /**
+   * Get system
+   */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -70,7 +84,9 @@ library Systems {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Get system (using the specified store) */
+  /**
+   * Get system (using the specified store)
+   */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -79,7 +95,9 @@ library Systems {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Set system */
+  /**
+   * Set system
+   */
   function setSystem(bytes32 resourceSelector, address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -87,7 +105,9 @@ library Systems {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)), getValueSchema());
   }
 
-  /** Set system (using the specified store) */
+  /**
+   * Set system (using the specified store)
+   */
   function setSystem(IStore _store, bytes32 resourceSelector, address system) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -95,7 +115,9 @@ library Systems {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)), getValueSchema());
   }
 
-  /** Get publicAccess */
+  /**
+   * Get publicAccess
+   */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -104,7 +126,9 @@ library Systems {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Get publicAccess (using the specified store) */
+  /**
+   * Get publicAccess (using the specified store)
+   */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -113,7 +137,9 @@ library Systems {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Set publicAccess */
+  /**
+   * Set publicAccess
+   */
   function setPublicAccess(bytes32 resourceSelector, bool publicAccess) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -121,7 +147,9 @@ library Systems {
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)), getValueSchema());
   }
 
-  /** Set publicAccess (using the specified store) */
+  /**
+   * Set publicAccess (using the specified store)
+   */
   function setPublicAccess(IStore _store, bytes32 resourceSelector, bool publicAccess) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -129,7 +157,9 @@ library Systems {
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)), getValueSchema());
   }
 
-  /** Get the full data */
+  /**
+   * Get the full data
+   */
   function get(bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -138,7 +168,9 @@ library Systems {
     return decode(_blob);
   }
 
-  /** Get the full data (using the specified store) */
+  /**
+   * Get the full data (using the specified store)
+   */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
@@ -147,7 +179,9 @@ library Systems {
     return decode(_blob);
   }
 
-  /** Set the full data using individual values */
+  /**
+   * Set the full data using individual values
+   */
   function set(bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
 
@@ -157,7 +191,9 @@ library Systems {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using individual values (using the specified store) */
+  /**
+   * Set the full data using individual values (using the specified store)
+   */
   function set(IStore _store, bytes32 resourceSelector, address system, bool publicAccess) internal {
     bytes memory _data = encode(system, publicAccess);
 
@@ -167,19 +203,25 @@ library Systems {
     _store.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Decode the tightly packed blob using this table's schema */
+  /**
+   * Decode the tightly packed blob using this table's schema
+   */
   function decode(bytes memory _blob) internal pure returns (address system, bool publicAccess) {
     system = (address(Bytes.slice20(_blob, 0)));
 
     publicAccess = (_toBool(uint8(Bytes.slice1(_blob, 20))));
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(address system, bool publicAccess) internal pure returns (bytes memory) {
     return abi.encodePacked(system, publicAccess);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 resourceSelector) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -29,7 +29,9 @@ struct KeysInTableData {
 }
 
 library KeysInTable {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -37,7 +39,9 @@ library KeysInTable {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](5);
     _schema[0] = SchemaType.BYTES32_ARRAY;
@@ -49,13 +53,17 @@ library KeysInTable {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "sourceTable";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](5);
     fieldNames[0] = "keys0";
@@ -65,17 +73,23 @@ library KeysInTable {
     fieldNames[4] = "keys4";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get keys0 */
+  /**
+   * Get keys0
+   */
   function getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -84,7 +98,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keys0 (using the specified store) */
+  /**
+   * Get keys0 (using the specified store)
+   */
   function getKeys0(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -93,7 +109,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keys0 */
+  /**
+   * Set keys0
+   */
   function setKeys0(bytes32 sourceTable, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -101,7 +119,9 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)), getValueSchema());
   }
 
-  /** Set keys0 (using the specified store) */
+  /**
+   * Set keys0 (using the specified store)
+   */
   function setKeys0(IStore _store, bytes32 sourceTable, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -109,7 +129,9 @@ library KeysInTable {
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)), getValueSchema());
   }
 
-  /** Get the length of keys0 */
+  /**
+   * Get the length of keys0
+   */
   function lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -120,7 +142,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the length of keys0 (using the specified store) */
+  /**
+   * Get the length of keys0 (using the specified store)
+   */
   function lengthKeys0(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -173,7 +197,9 @@ library KeysInTable {
     }
   }
 
-  /** Push an element to keys0 */
+  /**
+   * Push an element to keys0
+   */
   function pushKeys0(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -181,7 +207,9 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keys0 (using the specified store) */
+  /**
+   * Push an element to keys0 (using the specified store)
+   */
   function pushKeys0(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -189,7 +217,9 @@ library KeysInTable {
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keys0 */
+  /**
+   * Pop an element from keys0
+   */
   function popKeys0(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -197,7 +227,9 @@ library KeysInTable {
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32, getValueSchema());
   }
 
-  /** Pop an element from keys0 (using the specified store) */
+  /**
+   * Pop an element from keys0 (using the specified store)
+   */
   function popKeys0(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -231,7 +263,9 @@ library KeysInTable {
     }
   }
 
-  /** Get keys1 */
+  /**
+   * Get keys1
+   */
   function getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -240,7 +274,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keys1 (using the specified store) */
+  /**
+   * Get keys1 (using the specified store)
+   */
   function getKeys1(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -249,7 +285,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keys1 */
+  /**
+   * Set keys1
+   */
   function setKeys1(bytes32 sourceTable, bytes32[] memory keys1) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -257,7 +295,9 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)), getValueSchema());
   }
 
-  /** Set keys1 (using the specified store) */
+  /**
+   * Set keys1 (using the specified store)
+   */
   function setKeys1(IStore _store, bytes32 sourceTable, bytes32[] memory keys1) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -265,7 +305,9 @@ library KeysInTable {
     _store.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)), getValueSchema());
   }
 
-  /** Get the length of keys1 */
+  /**
+   * Get the length of keys1
+   */
   function lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -276,7 +318,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the length of keys1 (using the specified store) */
+  /**
+   * Get the length of keys1 (using the specified store)
+   */
   function lengthKeys1(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -329,7 +373,9 @@ library KeysInTable {
     }
   }
 
-  /** Push an element to keys1 */
+  /**
+   * Push an element to keys1
+   */
   function pushKeys1(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -337,7 +383,9 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keys1 (using the specified store) */
+  /**
+   * Push an element to keys1 (using the specified store)
+   */
   function pushKeys1(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -345,7 +393,9 @@ library KeysInTable {
     _store.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keys1 */
+  /**
+   * Pop an element from keys1
+   */
   function popKeys1(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -353,7 +403,9 @@ library KeysInTable {
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32, getValueSchema());
   }
 
-  /** Pop an element from keys1 (using the specified store) */
+  /**
+   * Pop an element from keys1 (using the specified store)
+   */
   function popKeys1(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -387,7 +439,9 @@ library KeysInTable {
     }
   }
 
-  /** Get keys2 */
+  /**
+   * Get keys2
+   */
   function getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -396,7 +450,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keys2 (using the specified store) */
+  /**
+   * Get keys2 (using the specified store)
+   */
   function getKeys2(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -405,7 +461,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keys2 */
+  /**
+   * Set keys2
+   */
   function setKeys2(bytes32 sourceTable, bytes32[] memory keys2) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -413,7 +471,9 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)), getValueSchema());
   }
 
-  /** Set keys2 (using the specified store) */
+  /**
+   * Set keys2 (using the specified store)
+   */
   function setKeys2(IStore _store, bytes32 sourceTable, bytes32[] memory keys2) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -421,7 +481,9 @@ library KeysInTable {
     _store.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)), getValueSchema());
   }
 
-  /** Get the length of keys2 */
+  /**
+   * Get the length of keys2
+   */
   function lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -432,7 +494,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the length of keys2 (using the specified store) */
+  /**
+   * Get the length of keys2 (using the specified store)
+   */
   function lengthKeys2(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -485,7 +549,9 @@ library KeysInTable {
     }
   }
 
-  /** Push an element to keys2 */
+  /**
+   * Push an element to keys2
+   */
   function pushKeys2(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -493,7 +559,9 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keys2 (using the specified store) */
+  /**
+   * Push an element to keys2 (using the specified store)
+   */
   function pushKeys2(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -501,7 +569,9 @@ library KeysInTable {
     _store.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keys2 */
+  /**
+   * Pop an element from keys2
+   */
   function popKeys2(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -509,7 +579,9 @@ library KeysInTable {
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32, getValueSchema());
   }
 
-  /** Pop an element from keys2 (using the specified store) */
+  /**
+   * Pop an element from keys2 (using the specified store)
+   */
   function popKeys2(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -543,7 +615,9 @@ library KeysInTable {
     }
   }
 
-  /** Get keys3 */
+  /**
+   * Get keys3
+   */
   function getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -552,7 +626,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keys3 (using the specified store) */
+  /**
+   * Get keys3 (using the specified store)
+   */
   function getKeys3(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -561,7 +637,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keys3 */
+  /**
+   * Set keys3
+   */
   function setKeys3(bytes32 sourceTable, bytes32[] memory keys3) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -569,7 +647,9 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)), getValueSchema());
   }
 
-  /** Set keys3 (using the specified store) */
+  /**
+   * Set keys3 (using the specified store)
+   */
   function setKeys3(IStore _store, bytes32 sourceTable, bytes32[] memory keys3) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -577,7 +657,9 @@ library KeysInTable {
     _store.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)), getValueSchema());
   }
 
-  /** Get the length of keys3 */
+  /**
+   * Get the length of keys3
+   */
   function lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -588,7 +670,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the length of keys3 (using the specified store) */
+  /**
+   * Get the length of keys3 (using the specified store)
+   */
   function lengthKeys3(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -641,7 +725,9 @@ library KeysInTable {
     }
   }
 
-  /** Push an element to keys3 */
+  /**
+   * Push an element to keys3
+   */
   function pushKeys3(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -649,7 +735,9 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keys3 (using the specified store) */
+  /**
+   * Push an element to keys3 (using the specified store)
+   */
   function pushKeys3(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -657,7 +745,9 @@ library KeysInTable {
     _store.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keys3 */
+  /**
+   * Pop an element from keys3
+   */
   function popKeys3(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -665,7 +755,9 @@ library KeysInTable {
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32, getValueSchema());
   }
 
-  /** Pop an element from keys3 (using the specified store) */
+  /**
+   * Pop an element from keys3 (using the specified store)
+   */
   function popKeys3(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -699,7 +791,9 @@ library KeysInTable {
     }
   }
 
-  /** Get keys4 */
+  /**
+   * Get keys4
+   */
   function getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -708,7 +802,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keys4 (using the specified store) */
+  /**
+   * Get keys4 (using the specified store)
+   */
   function getKeys4(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -717,7 +813,9 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keys4 */
+  /**
+   * Set keys4
+   */
   function setKeys4(bytes32 sourceTable, bytes32[] memory keys4) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -725,7 +823,9 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)), getValueSchema());
   }
 
-  /** Set keys4 (using the specified store) */
+  /**
+   * Set keys4 (using the specified store)
+   */
   function setKeys4(IStore _store, bytes32 sourceTable, bytes32[] memory keys4) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -733,7 +833,9 @@ library KeysInTable {
     _store.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)), getValueSchema());
   }
 
-  /** Get the length of keys4 */
+  /**
+   * Get the length of keys4
+   */
   function lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -744,7 +846,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the length of keys4 (using the specified store) */
+  /**
+   * Get the length of keys4 (using the specified store)
+   */
   function lengthKeys4(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -797,7 +901,9 @@ library KeysInTable {
     }
   }
 
-  /** Push an element to keys4 */
+  /**
+   * Push an element to keys4
+   */
   function pushKeys4(bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -805,7 +911,9 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keys4 (using the specified store) */
+  /**
+   * Push an element to keys4 (using the specified store)
+   */
   function pushKeys4(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -813,7 +921,9 @@ library KeysInTable {
     _store.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keys4 */
+  /**
+   * Pop an element from keys4
+   */
   function popKeys4(bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -821,7 +931,9 @@ library KeysInTable {
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32, getValueSchema());
   }
 
-  /** Pop an element from keys4 (using the specified store) */
+  /**
+   * Pop an element from keys4 (using the specified store)
+   */
   function popKeys4(IStore _store, bytes32 sourceTable) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -855,7 +967,9 @@ library KeysInTable {
     }
   }
 
-  /** Get the full data */
+  /**
+   * Get the full data
+   */
   function get(bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -864,7 +978,9 @@ library KeysInTable {
     return decode(_blob);
   }
 
-  /** Get the full data (using the specified store) */
+  /**
+   * Get the full data (using the specified store)
+   */
   function get(IStore _store, bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;
@@ -873,7 +989,9 @@ library KeysInTable {
     return decode(_blob);
   }
 
-  /** Set the full data using individual values */
+  /**
+   * Set the full data using individual values
+   */
   function set(
     bytes32 sourceTable,
     bytes32[] memory keys0,
@@ -890,7 +1008,9 @@ library KeysInTable {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using individual values (using the specified store) */
+  /**
+   * Set the full data using individual values (using the specified store)
+   */
   function set(
     IStore _store,
     bytes32 sourceTable,
@@ -908,12 +1028,16 @@ library KeysInTable {
     _store.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using the data struct */
+  /**
+   * Set the full data using the data struct
+   */
   function set(bytes32 sourceTable, KeysInTableData memory _table) internal {
     set(sourceTable, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
   }
 
-  /** Set the full data using the data struct (using the specified store) */
+  /**
+   * Set the full data using the data struct (using the specified store)
+   */
   function set(IStore _store, bytes32 sourceTable, KeysInTableData memory _table) internal {
     set(_store, sourceTable, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
   }
@@ -962,7 +1086,9 @@ library KeysInTable {
     }
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(
     bytes32[] memory keys0,
     bytes32[] memory keys1,
@@ -993,7 +1119,9 @@ library KeysInTable {
       );
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 sourceTable) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = sourceTable;

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("UsedK
 bytes32 constant UsedKeysIndexTableId = _tableId;
 
 library UsedKeysIndex {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.BYTES32;
@@ -30,7 +32,9 @@ library UsedKeysIndex {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.BOOL;
@@ -39,31 +43,41 @@ library UsedKeysIndex {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](2);
     keyNames[0] = "sourceTable";
     keyNames[1] = "keysHash";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](2);
     fieldNames[0] = "has";
     fieldNames[1] = "index";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get has */
+  /**
+   * Get has
+   */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -73,7 +87,9 @@ library UsedKeysIndex {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Get has (using the specified store) */
+  /**
+   * Get has (using the specified store)
+   */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -83,7 +99,9 @@ library UsedKeysIndex {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Set has */
+  /**
+   * Set has
+   */
   function setHas(bytes32 sourceTable, bytes32 keysHash, bool has) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -92,7 +110,9 @@ library UsedKeysIndex {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)), getValueSchema());
   }
 
-  /** Set has (using the specified store) */
+  /**
+   * Set has (using the specified store)
+   */
   function setHas(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -101,7 +121,9 @@ library UsedKeysIndex {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)), getValueSchema());
   }
 
-  /** Get index */
+  /**
+   * Get index
+   */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -111,7 +133,9 @@ library UsedKeysIndex {
     return (uint40(Bytes.slice5(_blob, 0)));
   }
 
-  /** Get index (using the specified store) */
+  /**
+   * Get index (using the specified store)
+   */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -121,7 +145,9 @@ library UsedKeysIndex {
     return (uint40(Bytes.slice5(_blob, 0)));
   }
 
-  /** Set index */
+  /**
+   * Set index
+   */
   function setIndex(bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -130,7 +156,9 @@ library UsedKeysIndex {
     StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)), getValueSchema());
   }
 
-  /** Set index (using the specified store) */
+  /**
+   * Set index (using the specified store)
+   */
   function setIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -139,7 +167,9 @@ library UsedKeysIndex {
     _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)), getValueSchema());
   }
 
-  /** Get the full data */
+  /**
+   * Get the full data
+   */
   function get(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -149,7 +179,9 @@ library UsedKeysIndex {
     return decode(_blob);
   }
 
-  /** Get the full data (using the specified store) */
+  /**
+   * Get the full data (using the specified store)
+   */
   function get(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;
@@ -159,7 +191,9 @@ library UsedKeysIndex {
     return decode(_blob);
   }
 
-  /** Set the full data using individual values */
+  /**
+   * Set the full data using individual values
+   */
   function set(bytes32 sourceTable, bytes32 keysHash, bool has, uint40 index) internal {
     bytes memory _data = encode(has, index);
 
@@ -170,7 +204,9 @@ library UsedKeysIndex {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using individual values (using the specified store) */
+  /**
+   * Set the full data using individual values (using the specified store)
+   */
   function set(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has, uint40 index) internal {
     bytes memory _data = encode(has, index);
 
@@ -181,19 +217,25 @@ library UsedKeysIndex {
     _store.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Decode the tightly packed blob using this table's schema */
+  /**
+   * Decode the tightly packed blob using this table's schema
+   */
   function decode(bytes memory _blob) internal pure returns (bool has, uint40 index) {
     has = (_toBool(uint8(Bytes.slice1(_blob, 0))));
 
     index = (uint40(Bytes.slice5(_blob, 1)));
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bool has, uint40 index) internal pure returns (bytes memory) {
     return abi.encodePacked(has, index);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 sourceTable, bytes32 keysHash) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = sourceTable;

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -18,7 +18,9 @@ import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
 library KeysWithValue {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -26,7 +28,9 @@ library KeysWithValue {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32_ARRAY;
@@ -34,29 +38,39 @@ library KeysWithValue {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "valueHash";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "keysWithValue";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register(bytes32 _tableId) internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get keysWithValue */
+  /**
+   * Get keysWithValue
+   */
   function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -65,7 +79,9 @@ library KeysWithValue {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Get keysWithValue (using the specified store) */
+  /**
+   * Get keysWithValue (using the specified store)
+   */
   function get(
     IStore _store,
     bytes32 _tableId,
@@ -78,7 +94,9 @@ library KeysWithValue {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
-  /** Set keysWithValue */
+  /**
+   * Set keysWithValue
+   */
   function set(bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -86,7 +104,9 @@ library KeysWithValue {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)), getValueSchema());
   }
 
-  /** Set keysWithValue (using the specified store) */
+  /**
+   * Set keysWithValue (using the specified store)
+   */
   function set(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32[] memory keysWithValue) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -94,7 +114,9 @@ library KeysWithValue {
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keysWithValue)), getValueSchema());
   }
 
-  /** Get the length of keysWithValue */
+  /**
+   * Get the length of keysWithValue
+   */
   function length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -105,7 +127,9 @@ library KeysWithValue {
     }
   }
 
-  /** Get the length of keysWithValue (using the specified store) */
+  /**
+   * Get the length of keysWithValue (using the specified store)
+   */
   function length(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -158,7 +182,9 @@ library KeysWithValue {
     }
   }
 
-  /** Push an element to keysWithValue */
+  /**
+   * Push an element to keysWithValue
+   */
   function push(bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -166,7 +192,9 @@ library KeysWithValue {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to keysWithValue (using the specified store) */
+  /**
+   * Push an element to keysWithValue (using the specified store)
+   */
   function push(IStore _store, bytes32 _tableId, bytes32 valueHash, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -174,7 +202,9 @@ library KeysWithValue {
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from keysWithValue */
+  /**
+   * Pop an element from keysWithValue
+   */
   function pop(bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -182,7 +212,9 @@ library KeysWithValue {
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32, getValueSchema());
   }
 
-  /** Pop an element from keysWithValue (using the specified store) */
+  /**
+   * Pop an element from keysWithValue (using the specified store)
+   */
   function pop(IStore _store, bytes32 _tableId, bytes32 valueHash) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;
@@ -216,7 +248,9 @@ library KeysWithValue {
     }
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bytes32[] memory keysWithValue) internal pure returns (bytes memory) {
     PackedCounter _encodedLengths;
     // Lengths are effectively checked during copy by 2**40 bytes exceeding gas limits
@@ -227,7 +261,9 @@ library KeysWithValue {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((keysWithValue)));
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 valueHash) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = valueHash;

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -18,14 +18,18 @@ import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
 library UniqueEntity {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](0);
 
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.UINT256;
@@ -33,28 +37,38 @@ library UniqueEntity {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](0);
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "value";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register(bytes32 _tableId) internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get value */
+  /**
+   * Get value
+   */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
@@ -62,7 +76,9 @@ library UniqueEntity {
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
-  /** Get value (using the specified store) */
+  /**
+   * Get value (using the specified store)
+   */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
@@ -70,26 +86,34 @@ library UniqueEntity {
     return (uint256(Bytes.slice32(_blob, 0)));
   }
 
-  /** Set value */
+  /**
+   * Set value
+   */
   function set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getValueSchema());
   }
 
-  /** Set value (using the specified store) */
+  /**
+   * Set value (using the specified store)
+   */
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(uint256 value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple() internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 

--- a/packages/world/src/modules/utils/getTargetTableSelector.sol
+++ b/packages/world/src/modules/utils/getTargetTableSelector.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { ResourceSelector } from "../../ResourceSelector.sol";
 
 /**

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -25,7 +25,9 @@ struct InstalledModulesData {
 }
 
 library InstalledModules {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.BYTES16;
@@ -34,7 +36,9 @@ library InstalledModules {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.ADDRESS;
@@ -42,30 +46,40 @@ library InstalledModules {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](2);
     keyNames[0] = "moduleName";
     keyNames[1] = "argumentsHash";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "moduleAddress";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get moduleAddress */
+  /**
+   * Get moduleAddress
+   */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);
@@ -75,7 +89,9 @@ library InstalledModules {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Get moduleAddress (using the specified store) */
+  /**
+   * Get moduleAddress (using the specified store)
+   */
   function getModuleAddress(
     IStore _store,
     bytes16 moduleName,
@@ -89,7 +105,9 @@ library InstalledModules {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Set moduleAddress */
+  /**
+   * Set moduleAddress
+   */
   function setModuleAddress(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);
@@ -98,7 +116,9 @@ library InstalledModules {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)), getValueSchema());
   }
 
-  /** Set moduleAddress (using the specified store) */
+  /**
+   * Set moduleAddress (using the specified store)
+   */
   function setModuleAddress(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);
@@ -107,7 +127,9 @@ library InstalledModules {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)), getValueSchema());
   }
 
-  /** Get the full data */
+  /**
+   * Get the full data
+   */
   function get(bytes16 moduleName, bytes32 argumentsHash) internal view returns (InstalledModulesData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);
@@ -117,7 +139,9 @@ library InstalledModules {
     return decode(_blob);
   }
 
-  /** Get the full data (using the specified store) */
+  /**
+   * Get the full data (using the specified store)
+   */
   function get(
     IStore _store,
     bytes16 moduleName,
@@ -131,7 +155,9 @@ library InstalledModules {
     return decode(_blob);
   }
 
-  /** Set the full data using individual values */
+  /**
+   * Set the full data using individual values
+   */
   function set(bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
 
@@ -142,7 +168,9 @@ library InstalledModules {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using individual values (using the specified store) */
+  /**
+   * Set the full data using individual values (using the specified store)
+   */
   function set(IStore _store, bytes16 moduleName, bytes32 argumentsHash, address moduleAddress) internal {
     bytes memory _data = encode(moduleAddress);
 
@@ -153,27 +181,37 @@ library InstalledModules {
     _store.setRecord(_tableId, _keyTuple, _data, getValueSchema());
   }
 
-  /** Set the full data using the data struct */
+  /**
+   * Set the full data using the data struct
+   */
   function set(bytes16 moduleName, bytes32 argumentsHash, InstalledModulesData memory _table) internal {
     set(moduleName, argumentsHash, _table.moduleAddress);
   }
 
-  /** Set the full data using the data struct (using the specified store) */
+  /**
+   * Set the full data using the data struct (using the specified store)
+   */
   function set(IStore _store, bytes16 moduleName, bytes32 argumentsHash, InstalledModulesData memory _table) internal {
     set(_store, moduleName, argumentsHash, _table.moduleAddress);
   }
 
-  /** Decode the tightly packed blob using this table's schema */
+  /**
+   * Decode the tightly packed blob using this table's schema
+   */
   function decode(bytes memory _blob) internal pure returns (InstalledModulesData memory _table) {
     _table.moduleAddress = (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(address moduleAddress) internal pure returns (bytes memory) {
     return abi.encodePacked(moduleAddress);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes16 moduleName, bytes32 argumentsHash) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = bytes32(moduleName);

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Names
 bytes32 constant NamespaceOwnerTableId = _tableId;
 
 library NamespaceOwner {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES16;
@@ -29,7 +31,9 @@ library NamespaceOwner {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.ADDRESS;
@@ -37,29 +41,39 @@ library NamespaceOwner {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "namespace";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "owner";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get owner */
+  /**
+   * Get owner
+   */
   function get(bytes16 namespace) internal view returns (address owner) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
@@ -68,7 +82,9 @@ library NamespaceOwner {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Get owner (using the specified store) */
+  /**
+   * Get owner (using the specified store)
+   */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
@@ -77,7 +93,9 @@ library NamespaceOwner {
     return (address(Bytes.slice20(_blob, 0)));
   }
 
-  /** Set owner */
+  /**
+   * Set owner
+   */
   function set(bytes16 namespace, address owner) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
@@ -85,7 +103,9 @@ library NamespaceOwner {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)), getValueSchema());
   }
 
-  /** Set owner (using the specified store) */
+  /**
+   * Set owner (using the specified store)
+   */
   function set(IStore _store, bytes16 namespace, address owner) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
@@ -93,12 +113,16 @@ library NamespaceOwner {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(address owner) internal pure returns (bytes memory) {
     return abi.encodePacked(owner);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes16 namespace) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -21,7 +21,9 @@ bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Resou
 bytes32 constant ResourceAccessTableId = _tableId;
 
 library ResourceAccess {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](2);
     _schema[0] = SchemaType.BYTES32;
@@ -30,7 +32,9 @@ library ResourceAccess {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BOOL;
@@ -38,30 +42,40 @@ library ResourceAccess {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](2);
     keyNames[0] = "resourceSelector";
     keyNames[1] = "caller";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "access";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register() internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get access */
+  /**
+   * Get access
+   */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;
@@ -71,7 +85,9 @@ library ResourceAccess {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Get access (using the specified store) */
+  /**
+   * Get access (using the specified store)
+   */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;
@@ -81,7 +97,9 @@ library ResourceAccess {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Set access */
+  /**
+   * Set access
+   */
   function set(bytes32 resourceSelector, address caller, bool access) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;
@@ -90,7 +108,9 @@ library ResourceAccess {
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)), getValueSchema());
   }
 
-  /** Set access (using the specified store) */
+  /**
+   * Set access (using the specified store)
+   */
   function set(IStore _store, bytes32 resourceSelector, address caller, bool access) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;
@@ -99,12 +119,16 @@ library ResourceAccess {
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((access)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bool access) internal pure returns (bytes memory) {
     return abi.encodePacked(access);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 resourceSelector, address caller) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](2);
     _keyTuple[0] = resourceSelector;

--- a/packages/world/test/KeysInTableModule.t.sol
+++ b/packages/world/test/KeysInTableModule.t.sol
@@ -20,6 +20,7 @@ import { hasKey } from "../src/modules/keysintable/hasKey.sol";
 
 contract KeysInTableModuleTest is Test, GasReporter {
   using ResourceSelector for bytes32;
+
   IBaseWorld world;
   KeysInTableModule keysInTableModule = new KeysInTableModule(); // Modules can be deployed once and installed multiple times
 

--- a/packages/world/test/KeysWithValueModule.t.sol
+++ b/packages/world/test/KeysWithValueModule.t.sol
@@ -22,6 +22,7 @@ import { getTargetTableSelector } from "../src/modules/utils/getTargetTableSelec
 
 contract KeysWithValueModuleTest is Test, GasReporter {
   using ResourceSelector for bytes32;
+
   IBaseWorld world;
   KeysWithValueModule keysWithValueModule = new KeysWithValueModule(); // Modules can be deployed once and installed multiple times
 

--- a/packages/world/test/Utils.t.sol
+++ b/packages/world/test/Utils.t.sol
@@ -19,6 +19,7 @@ contract UtilsTestSystem is System {
 
 contract UtilsTest is Test {
   using ResourceSelector for bytes32;
+
   IBaseWorld internal world;
 
   function setUp() public {

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -44,6 +44,7 @@ struct WorldTestSystemReturn {
 
 contract WorldTestSystem is System {
   error WorldTestSystemError(string err);
+
   event WorldTestSystemLog(string log);
 
   function getStoreAddress() public view returns (address) {

--- a/packages/world/test/query.t.sol
+++ b/packages/world/test/query.t.sol
@@ -20,6 +20,7 @@ import { query, QueryFragment, QueryType } from "../src/modules/keysintable/quer
 
 contract QueryTest is Test, GasReporter {
   using ResourceSelector for bytes32;
+
   IBaseWorld world;
   KeysInTableModule keysInTableModule = new KeysInTableModule(); // Modules can be deployed once and installed multiple times
   KeysWithValueModule keysWithValueModule = new KeysWithValueModule();

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -18,7 +18,9 @@ import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
 library AddressArray {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BYTES32;
@@ -26,7 +28,9 @@ library AddressArray {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.ADDRESS_ARRAY;
@@ -34,29 +38,39 @@ library AddressArray {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](1);
     keyNames[0] = "key";
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "value";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register(bytes32 _tableId) internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get value */
+  /**
+   * Get value
+   */
   function get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -65,7 +79,9 @@ library AddressArray {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
-  /** Get value (using the specified store) */
+  /**
+   * Get value (using the specified store)
+   */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -74,7 +90,9 @@ library AddressArray {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
-  /** Set value */
+  /**
+   * Set value
+   */
   function set(bytes32 _tableId, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -82,7 +100,9 @@ library AddressArray {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getValueSchema());
   }
 
-  /** Set value (using the specified store) */
+  /**
+   * Set value (using the specified store)
+   */
   function set(IStore _store, bytes32 _tableId, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -90,7 +110,9 @@ library AddressArray {
     _store.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getValueSchema());
   }
 
-  /** Get the length of value */
+  /**
+   * Get the length of value
+   */
   function length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -101,7 +123,9 @@ library AddressArray {
     }
   }
 
-  /** Get the length of value (using the specified store) */
+  /**
+   * Get the length of value (using the specified store)
+   */
   function length(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -154,7 +178,9 @@ library AddressArray {
     }
   }
 
-  /** Push an element to value */
+  /**
+   * Push an element to value
+   */
   function push(bytes32 _tableId, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -162,7 +188,9 @@ library AddressArray {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Push an element to value (using the specified store) */
+  /**
+   * Push an element to value (using the specified store)
+   */
   function push(IStore _store, bytes32 _tableId, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -170,7 +198,9 @@ library AddressArray {
     _store.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getValueSchema());
   }
 
-  /** Pop an element from value */
+  /**
+   * Pop an element from value
+   */
   function pop(bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -178,7 +208,9 @@ library AddressArray {
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20, getValueSchema());
   }
 
-  /** Pop an element from value (using the specified store) */
+  /**
+   * Pop an element from value (using the specified store)
+   */
   function pop(IStore _store, bytes32 _tableId, bytes32 key) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
@@ -212,7 +244,9 @@ library AddressArray {
     }
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(address[] memory value) internal pure returns (bytes memory) {
     PackedCounter _encodedLengths;
     // Lengths are effectively checked during copy by 2**40 bytes exceeding gas limits
@@ -223,7 +257,9 @@ library AddressArray {
     return abi.encodePacked(_encodedLengths.unwrap(), EncodeArray.encode((value)));
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple(bytes32 key) internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -18,14 +18,18 @@ import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
 library Bool {
-  /** Get the table's key schema */
+  /**
+   * Get the table's key schema
+   */
   function getKeySchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](0);
 
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's value schema */
+  /**
+   * Get the table's value schema
+   */
   function getValueSchema() internal pure returns (Schema) {
     SchemaType[] memory _schema = new SchemaType[](1);
     _schema[0] = SchemaType.BOOL;
@@ -33,28 +37,38 @@ library Bool {
     return SchemaLib.encode(_schema);
   }
 
-  /** Get the table's key names */
+  /**
+   * Get the table's key names
+   */
   function getKeyNames() internal pure returns (string[] memory keyNames) {
     keyNames = new string[](0);
   }
 
-  /** Get the table's field names */
+  /**
+   * Get the table's field names
+   */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
     fieldNames = new string[](1);
     fieldNames[0] = "value";
   }
 
-  /** Register the table's key schema, value schema, key names and value names */
+  /**
+   * Register the table's key schema, value schema, key names and value names
+   */
   function register(bytes32 _tableId) internal {
     StoreSwitch.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Register the table's key schema, value schema, key names and value names (using the specified store) */
+  /**
+   * Register the table's key schema, value schema, key names and value names (using the specified store)
+   */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
   }
 
-  /** Get value */
+  /**
+   * Get value
+   */
   function get(bytes32 _tableId) internal view returns (bool value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
@@ -62,7 +76,9 @@ library Bool {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Get value (using the specified store) */
+  /**
+   * Get value (using the specified store)
+   */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
@@ -70,26 +86,34 @@ library Bool {
     return (_toBool(uint8(Bytes.slice1(_blob, 0))));
   }
 
-  /** Set value */
+  /**
+   * Set value
+   */
   function set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getValueSchema());
   }
 
-  /** Set value (using the specified store) */
+  /**
+   * Set value (using the specified store)
+   */
   function set(IStore _store, bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getValueSchema());
   }
 
-  /** Tightly pack full data using this table's schema */
+  /**
+   * Tightly pack full data using this table's schema
+   */
   function encode(bool value) internal pure returns (bytes memory) {
     return abi.encodePacked(value);
   }
 
-  /** Encode keys as a bytes32 array using this table's schema */
+  /**
+   * Encode keys as a bytes32 array using this table's schema
+   */
   function encodeKeyTuple() internal pure returns (bytes32[] memory) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 

--- a/templates/phaser/packages/contracts/foundry.toml
+++ b/templates/phaser/packages/contracts/foundry.toml
@@ -25,6 +25,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/phaser/packages/contracts/foundry.toml
+++ b/templates/phaser/packages/contracts/foundry.toml
@@ -22,5 +22,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/react/packages/contracts/foundry.toml
+++ b/templates/react/packages/contracts/foundry.toml
@@ -25,6 +25,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/react/packages/contracts/foundry.toml
+++ b/templates/react/packages/contracts/foundry.toml
@@ -22,5 +22,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/threejs/packages/contracts/foundry.toml
+++ b/templates/threejs/packages/contracts/foundry.toml
@@ -25,6 +25,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/threejs/packages/contracts/foundry.toml
+++ b/templates/threejs/packages/contracts/foundry.toml
@@ -22,5 +22,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/threejs/packages/contracts/src/systems/MoveSystem.sol
+++ b/templates/threejs/packages/contracts/src/systems/MoveSystem.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
+
 import { System } from "@latticexyz/world/src/System.sol";
 import { Position, PositionData } from "../codegen/Tables.sol";
 

--- a/templates/vanilla/packages/contracts/foundry.toml
+++ b/templates/vanilla/packages/contracts/foundry.toml
@@ -25,6 +25,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 [fmt]
 tab_width = 2
 bracket_spacing = true
+ignore = ['**/codegen/**/*.sol']
 
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"

--- a/templates/vanilla/packages/contracts/foundry.toml
+++ b/templates/vanilla/packages/contracts/foundry.toml
@@ -22,5 +22,9 @@ extra_output_files = [
 ]
 fs_permissions = [{ access = "read", path = "./"}]
 
+[fmt]
+tab_width = 2
+bracket_spacing = true
+
 [profile.lattice-testnet]
 eth_rpc_url = "https://follower.testnet-chain.linfra.xyz"


### PR DESCRIPTION
At some point, prettier/vscode stopped talking to each other and wasn't getting format-on-save anymore.

This PR updates our vscode formatting to use `forge fmt` (and runs it across the repo).

Two notes that might block this PR from being good to merge:
- it's tricky to add a root-level formatter for our git hooks because `forge fmt` uses the `foundry.toml` relative to where the command was run, rather than relative to the source file (see #5686) but there's a workaround
- we probably should use `forge fmt` for codegen too and remove the ignores, but needs some deeper code changes
