### PR TITLE
fix(services): correctly export typescript types

### DIFF
--- a/.changeset/clever-rats-sip.md
+++ b/.changeset/clever-rats-sip.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/services": patch
+---
+
+Fixed an issue where the TypeScript types for createFaucetService were not exported correctly from the @latticexyz/services package

--- a/packages/services/.npmignore
+++ b/packages/services/.npmignore
@@ -5,3 +5,4 @@
 !package.json
 !README.md
 !protobuf/**
+!ts/**


### PR DESCRIPTION
Fixes #1374 