### PR TITLE
feat(dev-tools): hide tabs and custom tabs

### DIFF
--- a/packages/dev-tools/src/App.tsx
+++ b/packages/dev-tools/src/App.tsx
@@ -1,10 +1,11 @@
-import "./preflight.css";
-import "tailwindcss/tailwind.css";
-import { useEffect, useState } from "react";
-import { twMerge } from "tailwind-merge";
-import { router } from "./router";
+import { useEffect, useMemo } from "react";
 import { RouterProvider } from "react-router-dom";
+import { twMerge } from "tailwind-merge";
+import "tailwindcss/tailwind.css";
 import useLocalStorageState from "use-local-storage-state";
+import { useDevToolsContext } from "./DevToolsContext";
+import "./preflight.css";
+import { createRouter } from "./router";
 
 // TODO: fix tab index so that it's not possible to tab around in the UI when it's hidden
 
@@ -23,6 +24,8 @@ export function App() {
     return () => window.removeEventListener("keypress", listener);
   });
 
+  const settings = useDevToolsContext();
+  const router = useMemo(() => createRouter(settings), []);
   return (
     <div className="fixed inset-0 pointer-events-none">
       <div
@@ -35,14 +38,14 @@ export function App() {
         <div className="absolute bottom-0 right-full min-w-max flex flex-col-reverse items-end justify-center m-2 text-gray-500">
           <button
             type="button"
-            className="peer text-sm p-2 rounded leading-none transition opacity-60 hover:opacity-100"
+            className="peer text-sm rounded leading-none transition opacity-60 hover:opacity-100"
             onClick={() => setShown(!shown)}
           >
-            <span className="whitespace-nowrap font-medium">{shown ? "→" : "←"} MUD Dev Tools</span>
+            <span className="whitespace-nowrap font-medium text-xs">{shown ? "→" : "←"} MUD Dev Tools</span>
           </button>
           <span className="transition opacity-0 peer-hover:opacity-60 px-2 text-xs flex items-center justify-center gap-2">
-            Keyboard shortcut
-            <code className="bg-gray-500/10 p-1 rounded text-mono text-xs leading-none">`</code>
+            hotkey
+            <code className="bg-gray-500/10 p-1 border border-gray-300 rounded text-mono text-xs leading-none">`</code>
           </span>
         </div>
         <div

--- a/packages/dev-tools/src/RootPage.tsx
+++ b/packages/dev-tools/src/RootPage.tsx
@@ -1,10 +1,10 @@
-import { twMerge } from "tailwind-merge";
 import { Outlet } from "react-router-dom";
-import { NavButton } from "./NavButton";
+import { twMerge } from "tailwind-merge";
 import { useDevToolsContext } from "./DevToolsContext";
+import { NavButton } from "./NavButton";
 
 export function RootPage() {
-  const { recsWorld } = useDevToolsContext();
+  const { recsWorld, hideActions, hideComponents, hideEvents, tabs } = useDevToolsContext();
   return (
     <>
       <div className="flex-none bg-slate-900 text-white/60 font-medium">
@@ -16,23 +16,27 @@ export function RootPage() {
         >
           Summary
         </NavButton>
-        <NavButton
-          to="/actions"
-          className={({ isActive }) =>
-            twMerge("py-1.5 px-3", isActive ? "bg-slate-800 text-white" : "hover:bg-blue-800 hover:text-white")
-          }
-        >
-          Actions
-        </NavButton>
-        <NavButton
-          to="/events"
-          className={({ isActive }) =>
-            twMerge("py-1.5 px-3", isActive ? "bg-slate-800 text-white" : "hover:bg-blue-800 hover:text-white")
-          }
-        >
-          Store log
-        </NavButton>
-        {recsWorld ? (
+        {!hideActions && (
+          <NavButton
+            to="/actions"
+            className={({ isActive }) =>
+              twMerge("py-1.5 px-3", isActive ? "bg-slate-800 text-white" : "hover:bg-blue-800 hover:text-white")
+            }
+          >
+            Actions
+          </NavButton>
+        )}
+        {!hideEvents && (
+          <NavButton
+            to="/events"
+            className={({ isActive }) =>
+              twMerge("py-1.5 px-3", isActive ? "bg-slate-800 text-white" : "hover:bg-blue-800 hover:text-white")
+            }
+          >
+            Store log
+          </NavButton>
+        )}
+        {recsWorld && !hideComponents ? (
           <NavButton
             to="/components"
             className={({ isActive }) =>
@@ -42,6 +46,17 @@ export function RootPage() {
             Components
           </NavButton>
         ) : null}
+        {tabs?.map((tab) => (
+          <NavButton
+            key={tab.path}
+            to={`/${tab.path}`}
+            className={({ isActive }) =>
+              twMerge("py-1.5 px-3", isActive ? "bg-slate-800 text-white" : "hover:bg-blue-800 hover:text-white")
+            }
+          >
+            {tab.path}
+          </NavButton>
+        ))}
       </div>
       <div className="flex-1 overflow-auto">
         <Outlet />

--- a/packages/dev-tools/src/common.ts
+++ b/packages/dev-tools/src/common.ts
@@ -1,11 +1,11 @@
-import { Observable } from "rxjs";
-import { Abi, Block, Chain, PublicClient, Transport, WalletClient } from "viem";
-import { StoreConfig } from "@latticexyz/store";
-import { BlockStorageOperations } from "@latticexyz/store-sync";
 import { ContractWrite } from "@latticexyz/common";
 import { World as RecsWorld } from "@latticexyz/recs";
+import { StoreConfig } from "@latticexyz/store";
+import { BlockStorageOperations } from "@latticexyz/store-sync";
+import { Observable } from "rxjs";
+import { Abi, Block, Chain, PublicClient, Transport, WalletClient } from "viem";
 
-export type DevToolsOptions<TConfig extends StoreConfig = StoreConfig> = {
+export type DevToolsOptions<TConfig extends StoreConfig = StoreConfig> = RouteOptions & {
   config: TConfig;
   publicClient: PublicClient<Transport, Chain>;
   walletClient: WalletClient<Transport, Chain>;
@@ -15,4 +15,11 @@ export type DevToolsOptions<TConfig extends StoreConfig = StoreConfig> = {
   worldAbi: Abi;
   write$: Observable<ContractWrite>;
   recsWorld?: RecsWorld;
+};
+
+export type RouteOptions = {
+  hideActions?: boolean;
+  hideEvents?: boolean;
+  hideComponents?: boolean;
+  tabs?: { path: string; element: JSX.Element }[];
 };

--- a/packages/dev-tools/src/router.tsx
+++ b/packages/dev-tools/src/router.tsx
@@ -1,21 +1,26 @@
 import { createMemoryRouter, createRoutesFromElements, Route } from "react-router-dom";
+import { ActionsPage } from "./actions/ActionsPage";
+import { RouteOptions } from "./common";
+import { EventsPage } from "./events/EventsPage";
+import { ComponentData } from "./recs/ComponentData";
+import { ComponentsPage } from "./recs/ComponentsPage";
 import { RootPage } from "./RootPage";
 import { RouteError } from "./RouteError";
-import { EventsPage } from "./events/EventsPage";
 import { SummaryPage } from "./summary/SummaryPage";
-import { ActionsPage } from "./actions/ActionsPage";
-import { ComponentsPage } from "./recs/ComponentsPage";
-import { ComponentData } from "./recs/ComponentData";
 
-export const router = createMemoryRouter(
-  createRoutesFromElements(
-    <Route path="/" element={<RootPage />} errorElement={<RouteError />}>
-      <Route index element={<SummaryPage />} />
-      <Route path="actions" element={<ActionsPage />} />
-      <Route path="events" element={<EventsPage />} />
-      <Route path="components" element={<ComponentsPage />}>
-        <Route path=":id" element={<ComponentData />} />
+export const createRouter = (settings: RouteOptions) =>
+  createMemoryRouter(
+    createRoutesFromElements(
+      <Route path="/" element={<RootPage />} errorElement={<RouteError />}>
+        <Route index element={<SummaryPage />} />
+        <Route path="actions" element={<ActionsPage />} />
+        <Route path="events" element={<EventsPage />} />
+        <Route path="components" element={<ComponentsPage />}>
+          <Route path=":id" element={<ComponentData />} />
+        </Route>
+        {settings.tabs?.map((tab, i) => (
+          <Route key={tab.path + i} path={tab.path} element={tab.element} />
+        ))}
       </Route>
-    </Route>
-  )
-);
+    )
+  );


### PR DESCRIPTION
I want to continue using my modified ecs-browser but also want access to the new mud dev-tools. This PR allows me to continue using my custom tooling within the mud dev tools window. It also adds options for hiding unused tools.