### PR TITLE
docs: fix the incorrect link on the world-101 page

### DIFF
--- a/docs/pages/world/world-101.mdx
+++ b/docs/pages/world/world-101.mdx
@@ -60,7 +60,7 @@ In most basic cases, you don’t need to worry about namespaces and access contr
 Systems are stateless pieces of logic executed on the World, represented as a resource within a namespace.
 They are written in Solidity and compile to the EVM like regular smart contracts. You can think of them as SQL functions acting your SQL database (Store in this case).
 
-Systems read and store their state on the World's Store. These storage access are abstracted via the libraries generated with `tablegen`. You can learn more about `tablegen` in the [Store doc](//reading-and-writing).
+Systems read and store their state on the World's Store. These storage access are abstracted via the libraries generated with `tablegen`. You can learn more about `tablegen` in the [Store doc](/store/reading-and-writing).
 
 **Reading and writing to the state in a system:**
 


### PR DESCRIPTION
fix the incorrect link

https://mud.dev/reading-and-writing
error code: 404 (not found), linked from page(s):
	https://mud.dev/world/world-101