### PR TITLE
ci: pin bun to 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier:check": "prettier --check '**/*.{ts,tsx,css,md,mdx,sol}'",
     "release:check": "changeset status --verbose --since=origin/main",
     "release:publish": "pnpm install && pnpm build && changeset publish",
-    "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun scripts/changelog.ts",
+    "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
     "test": "pnpm recursive run test"
   },


### PR DESCRIPTION
There is a bun issue with `0.8.1` that makes our pre-release changelog action fail in CI, see https://github.com/oven-sh/bun/issues/4327 for context. Pinning it to `0.7.3` should hopefully fix it for now.