### PR TITLE
docs: delete the introduction of the RegistrationModule

### DIFF
--- a/docs/pages/world/modules.mdx
+++ b/docs/pages/world/modules.mdx
@@ -12,10 +12,6 @@ It adds critical tables and systems to the World, which are externalized to keep
 
 See [World internals](/world/internals) for table and system details.
 
-2. **`RegistrationModule`**
-
-The [`RegistrationModule`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/registration/RegistrationModule.sol) adds the [`RegistrationSystem`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/registration/RegistrationSystem.sol) along with its dependencies to the World. This registration system surfaces the APIs necessary to register Systems, Tables, and Namespaces on-chain without being the World root user. If you do not want to make your World permissionlessly extensible, you can simply not install the RegistrationModule (this is not supported by the CLI right now).
-
 #### **`UniqueEntityModule`**
 
 The [`UniqueEntityModule`](https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/uniqueentity/UniqueEntityModule.sol) installs a system that always returns a unique `bytes32` key. It is designed for tables that have one key (eg: ECS components).


### PR DESCRIPTION
Delete the introduction of the RegistrationModule on the modules page, as the module has been deleted or renamed.

https://mud.dev/world/modules
	https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/registration/RegistrationModule.sol
	  \_____ error code: 404 (not found)
	https://github.com/latticexyz/mud/blob/main/packages/world/src/modules/registration/RegistrationSystem.sol
	  \_____ error code: 404 (not found)

If you wish to keep, please edit it again.