### PR TITLE
chore: suppress diffs for codegen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# suppress diffs for codegen in PRs
+**/abi/**/* linguist-generated=true
+**/codegen/**/* linguist-generated=true


### PR DESCRIPTION
mostly a quality of life thing to make it easier to review PRs

looks like:
<img width="1159" alt="image" src="https://github.com/latticexyz/mud/assets/508855/90a84ec7-c012-4984-89c8-de0851649b42">
