### PR TITLE
docs: fix the license link

### DIFF
--- a/docs/pages/introduction.mdx
+++ b/docs/pages/introduction.mdx
@@ -13,4 +13,4 @@ MUD is maximally onchain: the entire application state lives in the EVM, and the
 
 ## License
 
-MUD is open-source software [licensed as MIT](LICENSE).
+MUD is open-source software [licensed as MIT](https://github.com/latticexyz/mud/blob/main/LICENSE).


### PR DESCRIPTION
Fix the license hyperlink to align it with the MUD GitHub jump location.