### PR TITLE
build: use git context when creating docker metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
+          context: git
           images: ${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
https://github.com/docker/metadata-action#context-input

Hoping that this will help the workflow find the next tags, since they may not be available in e.g. `workflow_dispatch` event (manual trigger).