### PR TITLE
docs: Add /trpc subroute to url indexer documentation and read example

### DIFF
--- a/docs/pages/indexer.mdx
+++ b/docs/pages/indexer.mdx
@@ -38,7 +38,7 @@ They are written under the assumption you are using `anvil` for your test chain,
 1. Run this command as a sanity check to verify the indexer is working correctly:
 
    ```sh copy
-   curl 'http://localhost:3001/findAll?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' | jq
+   curl 'http://localhost:3001/trpc/findAll?batch=1&input=%7B%220%22%3A%7B%22json%22%3A%7B%22chainId%22%3A31337%2C%22address%22%3A%220x5FbDB2315678afecb367f032d93F642f64180aa3%22%7D%7D%7D' | jq
    ```
 
    The result should be nicely formatted (and long) JSON output.
@@ -89,11 +89,11 @@ The actual value: 2
 ```ts
 import { createIndexerClient } from "@latticexyz/store-sync/trpc-indexer";
 const indexer = createIndexerClient({
-  url: "http://localhost:3001",
+  url: "http://localhost:3001/trpc",
 });
 ```
 
-Create an indexer client. The URL, `http://localhost/3001`, is the one for the indexer you run on the local computer.
+Create an indexer client. The URL, `http://localhost/3001/trpc`, is the one for the indexer you run on the local computer.
 If the indexer is elsewhere, modify the URL as appropriate.
 
 ```ts

--- a/examples/indexer-client/index.ts
+++ b/examples/indexer-client/index.ts
@@ -1,6 +1,6 @@
 import { createIndexerClient } from "@latticexyz/store-sync/trpc-indexer";
 const indexer = createIndexerClient({
-  url: "http://localhost:3001",
+  url: "http://localhost:3001/trpc",
 });
 
 const result = await indexer.findAll.query({


### PR DESCRIPTION
When attempting to follow the [installation](https://mud.dev/indexer#installation) instructions on for the indexer and run the indexer. A call to the indexer yields a 404 response. This is because the indexer client url is missing the `/trpc` subroute in order to be able to communicate with the latest indexer.

This commit: 
- Updates the indexer installation documentation
- Updates the indexer client url in the `read-indexer` example