### PR TITLE
fix(ci): only process added changesets in changelog.ts script

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -99,7 +99,7 @@ async function getChanges(include: "diff" | "all") {
     const changesetDiff = (await execa("git", ["diff", "main", ".changeset/pre.json"])).stdout;
 
     // Get the list of changesets
-    const addedLinesRegex = /\+\s+"([^"]+)"/g;
+    const addedLinesRegex = /\+\s+"(?!.*:)([^"]+)"/g;
     changesetsToInclude.push(...[...changesetDiff.matchAll(addedLinesRegex)].map((match) => match[1]));
   } else if (include === "all") {
     // Load all current changesets from the .changeset/pre.json file


### PR DESCRIPTION
The previous script was processing any added line to the `.changeset/pre.json` file, causing issues when there was a package added to `initialVersions` in `.changeset/pre.json`. Now we're restricting the regex to lines matching the changeset pattern.