### PR TITLE
docs: Change the name of "getting started example" to "template"

### DIFF
--- a/docs/pages/tutorials.mdx
+++ b/docs/pages/tutorials.mdx
@@ -2,9 +2,9 @@
 
 These tutorials teach you how to do various things with MUD.
 
-## Modifying the getting started example
+## Modifying the template
 
-[These tutorials](tutorials/minimal) teach you how to make various changes to [the getting started example](https://github.com/latticexyz/mud/tree/main/examples/minimal).
+[These tutorials](tutorials/minimal) teach you how to make various changes to [the application template](https://github.com/latticexyz/mud/tree/main/examples/minimal).
 This is an easy way to learn how to modify MUD functionality in various ways.
 
 - [Add a table](tutorials/minimal/add-table):
@@ -16,7 +16,7 @@ This is an easy way to learn how to modify MUD functionality in various ways.
 
 [These tutorials](tutorials/walkthrough) are deep dives into various sections of code.
 
-- [The onchain components of getting started](tutorials/walkthrough/onchain):
+- [The onchain components of the template](tutorials/walkthrough/onchain):
   In this tutorial you learn how to understand the onchain components of the minimal template.
 
 ## Emojimon

--- a/docs/pages/tutorials/minimal.mdx
+++ b/docs/pages/tutorials/minimal.mdx
@@ -5,7 +5,7 @@ This is an easy way to learn how to modify MUD functionality in various ways.
 
 ## Getting the initial version
 
-All of these examples are based on the vanilla version of the tempolate.
+All of these examples are based on the vanilla version of the template.
 To create the basic version to modify, follow these steps:
 
 1. Create a version 2.0 MUD starter.

--- a/docs/pages/tutorials/minimal.mdx
+++ b/docs/pages/tutorials/minimal.mdx
@@ -1,11 +1,11 @@
-# Modifying the getting started example
+# Modifying the template
 
-These tutorials teach you how to make various changes to [the getting started example](https://github.com/latticexyz/mud/tree/main/examples/minimal).
+These tutorials teach you how to make various changes to [the vanilla template](https://github.com/latticexyz/mud/tree/main/templates/vanilla).
 This is an easy way to learn how to modify MUD functionality in various ways.
 
 ## Getting the initial version
 
-All of these examples are based on the vanilla version of getting started.
+All of these examples are based on the vanilla version of the tempolate.
 To create the basic version to modify, follow these steps:
 
 1. Create a version 2.0 MUD starter.
@@ -16,7 +16,7 @@ To create the basic version to modify, follow these steps:
 
 1. Select the **vanilla** template.
 
-1. Change to the tutorial directory and start the getting started application.
+1. Change to the tutorial directory and start the application.
 
    ```bash copy
    cd tutorial

--- a/docs/pages/tutorials/walkthrough/_meta.js
+++ b/docs/pages/tutorials/walkthrough/_meta.js
@@ -1,3 +1,3 @@
 export default {
-  "minimal-onchain": "Onchain components of getting started",
+  "minimal-onchain": "The onchain components of the template",
 };

--- a/docs/pages/tutorials/walkthrough/minimal-onchain.mdx
+++ b/docs/pages/tutorials/walkthrough/minimal-onchain.mdx
@@ -1,6 +1,6 @@
-# The onchain components of getting started
+# The onchain components of the template
 
-You [installed the getting started code](/quick-start), and now you can increment the counter with the best of them.
+You [installed the template code](/quick-start), and now you can increment the counter with the best of them.
 Unfortunately, when you tried to figure out what is happening, it is as clear as mud.
 Have no fear, in this tutorial you learn how to understand the onchain components of the minimal template.
 


### PR DESCRIPTION
In the tutorials which use the template