### PR TITLE
docs: fix table references in store hooks example

### DIFF
--- a/docs/pages/store/advanced-features.mdx
+++ b/docs/pages/store/advanced-features.mdx
@@ -90,17 +90,17 @@ contract MirrorSubscriber is IStoreHook {
   }
 
   function onSetRecord(uint256 table, bytes32[] memory key, bytes memory data) public {
-    if (table != table) revert("invalid table");
+    if (_table != table) revert("invalid table");
     StoreSwitch.setRecord(indexerTableId, key, data);
   }
 
   function onSetField(uint256 table, bytes32[] memory key, uint8 schemaIndex, bytes memory data) public {
-    if (table != table) revert("invalid table");
+    if (_table != table) revert("invalid table");
     StoreSwitch.setField(indexerTableId, key, schemaIndex, data);
   }
 
   function onDeleteRecord(uint256 table, bytes32[] memory key) public {
-    if (table != table) revert("invalid table");
+    if (_table != table) revert("invalid table");
     StoreSwitch.deleteRecord(indexerTableId, key);
   }
 }


### PR DESCRIPTION
Chang 
```
if (table != table) revert("invalid table");
```
to
```
if (_table != table) revert("invalid table");
```