### PR TITLE
build(docker): push latest next version under next tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=match,pattern=@(.*),group=1
+            type=match,pattern=@.*-(next),group=1
             type=ref,event=branch
             type=sha
       - name: Build and push Docker image


### PR DESCRIPTION
This should take any next version (e.g. `2.0.0-next.5`) and publish it under the `next` tag.