### PR TITLE
fix(abi-ts): remove cwd join

### DIFF
--- a/.changeset/long-lizards-admire.md
+++ b/.changeset/long-lizards-admire.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/abi-ts": patch
+---
+
+Let `glob` handle resolving the glob against the current working directory.

--- a/packages/abi-ts/src/index.ts
+++ b/packages/abi-ts/src/index.ts
@@ -24,7 +24,7 @@ const commandModule: CommandModule<Options, Options> = {
   },
 
   handler({ input }) {
-    const files = glob.sync(path.join(process.cwd(), input));
+    const files = glob.sync(input);
 
     if (!files.length) {
       console.error(`No files found for glob: ${input}`);


### PR DESCRIPTION
Realized that this will fail for a glob that targets multiple files, e.g. `abi/IWorld.sol/IWorld.abi.json,abi/IStore.sol/IStore.abi.json`. And `glob` already defaults to using `process.cwd()` for how the glob is resolved.