### PR TITLE
docs: fix the hyperlink for the "tablegen" button

### DIFF
--- a/docs/pages/store/advanced-features.mdx
+++ b/docs/pages/store/advanced-features.mdx
@@ -32,7 +32,7 @@ CounterSingleton.set(1);
 uint256 value = CounterSingleton.get();
 ```
 
-Additional documentation on Table library generation can be found in the [`tablegen`](tablegen) section.
+Additional documentation on Table library generation can be found in the [`tablegen`](/world/internals) section.
 
 ### Ephemeral tables
 


### PR DESCRIPTION
I have a few questions about this. Although the example in the previous context is a table in the Store, according to the original article, it should jump to "store/internals". However, the introduction to tables in "world/internals" is clearly more detailed and comprehensive. Considering that the World uses Store internals because it calls StoreCore.initialize in its constructor, I will redirect the link to the "world/internals" directory.