### PR TITLE
chore: move CI tests to test:ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           DATABASE_URL: "postgres://postgres@localhost:5432/postgres"
         working-directory: ./e2e/packages/sync-test
-        run: pnpm test
+        run: pnpm test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: "postgres://postgres@localhost:5432/postgres"
-        run: pnpm test
+        run: pnpm test:ci
 
       - name: Generate gas reports
         run: pnpm gas-report

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,8 @@
     "build": "pnpm recursive run build",
     "clean": "pnpm recursive run clean",
     "playwright-install": "pnpx playwright@1.35.1 install --with-deps chromium",
-    "test": "pnpm recursive run test"
+    "test": "pnpm recursive run test",
+    "test:ci": "pnpm run test"
   },
   "devDependencies": {
     "@playwright/test": "1.35.1"

--- a/e2e/packages/contracts/package.json
+++ b/e2e/packages/contracts/package.json
@@ -13,7 +13,8 @@
     "clean:mud": "rimraf src/codegen",
     "clean:typechain": "rimraf types",
     "deploy:local": "mud deploy",
-    "test": "mud test"
+    "test": "mud test",
+    "test:ci": "pnpm run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../../packages/cli",

--- a/e2e/packages/sync-test/package.json
+++ b/e2e/packages/sync-test/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "test:ci": "pnpm run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../../packages/cli",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "release:publish": "pnpm install && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
-    "test": "pnpm recursive run test"
+    "test": "pnpm recursive run test",
+    "test:ci": "pnpm recursive run test:ci"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",

--- a/packages/block-logs-stream/package.json
+++ b/packages/block-logs-stream/package.json
@@ -20,7 +20,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint .",
-    "test": "vitest typecheck --run --passWithNoTests && vitest --run --passWithNoTests"
+    "test": "vitest typecheck --run --passWithNoTests && vitest --run --passWithNoTests",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/common": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts",
-    "test": "tsc --noEmit && forge test"
+    "test": "tsc --noEmit && forge test",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -53,7 +53,8 @@
     "clean": "pnpm run clean:js",
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "vitest typecheck --run --passWithNoTests && vitest --run"
+    "test": "vitest typecheck --run --passWithNoTests && vitest --run",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/schema-type": "workspace:*",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -33,7 +33,8 @@
     "clean": "pnpm run clean:js",
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/common": "workspace:*",

--- a/packages/create-mud/package.json
+++ b/packages/create-mud/package.json
@@ -16,6 +16,7 @@
     "dev": "tsup --watch",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "pnpm run test:vanilla && pnpm run test:react && pnpm run test:phaser && pnpm run test:threejs",
+    "test:ci": "pnpm run test",
     "test:phaser": "dist/cli.js test-project --template phaser && rimraf test-project",
     "test:react": "dist/cli.js test-project --template react && rimraf test-project",
     "test:threejs": "dist/cli.js test-project --template threejs && rimraf test-project",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -19,7 +19,8 @@
     "clean": "pnpm run clean:js",
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/common": "workspace:*",

--- a/packages/gas-report/package.json
+++ b/packages/gas-report/package.json
@@ -26,7 +26,8 @@
     "build": "tsup",
     "clean": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "vitest typecheck --run --passWithNoTests && vitest --run --passWithNoTests && forge test"
+    "test": "vitest typecheck --run --passWithNoTests && vitest --run --passWithNoTests && forge test",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "chalk": "^5.3.0",

--- a/packages/noise/package.json
+++ b/packages/noise/package.json
@@ -16,7 +16,8 @@
     "clean:wasm": "rimraf build",
     "dev": "tsup --watch",
     "start": "npx serve .",
-    "test": "forge test && tsc --noEmit"
+    "test": "forge test && tsc --noEmit",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "abdk-libraries-solidity": "^3.0.0",

--- a/packages/phaserx/package.json
+++ b/packages/phaserx/package.json
@@ -19,7 +19,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts",
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/utils": "workspace:*",

--- a/packages/protocol-parser/package.json
+++ b/packages/protocol-parser/package.json
@@ -20,7 +20,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint .",
-    "test": "vitest typecheck --run && vitest --run"
+    "test": "vitest typecheck --run && vitest --run",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/common": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,8 @@
     "clean": "pnpm run clean:js",
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
-    "test": "tsc --noEmit && vitest --run"
+    "test": "tsc --noEmit && vitest --run",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/recs": "workspace:*",

--- a/packages/recs/package.json
+++ b/packages/recs/package.json
@@ -29,7 +29,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts",
-    "test": "tsc --noEmit && jest"
+    "test": "tsc --noEmit && jest",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/schema-type": "workspace:*",

--- a/packages/schema-type/package.json
+++ b/packages/schema-type/package.json
@@ -30,7 +30,8 @@
     "clean:js": "rimraf dist/typescript",
     "dev": "tsup --watch",
     "gas-report": "mud-gas-report --save gas-report.json",
-    "test": "vitest typecheck --run && vitest --run && forge test"
+    "test": "vitest typecheck --run && vitest --run && forge test",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "abitype": "0.9.3",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -42,6 +42,7 @@
     "build:protobuf": "make protoc-ts && prettier --write protobuf/ts/**/*.ts",
     "dev": "tsup --watch",
     "test": "pnpm run test:go",
+    "test:ci": "pnpm run test",
     "test:go": "go test -v ./..."
   },
   "dependencies": {

--- a/packages/store-indexer/package.json
+++ b/packages/store-indexer/package.json
@@ -28,7 +28,8 @@
     "start:sqlite:local": "SQLITE_FILENAME=anvil.db CHAIN_ID=31337 pnpm start:sqlite",
     "start:sqlite:testnet": "SQLITE_FILENAME=testnet.db CHAIN_ID=4242 START_BLOCK=19037160 pnpm start:sqlite",
     "start:sqlite:testnet2": "SQLITE_FILENAME=testnet2.db CHAIN_ID=4243 pnpm start:sqlite",
-    "test": "tsc --noEmit --skipLibCheck"
+    "test": "tsc --noEmit --skipLibCheck",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@fastify/cors": "^8.3.0",

--- a/packages/store-sync/package.json
+++ b/packages/store-sync/package.json
@@ -43,7 +43,8 @@
     "dev": "tsup --watch",
     "lint": "eslint .",
     "test": "vitest --run",
-    "test:local": "DATABASE_URL=http://127.0.0.1:5432/postgres vitest"
+    "test:local": "DATABASE_URL=http://127.0.0.1:5432/postgres vitest",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@latticexyz/block-logs-stream": "workspace:*",

--- a/packages/store-sync/package.json
+++ b/packages/store-sync/package.json
@@ -42,9 +42,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint .",
-    "test": "vitest --run",
-    "test:local": "DATABASE_URL=http://127.0.0.1:5432/postgres vitest",
-    "test:ci": "pnpm run test"
+    "test": "DATABASE_URL=http://127.0.0.1:5432/postgres vitest",
+    "test:ci": "vitest --run"
   },
   "dependencies": {
     "@latticexyz/block-logs-stream": "workspace:*",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -48,7 +48,8 @@
     "dev": "tsup --watch",
     "gas-report": "mud-gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",
-    "test": "vitest typecheck --run && vitest --run --passWithNoTests && forge test"
+    "test": "vitest typecheck --run && vitest --run --passWithNoTests && forge test",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,8 @@
     "clean:js": "rimraf dist",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts",
-    "test": "tsc --noEmit && jest"
+    "test": "tsc --noEmit && jest",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "ethers": "^5.7.2",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -44,7 +44,8 @@
     "dev": "tsup --watch",
     "gas-report": "mud-gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",
-    "test": "tsc --noEmit && vitest --run && forge test"
+    "test": "tsc --noEmit && vitest --run && forge test",
+    "test:ci": "pnpm run test"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",


### PR DESCRIPTION
Fix #1361

- Added `test:ci` to teach package inside `packages/`, default to `test`
- Updated CI to use `test:ci`