### PR TITLE
build: wait for snapshot/prerelease before pushing docker container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,22 @@ jobs:
           - image: ghcr.io/latticexyz/store-indexer
             target: store-indexer
     steps:
+      - name: Wait for snapshot
+        if: github.event_name != 'workflow_dispatch'
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: "Publish snapshot release to npm"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      - name: Wait for prerelease
+        if: github.event_name != 'workflow_dispatch'
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: "Changesets Prerelease"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Log in to the Container registry

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   prerelease:
-    name: Changests Prerelease
+    name: Changesets Prerelease
     if: github.repository == 'latticexyz/mud'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
@@ -33,7 +33,7 @@ jobs:
         run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+
       - name: Check for pre.json file existence
         id: check_files
         uses: andstor/file-existence-action@v2.0.0
@@ -47,10 +47,9 @@ jobs:
         run: npx changeset pre enter next
 
       - name: Create next version PR or publish 🚀
-        uses: changesets/action@v1 
+        uses: changesets/action@v1
         with:
           version: pnpm release:version
           publish: pnpm release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
I think we're not seeing Docker images tagged with `next` because the tag doesn't exist at the time the docker job is run (because the snapshot/prerelease jobs haven't completed, thus haven't created tags).

This PR attempts to wait for these jobs to complete before running the docker job.