### PR TITLE
draft: gas optimization

### DIFF
--- a/e2e/packages/contracts/foundry.toml
+++ b/e2e/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/examples/minimal/packages/contracts/foundry.toml
+++ b/examples/minimal/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -87,6 +87,18 @@ library Dynamics1 {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -98,6 +110,15 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get staticB32 */
+  function _getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -116,6 +137,20 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.setField(
+      _tableId,
+      _keyTuple,
+      0,
+      EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)),
+      getFieldLayout()
+    );
+  }
+
+  /** Set staticB32 */
+  function _setStaticB32(bytes32 key, bytes32[1] memory staticB32) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(
       _tableId,
       _keyTuple,
       0,
@@ -143,6 +178,17 @@ library Dynamics1 {
     }
   }
 
+  /** Get the length of staticB32 */
+  function _lengthStaticB32(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
   /** Get the length of staticB32 (using the specified store) */
   function lengthStaticB32(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -164,6 +210,27 @@ library Dynamics1 {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of staticB32
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStaticB32(bytes32 key, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -204,6 +271,14 @@ library Dynamics1 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to staticB32 */
+  function _pushStaticB32(bytes32 key, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to staticB32 (using the specified store) */
   function pushStaticB32(IStore _store, bytes32 key, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -218,6 +293,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32, getFieldLayout());
+  }
+
+  /** Pop an element from staticB32 */
+  function _popStaticB32(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 32, getFieldLayout());
   }
 
   /** Pop an element from staticB32 (using the specified store) */
@@ -242,6 +325,19 @@ library Dynamics1 {
   }
 
   /**
+   * Update an element of staticB32 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStaticB32(bytes32 key, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
    * Update an element of staticB32 (using the specified store) at `_index`
    * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
    */
@@ -260,6 +356,15 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
+  }
+
+  /** Get staticI32 */
+  function _getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
@@ -286,6 +391,20 @@ library Dynamics1 {
     );
   }
 
+  /** Set staticI32 */
+  function _setStaticI32(bytes32 key, int32[2] memory staticI32) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(
+      _tableId,
+      _keyTuple,
+      1,
+      EncodeArray.encode(fromStaticArray_int32_2(staticI32)),
+      getFieldLayout()
+    );
+  }
+
   /** Set staticI32 (using the specified store) */
   function setStaticI32(IStore _store, bytes32 key, int32[2] memory staticI32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -300,6 +419,17 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    unchecked {
+      return _byteLength / 4;
+    }
+  }
+
+  /** Get the length of staticI32 */
+  function _lengthStaticI32(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
     unchecked {
       return _byteLength / 4;
     }
@@ -338,6 +468,27 @@ library Dynamics1 {
   }
 
   /**
+   * Get an item of staticI32
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStaticI32(bytes32 key, uint256 _index) internal view returns (int32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        1,
+        getFieldLayout(),
+        _index * 4,
+        (_index + 1) * 4
+      );
+      return (int32(uint32(Bytes.slice4(_blob, 0))));
+    }
+  }
+
+  /**
    * Get an item of staticI32 (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -359,6 +510,14 @@ library Dynamics1 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to staticI32 */
+  function _pushStaticI32(bytes32 key, int32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to staticI32 (using the specified store) */
   function pushStaticI32(IStore _store, bytes32 key, int32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -373,6 +532,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 4, getFieldLayout());
+  }
+
+  /** Pop an element from staticI32 */
+  function _popStaticI32(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 1, 4, getFieldLayout());
   }
 
   /** Pop an element from staticI32 (using the specified store) */
@@ -393,6 +560,19 @@ library Dynamics1 {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of staticI32 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStaticI32(bytes32 key, uint256 _index, int32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 1, _index * 4, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -418,6 +598,15 @@ library Dynamics1 {
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
+  /** Get staticU128 */
+  function _getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
+  }
+
   /** Get staticU128 (using the specified store) */
   function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -433,6 +622,20 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.setField(
+      _tableId,
+      _keyTuple,
+      2,
+      EncodeArray.encode(fromStaticArray_uint128_3(staticU128)),
+      getFieldLayout()
+    );
+  }
+
+  /** Set staticU128 */
+  function _setStaticU128(bytes32 key, uint128[3] memory staticU128) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(
       _tableId,
       _keyTuple,
       2,
@@ -466,6 +669,17 @@ library Dynamics1 {
     }
   }
 
+  /** Get the length of staticU128 */
+  function _lengthStaticU128(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    unchecked {
+      return _byteLength / 16;
+    }
+  }
+
   /** Get the length of staticU128 (using the specified store) */
   function lengthStaticU128(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -487,6 +701,27 @@ library Dynamics1 {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        2,
+        getFieldLayout(),
+        _index * 16,
+        (_index + 1) * 16
+      );
+      return (uint128(Bytes.slice16(_blob, 0)));
+    }
+  }
+
+  /**
+   * Get an item of staticU128
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStaticU128(bytes32 key, uint256 _index) internal view returns (uint128) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         2,
@@ -527,6 +762,14 @@ library Dynamics1 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to staticU128 */
+  function _pushStaticU128(bytes32 key, uint128 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to staticU128 (using the specified store) */
   function pushStaticU128(IStore _store, bytes32 key, uint128 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -541,6 +784,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 16, getFieldLayout());
+  }
+
+  /** Pop an element from staticU128 */
+  function _popStaticU128(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 2, 16, getFieldLayout());
   }
 
   /** Pop an element from staticU128 (using the specified store) */
@@ -561,6 +812,19 @@ library Dynamics1 {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of staticU128 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStaticU128(bytes32 key, uint256 _index, uint128 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 2, _index * 16, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -586,6 +850,15 @@ library Dynamics1 {
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
+  /** Get staticAddrs */
+  function _getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
+  }
+
   /** Get staticAddrs (using the specified store) */
   function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -601,6 +874,20 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.setField(
+      _tableId,
+      _keyTuple,
+      3,
+      EncodeArray.encode(fromStaticArray_address_4(staticAddrs)),
+      getFieldLayout()
+    );
+  }
+
+  /** Set staticAddrs */
+  function _setStaticAddrs(bytes32 key, address[4] memory staticAddrs) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(
       _tableId,
       _keyTuple,
       3,
@@ -634,6 +921,17 @@ library Dynamics1 {
     }
   }
 
+  /** Get the length of staticAddrs */
+  function _lengthStaticAddrs(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    unchecked {
+      return _byteLength / 20;
+    }
+  }
+
   /** Get the length of staticAddrs (using the specified store) */
   function lengthStaticAddrs(IStore _store, bytes32 key) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -655,6 +953,27 @@ library Dynamics1 {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        3,
+        getFieldLayout(),
+        _index * 20,
+        (_index + 1) * 20
+      );
+      return (address(Bytes.slice20(_blob, 0)));
+    }
+  }
+
+  /**
+   * Get an item of staticAddrs
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStaticAddrs(bytes32 key, uint256 _index) internal view returns (address) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         3,
@@ -695,6 +1014,14 @@ library Dynamics1 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to staticAddrs */
+  function _pushStaticAddrs(bytes32 key, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to staticAddrs (using the specified store) */
   function pushStaticAddrs(IStore _store, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -709,6 +1036,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 20, getFieldLayout());
+  }
+
+  /** Pop an element from staticAddrs */
+  function _popStaticAddrs(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 3, 20, getFieldLayout());
   }
 
   /** Pop an element from staticAddrs (using the specified store) */
@@ -733,6 +1068,19 @@ library Dynamics1 {
   }
 
   /**
+   * Update an element of staticAddrs at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStaticAddrs(bytes32 key, uint256 _index, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 3, _index * 20, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
    * Update an element of staticAddrs (using the specified store) at `_index`
    * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
    */
@@ -751,6 +1099,15 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
+  }
+
+  /** Get staticBools */
+  function _getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
@@ -777,6 +1134,20 @@ library Dynamics1 {
     );
   }
 
+  /** Set staticBools */
+  function _setStaticBools(bytes32 key, bool[5] memory staticBools) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(
+      _tableId,
+      _keyTuple,
+      4,
+      EncodeArray.encode(fromStaticArray_bool_5(staticBools)),
+      getFieldLayout()
+    );
+  }
+
   /** Set staticBools (using the specified store) */
   function setStaticBools(IStore _store, bytes32 key, bool[5] memory staticBools) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -791,6 +1162,17 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of staticBools */
+  function _lengthStaticBools(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -829,6 +1211,27 @@ library Dynamics1 {
   }
 
   /**
+   * Get an item of staticBools
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStaticBools(bytes32 key, uint256 _index) internal view returns (bool) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        4,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    }
+  }
+
+  /**
    * Get an item of staticBools (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -850,6 +1253,14 @@ library Dynamics1 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to staticBools */
+  function _pushStaticBools(bytes32 key, bool _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to staticBools (using the specified store) */
   function pushStaticBools(IStore _store, bytes32 key, bool _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -864,6 +1275,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1, getFieldLayout());
+  }
+
+  /** Pop an element from staticBools */
+  function _popStaticBools(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 4, 1, getFieldLayout());
   }
 
   /** Pop an element from staticBools (using the specified store) */
@@ -888,6 +1307,19 @@ library Dynamics1 {
   }
 
   /**
+   * Update an element of staticBools at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStaticBools(bytes32 key, uint256 _index, bool _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 4, _index * 1, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
    * Update an element of staticBools (using the specified store) at `_index`
    * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
    */
@@ -906,6 +1338,15 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
+  /** Get the full data */
+  function _get(bytes32 key) internal view returns (Dynamics1Data memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
     return decode(_blob);
   }
 
@@ -935,6 +1376,23 @@ library Dynamics1 {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(
+    bytes32 key,
+    bytes32[1] memory staticB32,
+    int32[2] memory staticI32,
+    uint128[3] memory staticU128,
+    address[4] memory staticAddrs,
+    bool[5] memory staticBools
+  ) internal {
+    bytes memory _data = encode(staticB32, staticI32, staticU128, staticAddrs, staticBools);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(
     IStore _store,
@@ -955,6 +1413,11 @@ library Dynamics1 {
 
   /** Set the full data using the data struct */
   function set(bytes32 key, Dynamics1Data memory _table) internal {
+    set(key, _table.staticB32, _table.staticI32, _table.staticU128, _table.staticAddrs, _table.staticBools);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 key, Dynamics1Data memory _table) internal {
     set(key, _table.staticB32, _table.staticI32, _table.staticU128, _table.staticAddrs, _table.staticBools);
   }
 
@@ -1052,6 +1515,14 @@ library Dynamics1 {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -106,28 +106,31 @@ library Dynamics1 {
 
   /** Get staticB32 */
   function getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get staticB32 */
   function _getStaticB32(bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get staticB32 (using the specified store) */
   function getStaticB32(IStore _store, bytes32 key) internal view returns (bytes32[1] memory staticB32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_bytes32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -169,10 +172,10 @@ library Dynamics1 {
 
   /** Get the length of staticB32 */
   function lengthStaticB32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -180,10 +183,10 @@ library Dynamics1 {
 
   /** Get the length of staticB32 */
   function _lengthStaticB32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -191,10 +194,10 @@ library Dynamics1 {
 
   /** Get the length of staticB32 (using the specified store) */
   function lengthStaticB32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -205,18 +208,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticB32(bytes32 key, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -226,18 +222,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStaticB32(bytes32 key, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -247,18 +236,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticB32(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -352,28 +334,31 @@ library Dynamics1 {
 
   /** Get staticI32 */
   function getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
   /** Get staticI32 */
   function _getStaticI32(bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
   /** Get staticI32 (using the specified store) */
   function getStaticI32(IStore _store, bytes32 key) internal view returns (int32[2] memory staticI32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_int32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_int32());
   }
 
@@ -415,10 +400,10 @@ library Dynamics1 {
 
   /** Get the length of staticI32 */
   function lengthStaticI32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -426,10 +411,10 @@ library Dynamics1 {
 
   /** Get the length of staticI32 */
   function _lengthStaticI32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -437,10 +422,10 @@ library Dynamics1 {
 
   /** Get the length of staticI32 (using the specified store) */
   function lengthStaticI32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -451,18 +436,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticI32(bytes32 key, uint256 _index) internal view returns (int32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (int32(uint32(Bytes.slice4(_blob, 0))));
     }
   }
@@ -472,18 +450,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStaticI32(bytes32 key, uint256 _index) internal view returns (int32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (int32(uint32(Bytes.slice4(_blob, 0))));
     }
   }
@@ -493,11 +464,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticI32(IStore _store, bytes32 key, uint256 _index) internal view returns (int32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getFieldLayout(), _index * 4, (_index + 1) * 4);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (int32(uint32(Bytes.slice4(_blob, 0))));
     }
   }
@@ -591,28 +562,31 @@ library Dynamics1 {
 
   /** Get staticU128 */
   function getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
   /** Get staticU128 */
   function _getStaticU128(bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
   /** Get staticU128 (using the specified store) */
   function getStaticU128(IStore _store, bytes32 key) internal view returns (uint128[3] memory staticU128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint128_3(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint128());
   }
 
@@ -660,10 +634,10 @@ library Dynamics1 {
 
   /** Get the length of staticU128 */
   function lengthStaticU128(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 16;
     }
@@ -671,10 +645,10 @@ library Dynamics1 {
 
   /** Get the length of staticU128 */
   function _lengthStaticU128(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 16;
     }
@@ -682,10 +656,10 @@ library Dynamics1 {
 
   /** Get the length of staticU128 (using the specified store) */
   function lengthStaticU128(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 16;
     }
@@ -696,18 +670,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticU128(bytes32 key, uint256 _index) internal view returns (uint128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 16,
-        (_index + 1) * 16
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 16, (_index + 1) * 16);
       return (uint128(Bytes.slice16(_blob, 0)));
     }
   }
@@ -717,18 +684,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStaticU128(bytes32 key, uint256 _index) internal view returns (uint128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 16,
-        (_index + 1) * 16
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 16, (_index + 1) * 16);
       return (uint128(Bytes.slice16(_blob, 0)));
     }
   }
@@ -738,18 +698,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticU128(IStore _store, bytes32 key, uint256 _index) internal view returns (uint128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 16,
-        (_index + 1) * 16
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 16, (_index + 1) * 16);
       return (uint128(Bytes.slice16(_blob, 0)));
     }
   }
@@ -843,28 +796,31 @@ library Dynamics1 {
 
   /** Get staticAddrs */
   function getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get staticAddrs */
   function _getStaticAddrs(bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get staticAddrs (using the specified store) */
   function getStaticAddrs(IStore _store, bytes32 key) internal view returns (address[4] memory staticAddrs) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return toStaticArray_address_4(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
@@ -912,10 +868,10 @@ library Dynamics1 {
 
   /** Get the length of staticAddrs */
   function lengthStaticAddrs(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 20;
     }
@@ -923,10 +879,10 @@ library Dynamics1 {
 
   /** Get the length of staticAddrs */
   function _lengthStaticAddrs(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 20;
     }
@@ -934,10 +890,10 @@ library Dynamics1 {
 
   /** Get the length of staticAddrs (using the specified store) */
   function lengthStaticAddrs(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 20;
     }
@@ -948,18 +904,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticAddrs(bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }
@@ -969,18 +918,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStaticAddrs(bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }
@@ -990,18 +932,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticAddrs(IStore _store, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }
@@ -1095,28 +1030,31 @@ library Dynamics1 {
 
   /** Get staticBools */
   function getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
   /** Get staticBools */
   function _getStaticBools(bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
   /** Get staticBools (using the specified store) */
   function getStaticBools(IStore _store, bytes32 key) internal view returns (bool[5] memory staticBools) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return toStaticArray_bool_5(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bool());
   }
 
@@ -1158,10 +1096,10 @@ library Dynamics1 {
 
   /** Get the length of staticBools */
   function lengthStaticBools(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 1;
     }
@@ -1169,10 +1107,10 @@ library Dynamics1 {
 
   /** Get the length of staticBools */
   function _lengthStaticBools(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 1;
     }
@@ -1180,10 +1118,10 @@ library Dynamics1 {
 
   /** Get the length of staticBools (using the specified store) */
   function lengthStaticBools(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 1;
     }
@@ -1194,18 +1132,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticBools(bytes32 key, uint256 _index) internal view returns (bool) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (_toBool(uint8(Bytes.slice1(_blob, 0))));
     }
   }
@@ -1215,18 +1146,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStaticBools(bytes32 key, uint256 _index) internal view returns (bool) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (_toBool(uint8(Bytes.slice1(_blob, 0))));
     }
   }
@@ -1236,11 +1160,11 @@ library Dynamics1 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStaticBools(IStore _store, bytes32 key, uint256 _index) internal view returns (bool) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (_toBool(uint8(Bytes.slice1(_blob, 0))));
     }
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -34,6 +34,8 @@ struct Dynamics1Data {
 }
 
 library Dynamics1 {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Dynamics1")));
 bytes32 constant Dynamics1TableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000500000000000000000000000000000000000000000000000000000000
+);
+
 struct Dynamics1Data {
   bytes32[1] staticB32;
   int32[2] staticI32;
@@ -32,9 +36,7 @@ struct Dynamics1Data {
 library Dynamics1 {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 5);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Dynamics2")));
 bytes32 constant Dynamics2TableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000300000000000000000000000000000000000000000000000000000000
+);
+
 struct Dynamics2Data {
   uint64[] u64;
   string str;
@@ -30,9 +34,7 @@ struct Dynamics2Data {
 library Dynamics2 {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 3);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -81,6 +81,18 @@ library Dynamics2 {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -92,6 +104,15 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
+  }
+
+  /** Get u64 */
+  function _getU64(bytes32 key) internal view returns (uint64[] memory u64) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
@@ -112,6 +133,14 @@ library Dynamics2 {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)), getFieldLayout());
   }
 
+  /** Set u64 */
+  function _setU64(bytes32 key, uint64[] memory u64) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((u64)), getFieldLayout());
+  }
+
   /** Set u64 (using the specified store) */
   function setU64(IStore _store, bytes32 key, uint64[] memory u64) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -126,6 +155,17 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 8;
+    }
+  }
+
+  /** Get the length of u64 */
+  function _lengthU64(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 8;
     }
@@ -164,6 +204,27 @@ library Dynamics2 {
   }
 
   /**
+   * Get an item of u64
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemU64(bytes32 key, uint256 _index) internal view returns (uint64) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 8,
+        (_index + 1) * 8
+      );
+      return (uint64(Bytes.slice8(_blob, 0)));
+    }
+  }
+
+  /**
    * Get an item of u64 (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -185,6 +246,14 @@ library Dynamics2 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to u64 */
+  function _pushU64(bytes32 key, uint64 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to u64 (using the specified store) */
   function pushU64(IStore _store, bytes32 key, uint64 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -199,6 +268,14 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 8, getFieldLayout());
+  }
+
+  /** Pop an element from u64 */
+  function _popU64(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 8, getFieldLayout());
   }
 
   /** Pop an element from u64 (using the specified store) */
@@ -219,6 +296,19 @@ library Dynamics2 {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of u64 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateU64(bytes32 key, uint256 _index, uint64 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 8, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -244,6 +334,15 @@ library Dynamics2 {
     return (string(_blob));
   }
 
+  /** Get str */
+  function _getStr(bytes32 key) internal view returns (string memory str) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    return (string(_blob));
+  }
+
   /** Get str (using the specified store) */
   function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -261,6 +360,14 @@ library Dynamics2 {
     StoreSwitch.setField(_tableId, _keyTuple, 1, bytes((str)), getFieldLayout());
   }
 
+  /** Set str */
+  function _setStr(bytes32 key, string memory str) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 1, bytes((str)), getFieldLayout());
+  }
+
   /** Set str (using the specified store) */
   function setStr(IStore _store, bytes32 key, string memory str) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -275,6 +382,17 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of str */
+  function _lengthStr(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -313,6 +431,27 @@ library Dynamics2 {
   }
 
   /**
+   * Get an item of str
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemStr(bytes32 key, uint256 _index) internal view returns (string memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        1,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (string(_blob));
+    }
+  }
+
+  /**
    * Get an item of str (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -334,6 +473,14 @@ library Dynamics2 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, bytes((_slice)), getFieldLayout());
   }
 
+  /** Push a slice to str */
+  function _pushStr(bytes32 key, string memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 1, bytes((_slice)), getFieldLayout());
+  }
+
   /** Push a slice to str (using the specified store) */
   function pushStr(IStore _store, bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -348,6 +495,14 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 1, getFieldLayout());
+  }
+
+  /** Pop a slice from str */
+  function _popStr(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 1, 1, getFieldLayout());
   }
 
   /** Pop a slice from str (using the specified store) */
@@ -368,6 +523,19 @@ library Dynamics2 {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update a slice of str at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateStr(bytes32 key, uint256 _index, string memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 1, _index * 1, bytes((_slice)), getFieldLayout());
     }
   }
 
@@ -393,6 +561,15 @@ library Dynamics2 {
     return (bytes(_blob));
   }
 
+  /** Get b */
+  function _getB(bytes32 key) internal view returns (bytes memory b) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    return (bytes(_blob));
+  }
+
   /** Get b (using the specified store) */
   function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -410,6 +587,14 @@ library Dynamics2 {
     StoreSwitch.setField(_tableId, _keyTuple, 2, bytes((b)), getFieldLayout());
   }
 
+  /** Set b */
+  function _setB(bytes32 key, bytes memory b) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 2, bytes((b)), getFieldLayout());
+  }
+
   /** Set b (using the specified store) */
   function setB(IStore _store, bytes32 key, bytes memory b) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -424,6 +609,17 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of b */
+  function _lengthB(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -462,6 +658,27 @@ library Dynamics2 {
   }
 
   /**
+   * Get an item of b
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemB(bytes32 key, uint256 _index) internal view returns (bytes memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        2,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (bytes(_blob));
+    }
+  }
+
+  /**
    * Get an item of b (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -483,6 +700,14 @@ library Dynamics2 {
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, bytes((_slice)), getFieldLayout());
   }
 
+  /** Push a slice to b */
+  function _pushB(bytes32 key, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 2, bytes((_slice)), getFieldLayout());
+  }
+
   /** Push a slice to b (using the specified store) */
   function pushB(IStore _store, bytes32 key, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -497,6 +722,14 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 1, getFieldLayout());
+  }
+
+  /** Pop a slice from b */
+  function _popB(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 2, 1, getFieldLayout());
   }
 
   /** Pop a slice from b (using the specified store) */
@@ -517,6 +750,19 @@ library Dynamics2 {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update a slice of b at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateB(bytes32 key, uint256 _index, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 2, _index * 1, bytes((_slice)), getFieldLayout());
     }
   }
 
@@ -542,6 +788,15 @@ library Dynamics2 {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(bytes32 key) internal view returns (Dynamics2Data memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (Dynamics2Data memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -561,6 +816,16 @@ library Dynamics2 {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(bytes32 key, uint64[] memory u64, string memory str, bytes memory b) internal {
+    bytes memory _data = encode(u64, str, b);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 key, uint64[] memory u64, string memory str, bytes memory b) internal {
     bytes memory _data = encode(u64, str, b);
@@ -573,6 +838,11 @@ library Dynamics2 {
 
   /** Set the full data using the data struct */
   function set(bytes32 key, Dynamics2Data memory _table) internal {
+    set(key, _table.u64, _table.str, _table.b);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 key, Dynamics2Data memory _table) internal {
     set(key, _table.u64, _table.str, _table.b);
   }
 
@@ -638,6 +908,14 @@ library Dynamics2 {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -100,28 +100,31 @@ library Dynamics2 {
 
   /** Get u64 */
   function getU64(bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
   /** Get u64 */
   function _getU64(bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
   /** Get u64 (using the specified store) */
   function getU64(IStore _store, bytes32 key) internal view returns (uint64[] memory u64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint64());
   }
 
@@ -151,10 +154,10 @@ library Dynamics2 {
 
   /** Get the length of u64 */
   function lengthU64(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 8;
     }
@@ -162,10 +165,10 @@ library Dynamics2 {
 
   /** Get the length of u64 */
   function _lengthU64(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 8;
     }
@@ -173,10 +176,10 @@ library Dynamics2 {
 
   /** Get the length of u64 (using the specified store) */
   function lengthU64(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 8;
     }
@@ -187,18 +190,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemU64(bytes32 key, uint256 _index) internal view returns (uint64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 8,
-        (_index + 1) * 8
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 8, (_index + 1) * 8);
       return (uint64(Bytes.slice8(_blob, 0)));
     }
   }
@@ -208,18 +204,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemU64(bytes32 key, uint256 _index) internal view returns (uint64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 8,
-        (_index + 1) * 8
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 8, (_index + 1) * 8);
       return (uint64(Bytes.slice8(_blob, 0)));
     }
   }
@@ -229,11 +218,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemU64(IStore _store, bytes32 key, uint256 _index) internal view returns (uint64) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 0, getFieldLayout(), _index * 8, (_index + 1) * 8);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 8, (_index + 1) * 8);
       return (uint64(Bytes.slice8(_blob, 0)));
     }
   }
@@ -327,28 +316,31 @@ library Dynamics2 {
 
   /** Get str */
   function getStr(bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
   /** Get str */
   function _getStr(bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
   /** Get str (using the specified store) */
   function getStr(IStore _store, bytes32 key) internal view returns (string memory str) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
@@ -378,10 +370,10 @@ library Dynamics2 {
 
   /** Get the length of str */
   function lengthStr(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -389,10 +381,10 @@ library Dynamics2 {
 
   /** Get the length of str */
   function _lengthStr(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -400,10 +392,10 @@ library Dynamics2 {
 
   /** Get the length of str (using the specified store) */
   function lengthStr(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -414,18 +406,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStr(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }
@@ -435,18 +420,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemStr(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }
@@ -456,11 +434,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemStr(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }
@@ -554,28 +532,31 @@ library Dynamics2 {
 
   /** Get b */
   function getB(bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (bytes(_blob));
   }
 
   /** Get b */
   function _getB(bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (bytes(_blob));
   }
 
   /** Get b (using the specified store) */
   function getB(IStore _store, bytes32 key) internal view returns (bytes memory b) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (bytes(_blob));
   }
 
@@ -605,10 +586,10 @@ library Dynamics2 {
 
   /** Get the length of b */
   function lengthB(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 1;
     }
@@ -616,10 +597,10 @@ library Dynamics2 {
 
   /** Get the length of b */
   function _lengthB(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 1;
     }
@@ -627,10 +608,10 @@ library Dynamics2 {
 
   /** Get the length of b (using the specified store) */
   function lengthB(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 1;
     }
@@ -641,18 +622,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemB(bytes32 key, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -662,18 +636,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemB(bytes32 key, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -683,11 +650,11 @@ library Dynamics2 {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemB(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }

--- a/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics2.sol
@@ -32,6 +32,8 @@ struct Dynamics2Data {
 }
 
 library Dynamics2 {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Ephemeral {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -71,6 +71,18 @@ library Ephemeral {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -84,6 +96,16 @@ library Ephemeral {
     _keyTuple[0] = key;
 
     StoreSwitch.emitEphemeralRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
+  /** Emit the ephemeral event using individual values */
+  function _emitEphemeral(bytes32 key, uint256 value) internal {
+    bytes memory _data = encode(value);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.emitEphemeralRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
   /** Emit the ephemeral event using individual values (using the specified store) */

--- a/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
+++ b/packages/cli/contracts/src/codegen/tables/Ephemeral.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Ephemeral")));
 bytes32 constant EphemeralTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library Ephemeral {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -83,30 +83,43 @@ library Singleton {
   function getV1() internal view returns (int256 v1) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (int256(uint256(Bytes.slice32(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (int256(uint256(bytes32(_blob))));
   }
 
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (int256(uint256(Bytes.slice32(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (int256(uint256(bytes32(_blob))));
   }
 
   /** Set v1 */
   function setV1(int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((v1)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set v1 (using the specified store) */
   function setV1(IStore _store, int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get v2 */

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -95,6 +95,7 @@ library Singleton {
   /** Get v1 */
   function getV1() internal view returns (int256 v1) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (int256(uint256(bytes32(_blob))));
@@ -103,6 +104,7 @@ library Singleton {
   /** Get v1 */
   function _getV1() internal view returns (int256 v1) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (int256(uint256(bytes32(_blob))));
@@ -111,6 +113,7 @@ library Singleton {
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (int256(uint256(bytes32(_blob))));
@@ -120,7 +123,9 @@ library Singleton {
   function setV1(int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -137,7 +142,9 @@ library Singleton {
   function _setV1(int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -145,7 +152,9 @@ library Singleton {
   function setV1(IStore _store, int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -82,18 +82,16 @@ library Singleton {
 
   /** Get v1 */
   function getV1() internal view returns (int256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (int256(uint256(bytes32(_blob))));
   }
 
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (int256(uint256(bytes32(_blob))));
   }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -94,7 +94,7 @@ library Singleton {
 
   /** Get v1 */
   function getV1() internal view returns (int256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -103,7 +103,7 @@ library Singleton {
 
   /** Get v1 */
   function _getV1() internal view returns (int256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -112,7 +112,7 @@ library Singleton {
 
   /** Get v1 (using the specified store) */
   function getV1(IStore _store) internal view returns (int256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -123,7 +123,7 @@ library Singleton {
   function setV1(int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -142,7 +142,7 @@ library Singleton {
   function _setV1(int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -152,7 +152,7 @@ library Singleton {
   function setV1(IStore _store, int256 v1) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -160,25 +160,31 @@ library Singleton {
 
   /** Get v2 */
   function getV2() internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v2 */
   function _getV2() internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v2 (using the specified store) */
   function getV2(IStore _store) internal view returns (uint32[2] memory v2) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
@@ -205,9 +211,10 @@ library Singleton {
 
   /** Get the length of v2 */
   function lengthV2() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -215,9 +222,10 @@ library Singleton {
 
   /** Get the length of v2 */
   function _lengthV2() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -225,9 +233,10 @@ library Singleton {
 
   /** Get the length of v2 (using the specified store) */
   function lengthV2(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -238,17 +247,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV2(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -258,17 +261,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemV2(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -278,10 +275,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV2(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 1, getFieldLayout(), _index * 4, (_index + 1) * 4);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -366,25 +364,31 @@ library Singleton {
 
   /** Get v3 */
   function getV3() internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v3 */
   function _getV3() internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v3 (using the specified store) */
   function getV3(IStore _store) internal view returns (uint32[2] memory v3) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return toStaticArray_uint32_2(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
@@ -411,9 +415,10 @@ library Singleton {
 
   /** Get the length of v3 */
   function lengthV3() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -421,9 +426,10 @@ library Singleton {
 
   /** Get the length of v3 */
   function _lengthV3() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -431,9 +437,10 @@ library Singleton {
 
   /** Get the length of v3 (using the specified store) */
   function lengthV3(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 4;
     }
@@ -444,17 +451,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV3(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -464,17 +465,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemV3(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -484,10 +479,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV3(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getFieldLayout(), _index * 4, (_index + 1) * 4);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -572,25 +568,31 @@ library Singleton {
 
   /** Get v4 */
   function getV4() internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v4 */
   function _getV4() internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get v4 (using the specified store) */
   function getV4(IStore _store) internal view returns (uint32[1] memory v4) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return toStaticArray_uint32_1(SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
@@ -617,9 +619,10 @@ library Singleton {
 
   /** Get the length of v4 */
   function lengthV4() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 4;
     }
@@ -627,9 +630,10 @@ library Singleton {
 
   /** Get the length of v4 */
   function _lengthV4() internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 4;
     }
@@ -637,9 +641,10 @@ library Singleton {
 
   /** Get the length of v4 (using the specified store) */
   function lengthV4(IStore _store) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 4;
     }
@@ -650,17 +655,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV4(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -670,17 +669,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemV4(uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -690,10 +683,11 @@ library Singleton {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemV4(IStore _store, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getFieldLayout(), _index * 4, (_index + 1) * 4);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Singleton {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -105,9 +107,15 @@ library Singleton {
   function _getV1() internal view returns (int256 v1) {
     bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (int256(uint256(bytes32(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    int256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get v1 (using the specified store) */

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Singleton")));
 bytes32 constant SingletonTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010320000000000000000000000000000000000000000000000000000000
+);
+
 library Singleton {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 3);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -135,7 +135,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -152,7 +162,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -170,7 +190,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -188,7 +218,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -214,7 +254,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -241,7 +291,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -257,7 +317,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
@@ -274,7 +344,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
@@ -292,7 +372,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
@@ -310,7 +400,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -336,7 +436,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
@@ -363,7 +473,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
@@ -379,7 +499,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 36);
@@ -396,7 +526,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 36);
@@ -414,7 +554,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 36);
@@ -432,7 +582,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -458,7 +618,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -494,7 +664,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 16, 36, abi.encodePacked((v3)), _tableId, _keyTuple, 2, getFieldLayout());
@@ -510,7 +690,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 52);
@@ -527,7 +717,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 52);
@@ -545,7 +745,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 52);
@@ -563,7 +773,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -589,7 +809,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -625,7 +855,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 20, 52, abi.encodePacked((v4)), _tableId, _keyTuple, 3, getFieldLayout());
@@ -641,7 +881,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 72);
@@ -658,7 +908,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 72);
@@ -676,7 +936,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 72);
@@ -694,7 +964,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -720,7 +1000,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
@@ -747,7 +1037,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
@@ -763,7 +1063,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 73);
@@ -780,7 +1090,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 73);
@@ -798,7 +1118,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 73);
@@ -816,7 +1146,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -842,7 +1182,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -878,7 +1228,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -903,7 +1263,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 74);
@@ -920,7 +1290,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 74);
@@ -938,7 +1318,17 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 74);
@@ -956,7 +1346,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -982,7 +1382,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -1018,7 +1428,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6))),
+        bytes32(uint256(uint8(k7)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -136,6 +136,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (uint256 v1) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -152,6 +153,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (uint256 v1) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -169,6 +171,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (uint256 v1) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -185,7 +188,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -209,7 +214,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -234,7 +241,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -249,6 +258,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (int32 v2) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
@@ -265,6 +275,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (int32 v2) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
@@ -282,6 +293,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (int32 v2) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
@@ -298,7 +310,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       4,
@@ -322,7 +336,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
@@ -347,7 +363,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
@@ -362,6 +380,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bytes16 v3) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 36);
     return (bytes16(_blob));
@@ -378,6 +397,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bytes16 v3) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 36);
     return (bytes16(_blob));
@@ -395,6 +415,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bytes16 v3) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 36);
     return (bytes16(_blob));
@@ -411,7 +432,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       16,
@@ -435,7 +458,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       16,
@@ -469,7 +494,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 16, 36, abi.encodePacked((v3)), _tableId, _keyTuple, 2, getFieldLayout());
   }
 
@@ -484,6 +511,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (address v4) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 52);
     return (address(bytes20(_blob)));
@@ -500,6 +528,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (address v4) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 52);
     return (address(bytes20(_blob)));
@@ -517,6 +546,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (address v4) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 52);
     return (address(bytes20(_blob)));
@@ -533,7 +563,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       20,
@@ -557,7 +589,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       20,
@@ -591,7 +625,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 20, 52, abi.encodePacked((v4)), _tableId, _keyTuple, 3, getFieldLayout());
   }
 
@@ -606,6 +642,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bool v5) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 72);
     return (_toBool(uint8(bytes1(_blob))));
@@ -622,6 +659,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bool v5) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 72);
     return (_toBool(uint8(bytes1(_blob))));
@@ -639,6 +677,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (bool v5) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 72);
     return (_toBool(uint8(bytes1(_blob))));
@@ -655,7 +694,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -679,7 +720,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
   }
 
@@ -704,7 +747,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
   }
 
@@ -719,6 +764,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum1 v6) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 73);
     return Enum1(uint8(bytes1(_blob)));
@@ -735,6 +781,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum1 v6) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 73);
     return Enum1(uint8(bytes1(_blob)));
@@ -752,6 +799,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum1 v6) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 73);
     return Enum1(uint8(bytes1(_blob)));
@@ -768,7 +816,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -792,7 +842,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -826,7 +878,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       1,
@@ -850,6 +904,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum2 v7) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 74);
     return Enum2(uint8(bytes1(_blob)));
@@ -866,6 +921,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum2 v7) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 74);
     return Enum2(uint8(bytes1(_blob)));
@@ -883,6 +939,7 @@ library Statics {
     Enum2 k7
   ) internal view returns (Enum2 v7) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 74);
     return Enum2(uint8(bytes1(_blob)));
@@ -899,7 +956,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -923,7 +982,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -957,7 +1018,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       1,

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -123,16 +123,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
@@ -148,16 +140,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (uint256 v1) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
@@ -221,16 +205,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
   }
@@ -246,16 +222,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (int32 v2) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
   }
@@ -319,16 +287,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 36);
     return (bytes16(_blob));
   }
@@ -344,16 +304,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bytes16 v3) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 36);
     return (bytes16(_blob));
   }
@@ -417,16 +369,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 52);
     return (address(bytes20(_blob)));
   }
@@ -442,16 +386,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (address v4) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 52);
     return (address(bytes20(_blob)));
   }
@@ -515,16 +451,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 72);
     return (_toBool(uint8(bytes1(_blob))));
   }
@@ -540,16 +468,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (bool v5) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 72);
     return (_toBool(uint8(bytes1(_blob))));
   }
@@ -613,16 +533,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 73);
     return Enum1(uint8(bytes1(_blob)));
   }
@@ -638,16 +550,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum1 v6) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 73);
     return Enum1(uint8(bytes1(_blob)));
   }
@@ -720,16 +624,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 74);
     return Enum2(uint8(bytes1(_blob)));
   }
@@ -745,16 +641,8 @@ library Statics {
     Enum1 k6,
     Enum2 k7
   ) internal view returns (Enum2 v7) {
-    bytes32[] memory _keyTuple = new bytes32[](7);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-    _keyTuple[6] = bytes32(uint256(uint8(k7)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 74);
     return Enum2(uint8(bytes1(_blob)));
   }

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -24,6 +24,10 @@ import { Enum1, Enum2 } from "./../Types.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Statics")));
 bytes32 constant StaticsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x004b070020041014010101000000000000000000000000000000000000000000
+);
+
 struct StaticsData {
   uint256 v1;
   int32 v2;
@@ -37,16 +41,7 @@ struct StaticsData {
 library Statics {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](7);
-    _fieldLayout[0] = 32;
-    _fieldLayout[1] = 4;
-    _fieldLayout[2] = 16;
-    _fieldLayout[3] = 20;
-    _fieldLayout[4] = 1;
-    _fieldLayout[5] = 1;
-    _fieldLayout[6] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -137,8 +137,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Get v1 (using the specified store) */
@@ -161,8 +162,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Set v1 */
@@ -176,7 +178,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((v1)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set v1 (using the specified store) */
@@ -200,7 +212,8 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((v1)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get v2 */
@@ -222,8 +235,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (int32(uint32(Bytes.slice4(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
+    return (int32(uint32(bytes4(_blob))));
   }
 
   /** Get v2 (using the specified store) */
@@ -246,8 +260,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (int32(uint32(Bytes.slice4(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
+    return (int32(uint32(bytes4(_blob))));
   }
 
   /** Set v2 */
@@ -261,7 +276,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      4,
+      32,
+      abi.encodePacked((v2)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set v2 (using the specified store) */
@@ -285,7 +310,8 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((v2)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
   /** Get v3 */
@@ -307,8 +333,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
-    return (Bytes.slice16(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 36);
+    return (bytes16(_blob));
   }
 
   /** Get v3 (using the specified store) */
@@ -331,8 +358,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
-    return (Bytes.slice16(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 16, 36);
+    return (bytes16(_blob));
   }
 
   /** Set v3 */
@@ -346,7 +374,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      16,
+      36,
+      abi.encodePacked((v3)),
+      _tableId,
+      _keyTuple,
+      2,
+      getFieldLayout()
+    );
   }
 
   /** Set v3 (using the specified store) */
@@ -370,7 +408,8 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((v3)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 16, 36, abi.encodePacked((v3)), _tableId, _keyTuple, 2, getFieldLayout());
   }
 
   /** Get v4 */
@@ -392,8 +431,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 52);
+    return (address(bytes20(_blob)));
   }
 
   /** Get v4 (using the specified store) */
@@ -416,8 +456,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 20, 52);
+    return (address(bytes20(_blob)));
   }
 
   /** Set v4 */
@@ -431,7 +472,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      52,
+      abi.encodePacked((v4)),
+      _tableId,
+      _keyTuple,
+      3,
+      getFieldLayout()
+    );
   }
 
   /** Set v4 (using the specified store) */
@@ -455,7 +506,8 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 3, abi.encodePacked((v4)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 20, 52, abi.encodePacked((v4)), _tableId, _keyTuple, 3, getFieldLayout());
   }
 
   /** Get v5 */
@@ -477,8 +529,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 72);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get v5 (using the specified store) */
@@ -501,8 +554,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 4, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 72);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Set v5 */
@@ -516,7 +570,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      72,
+      abi.encodePacked((v5)),
+      _tableId,
+      _keyTuple,
+      4,
+      getFieldLayout()
+    );
   }
 
   /** Set v5 (using the specified store) */
@@ -540,7 +604,8 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 4, abi.encodePacked((v5)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
   }
 
   /** Get v6 */
@@ -562,8 +627,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 5, getFieldLayout());
-    return Enum1(uint8(Bytes.slice1(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 73);
+    return Enum1(uint8(bytes1(_blob)));
   }
 
   /** Get v6 (using the specified store) */
@@ -586,8 +652,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 5, getFieldLayout());
-    return Enum1(uint8(Bytes.slice1(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 73);
+    return Enum1(uint8(bytes1(_blob)));
   }
 
   /** Set v6 */
@@ -601,7 +668,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      73,
+      abi.encodePacked(uint8(v6)),
+      _tableId,
+      _keyTuple,
+      5,
+      getFieldLayout()
+    );
   }
 
   /** Set v6 (using the specified store) */
@@ -625,7 +702,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 5, abi.encodePacked(uint8(v6)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      1,
+      73,
+      abi.encodePacked(uint8(v6)),
+      _tableId,
+      _keyTuple,
+      5,
+      getFieldLayout()
+    );
   }
 
   /** Get v7 */
@@ -647,8 +734,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 6, getFieldLayout());
-    return Enum2(uint8(Bytes.slice1(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 74);
+    return Enum2(uint8(bytes1(_blob)));
   }
 
   /** Get v7 (using the specified store) */
@@ -671,8 +759,9 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 6, getFieldLayout());
-    return Enum2(uint8(Bytes.slice1(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 74);
+    return Enum2(uint8(bytes1(_blob)));
   }
 
   /** Set v7 */
@@ -686,7 +775,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      74,
+      abi.encodePacked(uint8(v7)),
+      _tableId,
+      _keyTuple,
+      6,
+      getFieldLayout()
+    );
   }
 
   /** Set v7 (using the specified store) */
@@ -710,7 +809,17 @@ library Statics {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
-    _store.setField(_tableId, _keyTuple, 6, abi.encodePacked(uint8(v7)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      1,
+      74,
+      abi.encodePacked(uint8(v7)),
+      _tableId,
+      _keyTuple,
+      6,
+      getFieldLayout()
+    );
   }
 
   /** Get the full data */

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -108,6 +108,18 @@ library Statics {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -126,6 +138,22 @@ library Statics {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /** Get v1 */
+  function _getV1(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (uint256 v1) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
@@ -170,6 +198,21 @@ library Statics {
     );
   }
 
+  /** Set v1 */
+  function _setV1(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, uint256 v1) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 32, 0, abi.encodePacked((v1)), _tableId, _keyTuple, 0, getFieldLayout());
+  }
+
   /** Set v1 (using the specified store) */
   function setV1(
     IStore _store,
@@ -208,6 +251,22 @@ library Statics {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
+    return (int32(uint32(bytes4(_blob))));
+  }
+
+  /** Get v2 */
+  function _getV2(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (int32 v2) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
     return (int32(uint32(bytes4(_blob))));
   }
 
@@ -252,6 +311,21 @@ library Statics {
     );
   }
 
+  /** Set v2 */
+  function _setV2(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, int32 v2) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 4, 32, abi.encodePacked((v2)), _tableId, _keyTuple, 1, getFieldLayout());
+  }
+
   /** Set v2 (using the specified store) */
   function setV2(
     IStore _store,
@@ -293,6 +367,22 @@ library Statics {
     return (bytes16(_blob));
   }
 
+  /** Get v3 */
+  function _getV3(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (bytes16 v3) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 36);
+    return (bytes16(_blob));
+  }
+
   /** Get v3 (using the specified store) */
   function getV3(
     IStore _store,
@@ -323,6 +413,30 @@ library Statics {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      16,
+      36,
+      abi.encodePacked((v3)),
+      _tableId,
+      _keyTuple,
+      2,
+      getFieldLayout()
+    );
+  }
+
+  /** Set v3 */
+  function _setV3(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bytes16 v3) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       16,
       36,
@@ -375,6 +489,22 @@ library Statics {
     return (address(bytes20(_blob)));
   }
 
+  /** Get v4 */
+  function _getV4(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (address v4) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 52);
+    return (address(bytes20(_blob)));
+  }
+
   /** Get v4 (using the specified store) */
   function getV4(
     IStore _store,
@@ -405,6 +535,30 @@ library Statics {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      52,
+      abi.encodePacked((v4)),
+      _tableId,
+      _keyTuple,
+      3,
+      getFieldLayout()
+    );
+  }
+
+  /** Set v4 */
+  function _setV4(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, address v4) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       20,
       52,
@@ -457,6 +611,22 @@ library Statics {
     return (_toBool(uint8(bytes1(_blob))));
   }
 
+  /** Get v5 */
+  function _getV5(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (bool v5) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 72);
+    return (_toBool(uint8(bytes1(_blob))));
+  }
+
   /** Get v5 (using the specified store) */
   function getV5(
     IStore _store,
@@ -496,6 +666,21 @@ library Statics {
       4,
       getFieldLayout()
     );
+  }
+
+  /** Set v5 */
+  function _setV5(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, bool v5) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 1, 72, abi.encodePacked((v5)), _tableId, _keyTuple, 4, getFieldLayout());
   }
 
   /** Set v5 (using the specified store) */
@@ -539,6 +724,22 @@ library Statics {
     return Enum1(uint8(bytes1(_blob)));
   }
 
+  /** Get v6 */
+  function _getV6(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (Enum1 v6) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 73);
+    return Enum1(uint8(bytes1(_blob)));
+  }
+
   /** Get v6 (using the specified store) */
   function getV6(
     IStore _store,
@@ -569,6 +770,30 @@ library Statics {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      73,
+      abi.encodePacked(uint8(v6)),
+      _tableId,
+      _keyTuple,
+      5,
+      getFieldLayout()
+    );
+  }
+
+  /** Set v6 */
+  function _setV6(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum1 v6) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       73,
@@ -630,6 +855,22 @@ library Statics {
     return Enum2(uint8(bytes1(_blob)));
   }
 
+  /** Get v7 */
+  function _getV7(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (Enum2 v7) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6, k7));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 74);
+    return Enum2(uint8(bytes1(_blob)));
+  }
+
   /** Get v7 (using the specified store) */
   function getV7(
     IStore _store,
@@ -660,6 +901,30 @@ library Statics {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      74,
+      abi.encodePacked(uint8(v7)),
+      _tableId,
+      _keyTuple,
+      6,
+      getFieldLayout()
+    );
+  }
+
+  /** Set v7 */
+  function _setV7(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7, Enum2 v7) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       74,
@@ -728,6 +993,29 @@ library Statics {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7
+  ) internal view returns (StaticsData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(
     IStore _store,
@@ -783,6 +1071,37 @@ library Statics {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    uint256 v1,
+    int32 v2,
+    bytes16 v3,
+    address v4,
+    bool v5,
+    Enum1 v6,
+    Enum2 v7
+  ) internal {
+    bytes memory _data = encode(v1, v2, v3, v4, v5, v6, v7);
+
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(
     IStore _store,
@@ -817,6 +1136,20 @@ library Statics {
 
   /** Set the full data using the data struct */
   function set(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    Enum1 k6,
+    Enum2 k7,
+    StaticsData memory _table
+  ) internal {
+    set(k1, k2, k3, k4, k5, k6, k7, _table.v1, _table.v2, _table.v3, _table.v4, _table.v5, _table.v6, _table.v7);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(
     uint256 k1,
     int32 k2,
     bytes16 k3,
@@ -924,6 +1257,20 @@ library Statics {
     _keyTuple[6] = bytes32(uint256(uint8(k7)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, Enum1 k6, Enum2 k7) internal {
+    bytes32[] memory _keyTuple = new bytes32[](7);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+    _keyTuple[6] = bytes32(uint256(uint8(k7)));
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -39,6 +39,8 @@ struct StaticsData {
 }
 
 library Statics {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -174,9 +176,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (uint256(bytes32(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get v1 (using the specified store) */
@@ -356,9 +364,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
-    return (int32(uint32(bytes4(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 1;
+    }
+    int32 _blob;
+    assembly {
+      _blob := shr(224, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get v2 (using the specified store) */
@@ -538,9 +552,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 36);
-    return (bytes16(_blob));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 1;
+    }
+    bytes16 _blob;
+    assembly {
+      _blob := shr(96, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get v3 (using the specified store) */
@@ -729,9 +749,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 52);
-    return (address(bytes20(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 1;
+    }
+    address _blob;
+    assembly {
+      _blob := or(shl(64, sload(storagePointer), shr(192, sload(add(storagePointer, 1)))))
+    }
+    return _blob;
   }
 
   /** Get v4 (using the specified store) */
@@ -920,9 +946,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 72);
-    return (_toBool(uint8(bytes1(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 2;
+    }
+    bool _blob;
+    assembly {
+      _blob := shr(184, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get v5 (using the specified store) */
@@ -1102,9 +1134,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 73);
-    return Enum1(uint8(bytes1(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 2;
+    }
+    uint8 _blob;
+    assembly {
+      _blob := shr(176, sload(storagePointer))
+    }
+    return Enum1(_blob);
   }
 
   /** Get v6 (using the specified store) */
@@ -1302,9 +1340,15 @@ library Statics {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 74);
-    return Enum2(uint8(bytes1(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 2;
+    }
+    uint8 _blob;
+    assembly {
+      _blob := shr(168, sload(storagePointer))
+    }
+    return Enum2(_blob);
   }
 
   /** Get v7 (using the specified store) */

--- a/packages/cli/foundry.toml
+++ b/packages/cli/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 # check all "WARNING:" comments before changing major solidity versions
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -56,7 +56,9 @@ export function renderCommonData({
   `;
 
   const _keyhashDefinition = `
-    bytes32 _keyHash = keccak256(abi.encode(${keyTuple.map(({ name }) => name).join(", ")}));
+    bytes32 _keyHash = keccak256(abi.encodePacked(${keyTuple
+      .map((key) => renderValueTypeToBytes32(key.name, key))
+      .join(", ")}));
   `;
 
   return {

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -1,13 +1,13 @@
 import path from "path";
+import { posixPath } from "../utils";
 import {
   AbsoluteImportDatum,
-  RelativeImportDatum,
   ImportDatum,
-  StaticResourceData,
+  RelativeImportDatum,
   RenderKeyTuple,
   RenderType,
+  StaticResourceData,
 } from "./types";
-import { posixPath } from "../utils";
 
 export const renderedSolidityHeader = `// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
@@ -131,14 +131,16 @@ export function renderWithStore(
     _typedStore: string | undefined,
     _store: string,
     _commentSuffix: string,
-    _untypedStore: string | undefined
+    _untypedStore: string | undefined,
+    _methodPrefix: string
   ) => string
 ): string {
   let result = "";
-  result += callback(undefined, "StoreSwitch", "", undefined);
+  result += callback(undefined, "StoreSwitch", "", undefined, "");
+  result += callback(undefined, "StoreCore", "", undefined, "_");
 
   if (storeArgument) {
-    result += "\n" + callback("IStore _store", "_store", " (using the specified store)", "_store");
+    result += "\n" + callback("IStore _store", "_store", " (using the specified store)", "_store", "");
   }
 
   return result;

--- a/packages/common/src/codegen/render-solidity/common.ts
+++ b/packages/common/src/codegen/render-solidity/common.ts
@@ -41,6 +41,7 @@ export function renderCommonData({
   _keyArgs: string;
   _typedKeyArgs: string;
   _keyTupleDefinition: string;
+  _keyhashDefinition: string;
 } {
   // static resource means static tableId as well, and no tableId arguments
   const _tableId = staticResourceData ? "" : "_tableId";
@@ -54,12 +55,17 @@ export function renderCommonData({
     ${renderList(keyTuple, (key, index) => `_keyTuple[${index}] = ${renderValueTypeToBytes32(key.name, key)};`)}
   `;
 
+  const _keyhashDefinition = `
+    bytes32 _keyHash = keccak256(abi.encode(${keyTuple.map(({ name }) => name).join(", ")}));
+  `;
+
   return {
     _tableId,
     _typedTableId,
     _keyArgs,
     _typedKeyArgs,
     _keyTupleDefinition,
+    _keyhashDefinition,
   };
 }
 

--- a/packages/gas-report/foundry.toml
+++ b/packages/gas-report/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.13'
+solc = '0.8.21'
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/noise/foundry.toml
+++ b/packages/noise/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/schema-type/foundry.toml
+++ b/packages/schema-type/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/store/abi/IStore.sol/IStore.abi.json
+++ b/packages/store/abi/IStore.sol/IStore.abi.json
@@ -479,6 +479,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/store/abi/IStore.sol/IStore.abi.json
+++ b/packages/store/abi/IStore.sol/IStore.abi.json
@@ -473,6 +473,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -654,6 +683,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/store/abi/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStore.abi.json.d.ts
@@ -479,6 +479,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/store/abi/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStore.abi.json.d.ts
@@ -473,6 +473,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -654,6 +683,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/store/abi/IStore.sol/IStoreData.abi.json
+++ b/packages/store/abi/IStore.sol/IStoreData.abi.json
@@ -298,6 +298,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -418,6 +447,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/store/abi/IStore.sol/IStoreData.abi.json
+++ b/packages/store/abi/IStore.sol/IStoreData.abi.json
@@ -304,6 +304,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/store/abi/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStoreData.abi.json.d.ts
@@ -298,6 +298,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -418,6 +447,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/store/abi/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStoreData.abi.json.d.ts
@@ -304,6 +304,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/store/abi/IStore.sol/IStoreRead.abi.json
+++ b/packages/store/abi/IStore.sol/IStoreRead.abi.json
@@ -196,5 +196,34 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/packages/store/abi/IStore.sol/IStoreRead.abi.json
+++ b/packages/store/abi/IStore.sol/IStoreRead.abi.json
@@ -206,6 +206,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/store/abi/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStoreRead.abi.json.d.ts
@@ -196,6 +196,35 @@ declare const abi: [
     ];
     stateMutability: "view";
     type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
   }
 ];
 export default abi;

--- a/packages/store/abi/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStoreRead.abi.json.d.ts
@@ -206,6 +206,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/store/abi/IStore.sol/IStoreWrite.abi.json
+++ b/packages/store/abi/IStore.sol/IStoreWrite.abi.json
@@ -227,6 +227,54 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"

--- a/packages/store/abi/IStore.sol/IStoreWrite.abi.json.d.ts
+++ b/packages/store/abi/IStore.sol/IStoreWrite.abi.json.d.ts
@@ -227,6 +227,54 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";

--- a/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json
+++ b/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json
@@ -43,27 +43,6 @@
         "type": "uint256"
       }
     ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
     "name": "PackedCounter_InvalidLength",
     "type": "error"
   },

--- a/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json
+++ b/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json
@@ -84,6 +84,81 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json.d.ts
+++ b/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json.d.ts
@@ -43,27 +43,6 @@ declare const abi: [
         type: "uint256";
       }
     ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
     name: "PackedCounter_InvalidLength";
     type: "error";
   },

--- a/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json.d.ts
+++ b/packages/store/abi/MirrorSubscriber.sol/MirrorSubscriber.abi.json.d.ts
@@ -84,6 +84,81 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [
       {
         internalType: "bytes32";

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json
@@ -547,6 +547,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -728,6 +757,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json
@@ -228,6 +228,50 @@
         "internalType": "bytes32[]",
         "name": "key",
         "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreEphemeralRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
       },
       {
         "indexed": false,
@@ -268,6 +312,62 @@
       }
     ],
     "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
     "type": "event"
   },
   {

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json
@@ -653,6 +653,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
@@ -653,6 +653,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
@@ -228,6 +228,50 @@ declare const abi: [
         internalType: "bytes32[]";
         name: "key";
         type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreEphemeralRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
       },
       {
         indexed: false;
@@ -268,6 +312,62 @@ declare const abi: [
       }
     ];
     name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
     type: "event";
   },
   {

--- a/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
+++ b/packages/store/abi/StoreMock.sol/StoreMock.abi.json.d.ts
@@ -547,6 +547,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -728,6 +757,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/store/abi/StoreRead.sol/StoreRead.abi.json
+++ b/packages/store/abi/StoreRead.sol/StoreRead.abi.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "StoreCore_NotDynamicField",
     "type": "error"
@@ -233,6 +212,35 @@
       {
         "internalType": "Schema",
         "name": "schema",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
         "type": "bytes32"
       }
     ],

--- a/packages/store/abi/StoreRead.sol/StoreRead.abi.json
+++ b/packages/store/abi/StoreRead.sol/StoreRead.abi.json
@@ -227,6 +227,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/store/abi/StoreRead.sol/StoreRead.abi.json.d.ts
+++ b/packages/store/abi/StoreRead.sol/StoreRead.abi.json.d.ts
@@ -227,6 +227,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/store/abi/StoreRead.sol/StoreRead.abi.json.d.ts
+++ b/packages/store/abi/StoreRead.sol/StoreRead.abi.json.d.ts
@@ -1,26 +1,5 @@
 declare const abi: [
   {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
     inputs: [];
     name: "StoreCore_NotDynamicField";
     type: "error";
@@ -233,6 +212,35 @@ declare const abi: [
       {
         internalType: "Schema";
         name: "schema";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
         type: "bytes32";
       }
     ];

--- a/packages/store/abi/StoreSwitch.sol/StoreSwitch.abi.json
+++ b/packages/store/abi/StoreSwitch.sol/StoreSwitch.abi.json
@@ -1,1 +1,31 @@
-[]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/store/abi/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
+++ b/packages/store/abi/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
@@ -1,0 +1,32 @@
+declare const abi: [
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  }
+];
+export default abi;

--- a/packages/store/foundry.toml
+++ b/packages/store/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.13'
+solc = '0.8.21'
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -1077,7 +1077,7 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 411128
+    "gasUsed": 411139
   },
   {
     "file": "test/Vector2.t.sol",
@@ -1090,5 +1090,29 @@
     "test": "testSetAndGet",
     "name": "get Vector2 record",
     "gasUsed": 2548
+  },
+  {
+    "file": "test/Vector2.t.sol",
+    "test": "testSetAndGet",
+    "name": "get Vector2 x",
+    "gasUsed": 1077
+  },
+  {
+    "file": "test/Vector2.t.sol",
+    "test": "testSetAndGet",
+    "name": "_set Vector2 record",
+    "gasUsed": 29751
+  },
+  {
+    "file": "test/Vector2.t.sol",
+    "test": "testSetAndGet",
+    "name": "_get Vector2 record",
+    "gasUsed": 2263
+  },
+  {
+    "file": "test/Vector2.t.sol",
+    "test": "testSetAndGet",
+    "name": "_get Vector2 x",
+    "gasUsed": 531
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -339,13 +339,13 @@
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 104984
+    "gasUsed": 104952
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 7327
+    "gasUsed": 7302
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -531,25 +531,25 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8372
+    "gasUsed": 8363
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2440
+    "gasUsed": 2430
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4444
+    "gasUsed": 4434
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4670
+    "gasUsed": 4660
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -579,43 +579,43 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 21045
+    "gasUsed": 21026
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 15054
+    "gasUsed": 15032
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 22794
+    "gasUsed": 22774
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 14803
+    "gasUsed": 14780
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6160
+    "gasUsed": 6159
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1336
+    "gasUsed": 1337
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 2163
+    "gasUsed": 2152
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -627,19 +627,19 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1576
+    "gasUsed": 1564
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 7741
+    "gasUsed": 7729
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 1478
+    "gasUsed": 1477
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -657,19 +657,19 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 70821
+    "gasUsed": 70811
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 22514
+    "gasUsed": 22504
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 18564
+    "gasUsed": 18554
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -681,31 +681,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 164351
+    "gasUsed": 164333
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 25085
+    "gasUsed": 25066
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 19518
+    "gasUsed": 19508
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 12616
+    "gasUsed": 12580
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 35247
+    "gasUsed": 35208
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -717,13 +717,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get field layout (warm)",
-    "gasUsed": 1490
+    "gasUsed": 1491
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get schema (warm)",
-    "gasUsed": 1557
+    "gasUsed": 1556
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -735,13 +735,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 103021
+    "gasUsed": 102988
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4614
+    "gasUsed": 4591
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -759,13 +759,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 0",
-    "gasUsed": 22852
+    "gasUsed": 22853
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 1",
-    "gasUsed": 953
+    "gasUsed": 952
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -777,13 +777,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 32336
+    "gasUsed": 32325
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1337
+    "gasUsed": 1336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -795,7 +795,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 30979
+    "gasUsed": 30966
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,43 +807,43 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 53546
+    "gasUsed": 53519
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 2333
+    "gasUsed": 2319
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 31652
+    "gasUsed": 31624
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 2336
+    "gasUsed": 2321
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 32685
+    "gasUsed": 32675
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1588
+    "gasUsed": 1587
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 55189
+    "gasUsed": 55179
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -855,13 +855,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 13127
+    "gasUsed": 13091
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 14145
+    "gasUsed": 14106
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,103 +909,103 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 56630
+    "gasUsed": 56608
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 3806
+    "gasUsed": 3794
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 36010
+    "gasUsed": 35973
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 58635
+    "gasUsed": 58616
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 58635
+    "gasUsed": 58616
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: get field (warm)",
-    "gasUsed": 3789
+    "gasUsed": 3779
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 16103
+    "gasUsed": 16071
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 12505
+    "gasUsed": 12480
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 14125
+    "gasUsed": 14085
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 34694
+    "gasUsed": 34648
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 8153
+    "gasUsed": 8134
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 30782
+    "gasUsed": 30747
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 81323
+    "gasUsed": 81304
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 81234
+    "gasUsed": 81215
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 17018
+    "gasUsed": 17009
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGet",
     "name": "StoreHooks: get field (cold)",
-    "gasUsed": 9786
+    "gasUsed": 9777
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGetItem",
     "name": "StoreHooks: get 1 element (cold)",
-    "gasUsed": 6527
+    "gasUsed": 6517
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
@@ -1017,13 +1017,13 @@
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 22665
+    "gasUsed": 22646
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 24431
+    "gasUsed": 24402
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1077,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 412701
+    "gasUsed": 412664
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 33500
+    "gasUsed": 33488
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 2510
+    "gasUsed": 2509
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -254,14 +254,26 @@
   {
     "file": "test/GasStorageLoad.t.sol",
     "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load field (warm, 1 word)",
+    "gasUsed": 228
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load (warm, 1 word, partial)",
     "gasUsed": 460
   },
   {
     "file": "test/GasStorageLoad.t.sol",
     "test": "testCompareStorageLoadMUD",
+    "name": "MUD storage load field (warm, partial)",
+    "gasUsed": 228
+  },
+  {
+    "file": "test/GasStorageLoad.t.sol",
+    "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load (warm, 10 words)",
-    "gasUsed": 1914
+    "gasUsed": 1916
   },
   {
     "file": "test/GasStorageLoad.t.sol",
@@ -309,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 697905
+    "gasUsed": 697556
   },
   {
     "file": "test/Mixed.t.sol",
@@ -321,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 560027
+    "gasUsed": 559738
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 108640
+    "gasUsed": 108492
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 9640
+    "gasUsed": 9491
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -519,13 +531,13 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8425
+    "gasUsed": 8424
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2493
+    "gasUsed": 2492
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -537,13 +549,13 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4725
+    "gasUsed": 4724
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7966
+    "gasUsed": 7965
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -567,13 +579,13 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 22898
+    "gasUsed": 22897
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 16928
+    "gasUsed": 16927
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -585,19 +597,19 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 16678
+    "gasUsed": 16677
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6533
+    "gasUsed": 6389
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1481
+    "gasUsed": 1337
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -615,25 +627,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1631
+    "gasUsed": 1630
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 9470
+    "gasUsed": 9322
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 4465
+    "gasUsed": 4320
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "check for existence of table (non-existent)",
-    "gasUsed": 6468
+    "gasUsed": 6322
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -645,19 +657,19 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 73748
+    "gasUsed": 73476
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 25441
+    "gasUsed": 25169
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 21483
+    "gasUsed": 21211
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -669,7 +681,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167808
+    "gasUsed": 167535
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -681,55 +693,55 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 22901
+    "gasUsed": 22595
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 14558
+    "gasUsed": 14556
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 37206
+    "gasUsed": 37203
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 620356
+    "gasUsed": 620066
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get field layout (warm)",
-    "gasUsed": 4479
+    "gasUsed": 4333
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get schema (warm)",
-    "gasUsed": 5033
+    "gasUsed": 4887
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 9281
+    "gasUsed": 8986
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 104856
+    "gasUsed": 104710
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 5105
+    "gasUsed": 4957
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -741,7 +753,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using abi.encode",
-    "gasUsed": 267372
+    "gasUsed": 267371
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -765,31 +777,37 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 33831
+    "gasUsed": 33686
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1482
+    "gasUsed": 1337
+  },
+  {
+    "file": "test/StoreCoreGas.t.sol",
+    "test": "testSetAndGetField",
+    "name": "get static field V2 (1 slot)",
+    "gasUsed": 688
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 32479
+    "gasUsed": 32333
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 2010
+    "gasUsed": 1863
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 55195
+    "gasUsed": 55196
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -801,7 +819,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 33313
+    "gasUsed": 33314
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -813,37 +831,37 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 34181
+    "gasUsed": 34035
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1734
+    "gasUsed": 1589
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 56684
+    "gasUsed": 56539
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1922
+    "gasUsed": 1777
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 14835
+    "gasUsed": 14833
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 15865
+    "gasUsed": 15863
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -891,19 +909,19 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 59331
+    "gasUsed": 59330
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 5160
+    "gasUsed": 5159
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 39001
+    "gasUsed": 38999
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
@@ -951,13 +969,13 @@
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 10992
+    "gasUsed": 10840
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 33544
+    "gasUsed": 33543
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
@@ -975,7 +993,7 @@
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 19792
+    "gasUsed": 19649
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
@@ -1059,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 421491
+    "gasUsed": 421180
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 36809
+    "gasUsed": 36664
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4472
+    "gasUsed": 4326
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -69,7 +69,7 @@
     "file": "test/FieldLayout.t.sol",
     "test": "testEncodeDecodeFieldLayout",
     "name": "encode field layout with 5+1 entries",
-    "gasUsed": 2378
+    "gasUsed": 2440
   },
   {
     "file": "test/FieldLayout.t.sol",
@@ -81,7 +81,7 @@
     "file": "test/FieldLayout.t.sol",
     "test": "testGetNumDynamicFields",
     "name": "get number of dynamic fields from field layout",
-    "gasUsed": 363
+    "gasUsed": 389
   },
   {
     "file": "test/FieldLayout.t.sol",
@@ -93,13 +93,13 @@
     "file": "test/FieldLayout.t.sol",
     "test": "testGetNumStaticFields",
     "name": "get number of static fields from field layout",
-    "gasUsed": 293
+    "gasUsed": 311
   },
   {
     "file": "test/FieldLayout.t.sol",
     "test": "testGetStaticFieldLayoutLength",
     "name": "get static data length from field layout",
-    "gasUsed": 218
+    "gasUsed": 228
   },
   {
     "file": "test/FieldLayout.t.sol",
@@ -117,43 +117,43 @@
     "file": "test/FieldLayout.t.sol",
     "test": "testValidate",
     "name": "validate field layout",
-    "gasUsed": 3944
+    "gasUsed": 3993
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "abi encode",
-    "gasUsed": 949
+    "gasUsed": 924
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "abi decode",
-    "gasUsed": 1738
+    "gasUsed": 1713
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "custom encode",
-    "gasUsed": 1394
+    "gasUsed": 1343
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "custom decode",
-    "gasUsed": 1976
+    "gasUsed": 2002
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "pass abi encoded bytes to external contract",
-    "gasUsed": 6550
+    "gasUsed": 6536
   },
   {
     "file": "test/Gas.t.sol",
     "test": "testCompareAbiEncodeVsCustom",
     "name": "pass custom encoded bytes to external contract",
-    "gasUsed": 1444
+    "gasUsed": 1419
   },
   {
     "file": "test/Gas.t.sol",
@@ -207,7 +207,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageWriteSolidity",
     "name": "solidity storage write (cold, 10 words)",
-    "gasUsed": 199902
+    "gasUsed": 200020
   },
   {
     "file": "test/Gas.t.sol",
@@ -225,7 +225,7 @@
     "file": "test/Gas.t.sol",
     "test": "testCompareStorageWriteSolidity",
     "name": "solidity storage write (warm, 10 words)",
-    "gasUsed": 1988
+    "gasUsed": 2265
   },
   {
     "file": "test/GasStorageLoad.t.sol",
@@ -321,31 +321,31 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 688824
+    "gasUsed": 688983
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testCompareSolidity",
     "name": "store Mixed struct in storage (native solidity)",
-    "gasUsed": 92038
+    "gasUsed": 92007
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 550584
+    "gasUsed": 550770
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 104665
+    "gasUsed": 104743
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 7310
+    "gasUsed": 7381
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -375,7 +375,7 @@
     "file": "test/PackedCounter.t.sol",
     "test": "testSetAtIndex",
     "name": "set value at index of PackedCounter",
-    "gasUsed": 286
+    "gasUsed": 283
   },
   {
     "file": "test/Schema.t.sol",
@@ -387,19 +387,19 @@
     "file": "test/Schema.t.sol",
     "test": "testEncodeDecodeSchema",
     "name": "encode schema with 6 entries",
-    "gasUsed": 3555
+    "gasUsed": 3609
   },
   {
     "file": "test/Schema.t.sol",
     "test": "testEncodeDecodeSchema",
     "name": "get schema type at index",
-    "gasUsed": 115
+    "gasUsed": 119
   },
   {
     "file": "test/Schema.t.sol",
     "test": "testGetNumDynamicFields",
     "name": "get number of dynamic fields from schema",
-    "gasUsed": 363
+    "gasUsed": 389
   },
   {
     "file": "test/Schema.t.sol",
@@ -411,13 +411,13 @@
     "file": "test/Schema.t.sol",
     "test": "testGetNumStaticFields",
     "name": "get number of static fields from schema",
-    "gasUsed": 293
+    "gasUsed": 311
   },
   {
     "file": "test/Schema.t.sol",
     "test": "testGetStaticSchemaLength",
     "name": "get static data length from schema",
-    "gasUsed": 218
+    "gasUsed": 228
   },
   {
     "file": "test/Schema.t.sol",
@@ -435,7 +435,7 @@
     "file": "test/Schema.t.sol",
     "test": "testValidate",
     "name": "validate schema",
-    "gasUsed": 11336
+    "gasUsed": 11497
   },
   {
     "file": "test/Slice.t.sol",
@@ -459,13 +459,13 @@
     "file": "test/Slice.t.sol",
     "test": "testSubslice",
     "name": "subslice bytes (no copy) [1:4]",
-    "gasUsed": 311
+    "gasUsed": 324
   },
   {
     "file": "test/Slice.t.sol",
     "test": "testSubslice",
     "name": "subslice bytes (no copy) [4:37]",
-    "gasUsed": 311
+    "gasUsed": 324
   },
   {
     "file": "test/Slice.t.sol",
@@ -531,109 +531,109 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8363
+    "gasUsed": 8388
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2431
+    "gasUsed": 2456
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4434
+    "gasUsed": 4459
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4660
+    "gasUsed": 4685
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7739
+    "gasUsed": 7749
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (warm, 1 slot)",
-    "gasUsed": 1735
+    "gasUsed": 1745
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm due to , 2 slots)",
-    "gasUsed": 7740
+    "gasUsed": 7750
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm, 2 slots)",
-    "gasUsed": 1734
+    "gasUsed": 1744
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 20730
+    "gasUsed": 20788
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 14736
+    "gasUsed": 14794
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 22479
+    "gasUsed": 22544
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 14485
+    "gasUsed": 14550
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6169
+    "gasUsed": 6188
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1346
+    "gasUsed": 1361
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 2152
+    "gasUsed": 2169
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access length of dynamic field of non-existing record",
-    "gasUsed": 1102
+    "gasUsed": 1112
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1564
+    "gasUsed": 1589
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 7443
+    "gasUsed": 7503
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -651,67 +651,67 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 58781
+    "gasUsed": 58769
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 70182
+    "gasUsed": 70271
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 21875
+    "gasUsed": 21868
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 17982
+    "gasUsed": 18102
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 58781
+    "gasUsed": 58769
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 163716
+    "gasUsed": 163887
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 24419
+    "gasUsed": 24432
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 18936
+    "gasUsed": 19056
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 12285
+    "gasUsed": 12266
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 34912
+    "gasUsed": 34893
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 612735
+    "gasUsed": 612817
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -735,55 +735,55 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 102702
+    "gasUsed": 102831
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4600
+    "gasUsed": 4633
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using native solidity",
-    "gasUsed": 116842
+    "gasUsed": 116818
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using abi.encode",
-    "gasUsed": 267368
+    "gasUsed": 267534
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 0",
-    "gasUsed": 22853
+    "gasUsed": 22850
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 1",
-    "gasUsed": 952
+    "gasUsed": 949
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "reduce dynamic length of dynamic index 0",
-    "gasUsed": 942
+    "gasUsed": 939
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 32039
+    "gasUsed": 32059
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1345
+    "gasUsed": 1360
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -795,79 +795,79 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 30681
+    "gasUsed": 30713
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 1872
+    "gasUsed": 1892
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 53225
+    "gasUsed": 53255
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 2319
+    "gasUsed": 2336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 31329
+    "gasUsed": 31359
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 2321
+    "gasUsed": 2338
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 32388
+    "gasUsed": 32456
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1596
+    "gasUsed": 1615
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 54893
+    "gasUsed": 54961
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1785
+    "gasUsed": 1804
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 12796
+    "gasUsed": 12788
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 13810
+    "gasUsed": 13802
   },
   {
     "file": "test/StoreHook.t.sol",
     "test": "testCallHook",
     "name": "call an enabled hook",
-    "gasUsed": 10157
+    "gasUsed": 10155
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,121 +909,121 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 56307
+    "gasUsed": 56329
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 3776
+    "gasUsed": 3806
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 35671
+    "gasUsed": 35655
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 58321
+    "gasUsed": 58339
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 58321
+    "gasUsed": 58339
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: get field (warm)",
-    "gasUsed": 3779
+    "gasUsed": 3809
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 15776
+    "gasUsed": 15756
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 12185
+    "gasUsed": 12242
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 13790
+    "gasUsed": 13770
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 34353
+    "gasUsed": 34344
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 7848
+    "gasUsed": 7908
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 30452
+    "gasUsed": 30470
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 81009
+    "gasUsed": 81027
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 80920
+    "gasUsed": 80938
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 16723
+    "gasUsed": 16783
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGet",
     "name": "StoreHooks: get field (cold)",
-    "gasUsed": 9777
+    "gasUsed": 9807
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGetItem",
     "name": "StoreHooks: get 1 element (cold)",
-    "gasUsed": 6517
+    "gasUsed": 6519
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testLength",
     "name": "StoreHooks: get length (cold)",
-    "gasUsed": 5836
+    "gasUsed": 5846
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 22351
+    "gasUsed": 22415
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 24107
+    "gasUsed": 24109
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1041,19 +1041,19 @@
     "file": "test/tightcoder/EncodeArray.t.sol",
     "test": "testEncodeUint16Array",
     "name": "encode packed uint16[]",
-    "gasUsed": 595
+    "gasUsed": 594
   },
   {
     "file": "test/tightcoder/EncodeArray.t.sol",
     "test": "testEncodeUint32Array",
     "name": "encode packed uint32[]",
-    "gasUsed": 504
+    "gasUsed": 503
   },
   {
     "file": "test/tightcoder/EncodeArray.t.sol",
     "test": "testEncodeUint8Array",
     "name": "encode packed uint8[]",
-    "gasUsed": 493
+    "gasUsed": 492
   },
   {
     "file": "test/tightcoder/TightCoder.t.sol",
@@ -1065,7 +1065,7 @@
     "file": "test/tightcoder/TightCoder.t.sol",
     "test": "testToAndFromBytes24Array",
     "name": "encode packed bytes24[]",
-    "gasUsed": 501
+    "gasUsed": 503
   },
   {
     "file": "test/tightcoder/TightCoder.t.sol",
@@ -1077,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 412008
+    "gasUsed": 412244
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 33202
+    "gasUsed": 33274
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 2518
+    "gasUsed": 2548
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -255,7 +255,7 @@
     "file": "test/GasStorageLoad.t.sol",
     "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load field (warm, 1 word)",
-    "gasUsed": 228
+    "gasUsed": 245
   },
   {
     "file": "test/GasStorageLoad.t.sol",
@@ -267,7 +267,7 @@
     "file": "test/GasStorageLoad.t.sol",
     "test": "testCompareStorageLoadMUD",
     "name": "MUD storage load field (warm, partial)",
-    "gasUsed": 228
+    "gasUsed": 2378
   },
   {
     "file": "test/GasStorageLoad.t.sol",
@@ -321,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 696963
+    "gasUsed": 694127
   },
   {
     "file": "test/Mixed.t.sol",
@@ -333,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 559124
+    "gasUsed": 556283
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 107866
+    "gasUsed": 107865
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 9144
+    "gasUsed": 9143
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -543,67 +543,67 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4445
+    "gasUsed": 4444
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4671
+    "gasUsed": 4670
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7739
+    "gasUsed": 7740
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (warm, 1 slot)",
-    "gasUsed": 1735
+    "gasUsed": 1734
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm due to , 2 slots)",
-    "gasUsed": 7739
+    "gasUsed": 7740
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm, 2 slots)",
-    "gasUsed": 1734
+    "gasUsed": 1735
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 22111
+    "gasUsed": 22110
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 16121
+    "gasUsed": 16120
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 23860
+    "gasUsed": 23859
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 15870
+    "gasUsed": 15869
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6160
+    "gasUsed": 6159
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -621,31 +621,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access length of dynamic field of non-existing record",
-    "gasUsed": 1102
+    "gasUsed": 1103
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1576
+    "gasUsed": 1575
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 8804
+    "gasUsed": 8808
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 4319
+    "gasUsed": 1478
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "check for existence of table (non-existent)",
-    "gasUsed": 6321
+    "gasUsed": 3478
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -669,7 +669,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 20683
+    "gasUsed": 20691
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -693,43 +693,43 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 21637
+    "gasUsed": 21645
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 13684
+    "gasUsed": 13682
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 36315
+    "gasUsed": 36314
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 619462
+    "gasUsed": 616621
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get field layout (warm)",
-    "gasUsed": 4333
+    "gasUsed": 1491
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get schema (warm)",
-    "gasUsed": 4885
+    "gasUsed": 1557
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 8983
+    "gasUsed": 3037
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -741,7 +741,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4615
+    "gasUsed": 4614
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -765,13 +765,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 1",
-    "gasUsed": 952
+    "gasUsed": 953
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "reduce dynamic length of dynamic index 0",
-    "gasUsed": 942
+    "gasUsed": 943
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -783,13 +783,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1337
+    "gasUsed": 1336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field V2 (1 slot)",
-    "gasUsed": 687
+    "gasUsed": 713
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,19 +807,19 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 54612
+    "gasUsed": 54613
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 2334
+    "gasUsed": 2333
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 32720
+    "gasUsed": 32719
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -837,31 +837,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1587
+    "gasUsed": 1588
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 56256
+    "gasUsed": 56255
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1776
+    "gasUsed": 1777
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 14195
+    "gasUsed": 14194
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 15214
+    "gasUsed": 15213
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -921,7 +921,7 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 38129
+    "gasUsed": 38128
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
@@ -969,7 +969,7 @@
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 10284
+    "gasUsed": 10288
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
@@ -993,7 +993,7 @@
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 19144
+    "gasUsed": 19148
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
@@ -1077,13 +1077,13 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 420564
+    "gasUsed": 417746
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 36380
+    "gasUsed": 36379
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -321,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 694127
+    "gasUsed": 689422
   },
   {
     "file": "test/Mixed.t.sol",
@@ -333,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 556283
+    "gasUsed": 551241
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 107865
+    "gasUsed": 104984
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 9143
+    "gasUsed": 7327
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -579,43 +579,43 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 22110
+    "gasUsed": 21045
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 16120
+    "gasUsed": 15054
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 23859
+    "gasUsed": 22794
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 15869
+    "gasUsed": 14803
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6159
+    "gasUsed": 6160
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1337
+    "gasUsed": 1336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 2164
+    "gasUsed": 2163
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -627,13 +627,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1575
+    "gasUsed": 1576
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 8808
+    "gasUsed": 7741
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -645,79 +645,79 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "check for existence of table (non-existent)",
-    "gasUsed": 3478
+    "gasUsed": 3479
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 61185
+    "gasUsed": 59076
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 72948
+    "gasUsed": 70821
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 24641
+    "gasUsed": 22514
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 20691
+    "gasUsed": 18564
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 61185
+    "gasUsed": 59076
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 166479
+    "gasUsed": 164351
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 27212
+    "gasUsed": 25085
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 21645
+    "gasUsed": 19518
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 13682
+    "gasUsed": 12616
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 36314
+    "gasUsed": 35247
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 616621
+    "gasUsed": 613392
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get field layout (warm)",
-    "gasUsed": 1491
+    "gasUsed": 1490
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -729,13 +729,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 3037
+    "gasUsed": 3036
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 104087
+    "gasUsed": 103021
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -753,13 +753,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using abi.encode",
-    "gasUsed": 267369
+    "gasUsed": 267368
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 0",
-    "gasUsed": 22853
+    "gasUsed": 22852
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -777,13 +777,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 33402
+    "gasUsed": 32336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1336
+    "gasUsed": 1337
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -795,7 +795,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 32045
+    "gasUsed": 30979
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,7 +807,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 54613
+    "gasUsed": 53546
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -819,7 +819,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 32719
+    "gasUsed": 31652
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -831,7 +831,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 33751
+    "gasUsed": 32685
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -843,25 +843,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 56255
+    "gasUsed": 55189
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1777
+    "gasUsed": 1776
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 14194
+    "gasUsed": 13127
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 15213
+    "gasUsed": 14145
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,121 +909,121 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 58762
+    "gasUsed": 56630
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 4872
+    "gasUsed": 3806
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 38128
+    "gasUsed": 36010
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 60765
+    "gasUsed": 58635
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 60765
+    "gasUsed": 58635
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: get field (warm)",
-    "gasUsed": 4855
+    "gasUsed": 3789
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 18220
+    "gasUsed": 16103
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 14637
+    "gasUsed": 12505
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 16244
+    "gasUsed": 14125
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 36814
+    "gasUsed": 34694
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 10288
+    "gasUsed": 8153
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 32917
+    "gasUsed": 30782
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 83453
+    "gasUsed": 81323
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 83365
+    "gasUsed": 81234
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 19148
+    "gasUsed": 17018
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGet",
     "name": "StoreHooks: get field (cold)",
-    "gasUsed": 10851
+    "gasUsed": 9786
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGetItem",
     "name": "StoreHooks: get 1 element (cold)",
-    "gasUsed": 7592
+    "gasUsed": 6527
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testLength",
     "name": "StoreHooks: get length (cold)",
-    "gasUsed": 6901
+    "gasUsed": 5836
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 24795
+    "gasUsed": 22665
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 26546
+    "gasUsed": 24431
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1077,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 417746
+    "gasUsed": 412701
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 36379
+    "gasUsed": 33500
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4324
+    "gasUsed": 2510
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -321,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 688983
+    "gasUsed": 687785
   },
   {
     "file": "test/Mixed.t.sol",
@@ -333,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 550770
+    "gasUsed": 549631
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 104743
+    "gasUsed": 103597
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 7381
+    "gasUsed": 7483
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -531,115 +531,115 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8388
+    "gasUsed": 8436
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2456
+    "gasUsed": 2504
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4459
+    "gasUsed": 4507
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4685
+    "gasUsed": 4733
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7749
+    "gasUsed": 7755
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (warm, 1 slot)",
-    "gasUsed": 1745
+    "gasUsed": 1751
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm due to , 2 slots)",
-    "gasUsed": 7750
+    "gasUsed": 7756
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm, 2 slots)",
-    "gasUsed": 1744
+    "gasUsed": 1750
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 20788
+    "gasUsed": 19601
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 14794
+    "gasUsed": 13606
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 22544
+    "gasUsed": 21356
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 14550
+    "gasUsed": 13362
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6188
+    "gasUsed": 6194
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1361
+    "gasUsed": 1360
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 2169
+    "gasUsed": 2224
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access length of dynamic field of non-existing record",
-    "gasUsed": 1112
+    "gasUsed": 1119
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1589
+    "gasUsed": 1636
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 7503
+    "gasUsed": 6261
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 1110
+    "gasUsed": 1111
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -651,67 +651,67 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 58769
+    "gasUsed": 57630
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 70271
+    "gasUsed": 67740
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 21868
+    "gasUsed": 19358
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 18102
+    "gasUsed": 15636
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 58769
+    "gasUsed": 57630
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 163887
+    "gasUsed": 161464
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 24432
+    "gasUsed": 22030
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 19056
+    "gasUsed": 16602
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 12266
+    "gasUsed": 11125
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 34893
+    "gasUsed": 33751
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 612817
+    "gasUsed": 611678
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -735,13 +735,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 102831
+    "gasUsed": 101685
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4633
+    "gasUsed": 4734
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -753,31 +753,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using abi.encode",
-    "gasUsed": 267534
+    "gasUsed": 267533
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 0",
-    "gasUsed": 22850
+    "gasUsed": 22855
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 1",
-    "gasUsed": 949
+    "gasUsed": 955
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "reduce dynamic length of dynamic index 0",
-    "gasUsed": 939
+    "gasUsed": 945
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 32059
+    "gasUsed": 30811
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -789,13 +789,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field V2 (1 slot)",
-    "gasUsed": 721
+    "gasUsed": 722
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 30713
+    "gasUsed": 29464
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,31 +807,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 53255
+    "gasUsed": 52059
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 2336
+    "gasUsed": 2390
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 31359
+    "gasUsed": 30163
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 2338
+    "gasUsed": 2391
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 32456
+    "gasUsed": 31208
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -843,7 +843,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 54961
+    "gasUsed": 53713
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -855,13 +855,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 12788
+    "gasUsed": 11641
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 13802
+    "gasUsed": 12654
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,121 +909,121 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 56329
+    "gasUsed": 55159
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 3806
+    "gasUsed": 6484
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 35655
+    "gasUsed": 34535
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 58339
+    "gasUsed": 57176
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 58339
+    "gasUsed": 57176
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: get field (warm)",
-    "gasUsed": 3809
+    "gasUsed": 6481
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 15756
+    "gasUsed": 14645
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 12242
+    "gasUsed": 11083
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 13770
+    "gasUsed": 12659
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 34344
+    "gasUsed": 33227
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 7908
+    "gasUsed": 6694
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 30470
+    "gasUsed": 29299
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 81027
+    "gasUsed": 79863
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 80938
+    "gasUsed": 79775
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 16783
+    "gasUsed": 15571
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGet",
     "name": "StoreHooks: get field (cold)",
-    "gasUsed": 9807
+    "gasUsed": 12479
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGetItem",
     "name": "StoreHooks: get 1 element (cold)",
-    "gasUsed": 6519
+    "gasUsed": 5502
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testLength",
     "name": "StoreHooks: get length (cold)",
-    "gasUsed": 5846
+    "gasUsed": 4988
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 22415
+    "gasUsed": 21258
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 24109
+    "gasUsed": 22994
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1077,13 +1077,13 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 412244
+    "gasUsed": 411128
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 33274
+    "gasUsed": 32027
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -321,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 689422
+    "gasUsed": 688824
   },
   {
     "file": "test/Mixed.t.sol",
@@ -333,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 551241
+    "gasUsed": 550584
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 104952
+    "gasUsed": 104665
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 7302
+    "gasUsed": 7310
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -537,7 +537,7 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2430
+    "gasUsed": 2431
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -555,13 +555,13 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7740
+    "gasUsed": 7739
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (warm, 1 slot)",
-    "gasUsed": 1734
+    "gasUsed": 1735
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
@@ -573,43 +573,43 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm, 2 slots)",
-    "gasUsed": 1735
+    "gasUsed": 1734
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 21026
+    "gasUsed": 20730
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 15032
+    "gasUsed": 14736
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 22774
+    "gasUsed": 22479
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 14780
+    "gasUsed": 14485
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6159
+    "gasUsed": 6169
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access static field of non-existing record",
-    "gasUsed": 1337
+    "gasUsed": 1346
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -621,7 +621,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access length of dynamic field of non-existing record",
-    "gasUsed": 1103
+    "gasUsed": 1102
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -633,115 +633,115 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 7729
+    "gasUsed": 7443
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 1477
+    "gasUsed": 1110
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "check for existence of table (non-existent)",
-    "gasUsed": 3479
+    "gasUsed": 3108
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 59076
+    "gasUsed": 58781
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 70811
+    "gasUsed": 70182
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 22504
+    "gasUsed": 21875
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 18554
+    "gasUsed": 17982
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 59076
+    "gasUsed": 58781
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 164333
+    "gasUsed": 163716
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 25066
+    "gasUsed": 24419
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 19508
+    "gasUsed": 18936
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 12580
+    "gasUsed": 12285
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 35208
+    "gasUsed": 34912
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 613392
+    "gasUsed": 612735
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get field layout (warm)",
-    "gasUsed": 1491
+    "gasUsed": 1119
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get schema (warm)",
-    "gasUsed": 1556
+    "gasUsed": 1185
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 3036
+    "gasUsed": 2292
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 102988
+    "gasUsed": 102702
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4591
+    "gasUsed": 4600
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -771,43 +771,43 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "reduce dynamic length of dynamic index 0",
-    "gasUsed": 943
+    "gasUsed": 942
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 32325
+    "gasUsed": 32039
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (1 slot)",
-    "gasUsed": 1336
+    "gasUsed": 1345
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field V2 (1 slot)",
-    "gasUsed": 713
+    "gasUsed": 721
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 30966
+    "gasUsed": 30681
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field (overlap 2 slot)",
-    "gasUsed": 1863
+    "gasUsed": 1872
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 53519
+    "gasUsed": 53225
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -819,7 +819,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 31624
+    "gasUsed": 31329
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -831,37 +831,37 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 32675
+    "gasUsed": 32388
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1587
+    "gasUsed": 1596
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 55179
+    "gasUsed": 54893
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1776
+    "gasUsed": 1785
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 13091
+    "gasUsed": 12796
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 14106
+    "gasUsed": 13810
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,31 +909,31 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 56608
+    "gasUsed": 56307
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 3794
+    "gasUsed": 3776
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 35973
+    "gasUsed": 35671
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 58616
+    "gasUsed": 58321
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 58616
+    "gasUsed": 58321
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
@@ -945,55 +945,55 @@
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 16071
+    "gasUsed": 15776
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 12480
+    "gasUsed": 12185
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 14085
+    "gasUsed": 13790
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 34648
+    "gasUsed": 34353
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 8134
+    "gasUsed": 7848
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 30747
+    "gasUsed": 30452
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 81304
+    "gasUsed": 81009
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 81215
+    "gasUsed": 80920
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 17009
+    "gasUsed": 16723
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
@@ -1017,13 +1017,13 @@
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 22646
+    "gasUsed": 22351
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 24402
+    "gasUsed": 24107
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1077,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 412664
+    "gasUsed": 412008
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 33488
+    "gasUsed": 33202
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 2509
+    "gasUsed": 2518
   }
 ]

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -321,7 +321,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 697556
+    "gasUsed": 696963
   },
   {
     "file": "test/Mixed.t.sol",
@@ -333,19 +333,19 @@
     "file": "test/Mixed.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Mixed table",
-    "gasUsed": 559738
+    "gasUsed": 559124
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "set record in Mixed",
-    "gasUsed": 108492
+    "gasUsed": 107866
   },
   {
     "file": "test/Mixed.t.sol",
     "test": "testSetAndGet",
     "name": "get record from Mixed",
-    "gasUsed": 9491
+    "gasUsed": 9144
   },
   {
     "file": "test/PackedCounter.t.sol",
@@ -531,79 +531,79 @@
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (cold, 1 slot)",
-    "gasUsed": 8424
+    "gasUsed": 8372
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 1 slot)",
-    "gasUsed": 2492
+    "gasUsed": 2440
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (semi-cold, 1 slot)",
-    "gasUsed": 4498
+    "gasUsed": 4445
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetFieldSlice",
     "name": "get field slice (warm, 2 slots)",
-    "gasUsed": 4724
+    "gasUsed": 4671
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (cold, 1 slot)",
-    "gasUsed": 7965
+    "gasUsed": 7739
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetSecondFieldLength",
     "name": "get field length (warm, 1 slot)",
-    "gasUsed": 1961
+    "gasUsed": 1735
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm due to , 2 slots)",
-    "gasUsed": 7965
+    "gasUsed": 7739
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testGetThirdFieldLength",
     "name": "get field length (warm, 2 slots)",
-    "gasUsed": 1962
+    "gasUsed": 1734
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (cold, 1 slot, 1 uint32 item)",
-    "gasUsed": 22897
+    "gasUsed": 22111
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromSecondField",
     "name": "pop from field (warm, 1 slot, 1 uint32 item)",
-    "gasUsed": 16927
+    "gasUsed": 16121
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (cold, 2 slots, 10 uint32 items)",
-    "gasUsed": 24647
+    "gasUsed": 23860
   },
   {
     "file": "test/StoreCoreDynamic.t.sol",
     "test": "testPopFromThirdField",
     "name": "pop from field (warm, 2 slots, 10 uint32 items)",
-    "gasUsed": 16677
+    "gasUsed": 15870
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access non-existing record",
-    "gasUsed": 6389
+    "gasUsed": 6160
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -615,103 +615,103 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access dynamic field of non-existing record",
-    "gasUsed": 2449
+    "gasUsed": 2164
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access length of dynamic field of non-existing record",
-    "gasUsed": 1335
+    "gasUsed": 1102
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testAccessEmptyData",
     "name": "access slice of dynamic field of non-existing record",
-    "gasUsed": 1630
+    "gasUsed": 1576
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testDeleteData",
     "name": "delete record (complex data, 3 slots)",
-    "gasUsed": 9322
+    "gasUsed": 8804
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "Check for existence of table (existent)",
-    "gasUsed": 4320
+    "gasUsed": 4319
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHasFieldLayout",
     "name": "check for existence of table (non-existent)",
-    "gasUsed": 6322
+    "gasUsed": 6321
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "register subscriber",
-    "gasUsed": 61935
+    "gasUsed": 61185
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set record on table with subscriber",
-    "gasUsed": 73476
+    "gasUsed": 72948
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 25169
+    "gasUsed": 24641
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "delete record on table with subscriber",
-    "gasUsed": 21211
+    "gasUsed": 20683
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "register subscriber",
-    "gasUsed": 61935
+    "gasUsed": 61185
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) record on table with subscriber",
-    "gasUsed": 167535
+    "gasUsed": 166479
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 28269
+    "gasUsed": 27212
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "delete (dynamic) record on table with subscriber",
-    "gasUsed": 22595
+    "gasUsed": 21637
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (1 slot, 1 uint32 item)",
-    "gasUsed": 14556
+    "gasUsed": 13684
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testPushToField",
     "name": "push to field (2 slots, 10 uint32 items)",
-    "gasUsed": 37203
+    "gasUsed": 36315
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 620066
+    "gasUsed": 619462
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -723,25 +723,25 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get schema (warm)",
-    "gasUsed": 4887
+    "gasUsed": 4885
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 8986
+    "gasUsed": 8983
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "set complex record with dynamic data (4 slots)",
-    "gasUsed": 104710
+    "gasUsed": 104087
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "get complex record with dynamic data (4 slots)",
-    "gasUsed": 4957
+    "gasUsed": 4615
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -753,31 +753,31 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using abi.encode",
-    "gasUsed": 267371
+    "gasUsed": 267369
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 0",
-    "gasUsed": 23082
+    "gasUsed": 22853
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "set dynamic length of dynamic index 1",
-    "gasUsed": 1183
+    "gasUsed": 952
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicDataLength",
     "name": "reduce dynamic length of dynamic index 0",
-    "gasUsed": 1174
+    "gasUsed": 942
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (1 slot)",
-    "gasUsed": 33686
+    "gasUsed": 33402
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -789,13 +789,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get static field V2 (1 slot)",
-    "gasUsed": 688
+    "gasUsed": 687
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set static field (overlap 2 slot)",
-    "gasUsed": 32333
+    "gasUsed": 32045
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,61 +807,61 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 55196
+    "gasUsed": 54612
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, first dynamic field)",
-    "gasUsed": 2627
+    "gasUsed": 2334
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "set dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 33314
+    "gasUsed": 32720
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetField",
     "name": "get dynamic field (1 slot, second dynamic field)",
-    "gasUsed": 2635
+    "gasUsed": 2336
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "set static record (1 slot)",
-    "gasUsed": 34035
+    "gasUsed": 33751
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticData",
     "name": "get static record (1 slot)",
-    "gasUsed": 1589
+    "gasUsed": 1587
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "set static record (2 slots)",
-    "gasUsed": 56539
+    "gasUsed": 56256
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetStaticDataSpanningWords",
     "name": "get static record (2 slots)",
-    "gasUsed": 1777
+    "gasUsed": 1776
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "update in field (1 slot, 1 uint32 item)",
-    "gasUsed": 14833
+    "gasUsed": 14195
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testUpdateInField",
     "name": "push to field (2 slots, 6 uint64 items)",
-    "gasUsed": 15863
+    "gasUsed": 15214
   },
   {
     "file": "test/StoreHook.t.sol",
@@ -909,121 +909,121 @@
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: set field",
-    "gasUsed": 59330
+    "gasUsed": 58762
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: get field (warm)",
-    "gasUsed": 5159
+    "gasUsed": 4872
   },
   {
     "file": "test/tables/Callbacks.t.sol",
     "test": "testSetAndGet",
     "name": "Callbacks: push 1 element",
-    "gasUsed": 38999
+    "gasUsed": 38129
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testOneSlot",
     "name": "StoreHooks: set field with one elements (cold)",
-    "gasUsed": 61323
+    "gasUsed": 60765
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (cold)",
-    "gasUsed": 61323
+    "gasUsed": 60765
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: get field (warm)",
-    "gasUsed": 5136
+    "gasUsed": 4855
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (cold)",
-    "gasUsed": 19075
+    "gasUsed": 18220
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: pop 1 element (warm)",
-    "gasUsed": 15453
+    "gasUsed": 14637
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: push 1 element (warm)",
-    "gasUsed": 17134
+    "gasUsed": 16244
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: update 1 element (warm)",
-    "gasUsed": 37483
+    "gasUsed": 36814
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: delete record (warm)",
-    "gasUsed": 10840
+    "gasUsed": 10284
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTable",
     "name": "StoreHooks: set field (warm)",
-    "gasUsed": 33543
+    "gasUsed": 32917
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testThreeSlots",
     "name": "StoreHooks: set field with three elements (cold)",
-    "gasUsed": 84011
+    "gasUsed": 83453
   },
   {
     "file": "test/tables/StoreHooks.t.sol",
     "test": "testTwoSlots",
     "name": "StoreHooks: set field with two elements (cold)",
-    "gasUsed": 83923
+    "gasUsed": 83365
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testDelete",
     "name": "StoreHooks: delete record (cold)",
-    "gasUsed": 19649
+    "gasUsed": 19144
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGet",
     "name": "StoreHooks: get field (cold)",
-    "gasUsed": 11129
+    "gasUsed": 10851
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testGetItem",
     "name": "StoreHooks: get 1 element (cold)",
-    "gasUsed": 7644
+    "gasUsed": 7592
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testLength",
     "name": "StoreHooks: get length (cold)",
-    "gasUsed": 7127
+    "gasUsed": 6901
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testPop",
     "name": "StoreHooks: pop 1 element (cold)",
-    "gasUsed": 25580
+    "gasUsed": 24795
   },
   {
     "file": "test/tables/StoreHooksColdLoad.t.sol",
     "test": "testUpdate",
     "name": "StoreHooks: update 1 element (cold)",
-    "gasUsed": 27157
+    "gasUsed": 26546
   },
   {
     "file": "test/tightcoder/DecodeSlice.t.sol",
@@ -1077,18 +1077,18 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 421180
+    "gasUsed": 420564
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "set Vector2 record",
-    "gasUsed": 36664
+    "gasUsed": 36380
   },
   {
     "file": "test/Vector2.t.sol",
     "test": "testSetAndGet",
     "name": "get Vector2 record",
-    "gasUsed": 4326
+    "gasUsed": 4324
   }
 ]

--- a/packages/store/hardhat.config.ts
+++ b/packages/store/hardhat.config.ts
@@ -6,7 +6,7 @@ const config: HardhatUserConfig = {
     sources: "./src",
   },
   solidity: {
-    version: "0.8.13",
+    version: "0.8.21",
     settings: {
       optimizer: {
         enabled: true,

--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -28,6 +28,8 @@ interface IStoreRead {
     FieldLayout fieldLayout
   ) external view returns (bytes memory data);
 
+  function loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) external view returns (bytes32);
+
   // Get field length at schema index
   function getFieldLength(
     bytes32 table,
@@ -61,6 +63,17 @@ interface IStoreWrite {
     bytes32[] calldata key,
     uint8 schemaIndex,
     bytes calldata data,
+    FieldLayout fieldLayout
+  ) external;
+
+  function storeStaticField(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset,
+    bytes memory data,
+    bytes32 tableId,
+    bytes32[] memory key,
+    uint8 schemaIndex,
     FieldLayout fieldLayout
   ) external;
 

--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -30,6 +30,12 @@ interface IStoreRead {
 
   function loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) external view returns (bytes32);
 
+  function loadDynamicField(
+    uint256 storagePointer,
+    uint256 lengthStoragePointer,
+    uint8 dynamicSchemaIndex
+  ) external view returns (bytes memory);
+
   // Get field length at schema index
   function getFieldLength(
     bytes32 table,
@@ -37,6 +43,8 @@ interface IStoreRead {
     uint8 schemaIndex,
     FieldLayout fieldLayout
   ) external view returns (uint256);
+
+  function loadFieldLength(uint256 lengthStoragePointer, uint8 dynamicSchemaIndex) external view returns (uint256);
 
   // Get start:end slice of the field at schema index
   function getFieldSlice(
@@ -47,6 +55,8 @@ interface IStoreRead {
     uint256 start,
     uint256 end
   ) external view returns (bytes memory data);
+
+  function loadFieldSlice(uint256 storagePointer, uint256 start, uint256 end) external view returns (bytes memory data);
 }
 
 interface IStoreWrite {

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -99,6 +99,18 @@ library Storage {
     }
   }
 
+  function loadField(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes32 result) {
+    if (offset >= 32) {
+      unchecked {
+        storagePointer += offset / 32;
+        offset %= 32;
+      }
+    }
+    assembly {
+      result := shr(mul(sub(32, length), 8), shl(mul(offset, 8), sload(storagePointer)))
+    }
+  }
+
   function load(uint256 storagePointer) internal view returns (bytes32 word) {
     assembly {
       word := sload(storagePointer)

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -107,7 +107,7 @@ library Storage {
       }
     }
     assembly {
-      result := shr(mul(sub(32, length), 8), shl(mul(offset, 8), sload(storagePointer)))
+      result := shl(mul(offset, 8), sload(storagePointer))
     }
   }
 

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -106,8 +106,22 @@ library Storage {
         offset %= 32;
       }
     }
+
+    // NOTE: extra data past length is not masked out
     assembly {
       result := shl(mul(offset, 8), sload(storagePointer))
+    }
+
+    uint256 wordRemainder;
+    // (safe because of `offset %= 32` at the start)
+    unchecked {
+      wordRemainder = 32 - offset;
+    }
+
+    if (length > wordRemainder) {
+      assembly {
+        result := or(result, shr(mul(wordRemainder, 8), sload(add(storagePointer, 1))))
+      }
     }
   }
 

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -540,6 +540,9 @@ library StoreCore {
     }
   }
 
+  /**
+   * Load the static field stored at the given storagePointer, with the given length and offset
+   */
   function loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes32) {
     return StoreCoreInternal._loadStaticField(storagePointer, length, offset);
   }
@@ -814,14 +817,14 @@ library StoreCoreInternal {
     bytes32[] memory key,
     uint8 schemaIndex
   ) internal pure returns (uint256) {
-    return uint256(keccak256(abi.encode(SLOT, tableId, key, schemaIndex)));
+    return uint256(SLOT ^ tableId ^ keccak256(abi.encode(key, schemaIndex)));
   }
 
   /**
    * Compute the storage location for the length of the dynamic data
    */
   function _getDynamicDataLengthLocation(bytes32 tableId, bytes32[] memory key) internal pure returns (uint256) {
-    return uint256(keccak256(abi.encode(SLOT, tableId, key, "length")));
+    return uint256(SLOT ^ tableId ^ bytes32("length") ^ keccak256(abi.encodePacked(key)));
   }
 
   /**

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -832,7 +832,11 @@ library StoreCoreInternal {
    * Compute the storage location based on tableId id and index tuple
    */
   function _getStaticDataLocation(bytes32 tableId, bytes32[] memory key) internal pure returns (uint256) {
-    return uint256(SLOT ^ tableId ^ keccak256(abi.encodePacked(key)));
+    return _getStaticDataLocation(tableId, keccak256(abi.encodePacked(key)));
+  }
+
+  function _getStaticDataLocation(bytes32 tableId, bytes32 keyHash) internal pure returns (uint256) {
+    return uint256(SLOT ^ tableId ^ keyHash);
   }
 
   /**

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -540,6 +540,10 @@ library StoreCore {
     }
   }
 
+  function loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes32) {
+    return StoreCoreInternal._loadStaticField(storagePointer, length, offset);
+  }
+
   /**
    * Get the byte length of a single field from the given tableId and key tuple, with the given value field layout
    */
@@ -592,6 +596,10 @@ library StoreCoreInternal {
    *    SET DATA
    *
    ************************************************************************/
+
+  function _loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes32) {
+    return Storage.loadField(storagePointer, length, offset);
+  }
 
   function _setStaticField(
     bytes32 tableId,
@@ -780,7 +788,7 @@ library StoreCoreInternal {
    * Compute the storage location based on tableId id and index tuple
    */
   function _getStaticDataLocation(bytes32 tableId, bytes32[] memory key) internal pure returns (uint256) {
-    return uint256(keccak256(abi.encode(SLOT, tableId, key)));
+    return uint256(SLOT ^ tableId ^ keccak256(abi.encodePacked(key)));
   }
 
   /**

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -858,7 +858,8 @@ library StoreCoreInternal {
     bytes32[] memory key,
     uint8 schemaIndex
   ) internal pure returns (uint256) {
-    return uint256(SLOT ^ tableId ^ keccak256(abi.encode(key, schemaIndex)));
+    // offset by 1 to avoid collision with static data
+    return uint256(SLOT ^ tableId ^ bytes1(schemaIndex + 1) ^ keccak256(abi.encodePacked(key)));
   }
 
   /**

--- a/packages/store/src/StoreCore.sol
+++ b/packages/store/src/StoreCore.sol
@@ -175,7 +175,7 @@ library StoreCore {
     emit StoreSetRecord(tableId, key, data);
 
     // Call onBeforeSetRecord hooks (before actually modifying the state, so observers have access to the previous state if needed)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_SET_RECORD))) {
@@ -242,7 +242,7 @@ library StoreCore {
     emit StoreSetField(tableId, key, schemaIndex, data);
 
     // Call onBeforeSetField hooks (before modifying the state)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_SET_FIELD))) {
@@ -276,7 +276,7 @@ library StoreCore {
     FieldLayout fieldLayout
   ) internal {
     // Call onBeforeSetField hooks (before modifying the state)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
 
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
@@ -307,7 +307,7 @@ library StoreCore {
     emit StoreDeleteRecord(tableId, key);
 
     // Call onBeforeDeleteRecord hooks (before actually modifying the state, so observers have access to the previous state if needed)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_DELETE_RECORD))) {
@@ -358,7 +358,7 @@ library StoreCore {
     emit StoreSetField(tableId, key, schemaIndex, fullData);
 
     // Call onBeforeSetField hooks (before modifying the state)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_SET_FIELD))) {
@@ -402,7 +402,7 @@ library StoreCore {
     emit StoreSetField(tableId, key, schemaIndex, fullData);
 
     // Call onBeforeSetField hooks (before modifying the state)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_SET_FIELD))) {
@@ -456,7 +456,7 @@ library StoreCore {
     emit StoreSetField(tableId, key, schemaIndex, fullData);
 
     // Call onBeforeSetField hooks (before modifying the state)
-    bytes21[] memory hooks = StoreHooks.get(tableId);
+    bytes21[] memory hooks = StoreHooks._get(tableId);
     for (uint256 i; i < hooks.length; i++) {
       Hook hook = Hook.wrap(hooks[i]);
       if (hook.isEnabled(uint8(StoreHookType.BEFORE_SET_FIELD))) {

--- a/packages/store/src/StoreRead.sol
+++ b/packages/store/src/StoreRead.sol
@@ -46,6 +46,14 @@ contract StoreRead is IStoreRead {
     return StoreCore.loadStaticField(storagePointer, length, offset);
   }
 
+  function loadDynamicField(
+    uint256 storagePointer,
+    uint256 lengthStoragePointer,
+    uint8 dynamicSchemaIndex
+  ) public view virtual returns (bytes memory) {
+    return StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, dynamicSchemaIndex);
+  }
+
   function getFieldLength(
     bytes32 tableId,
     bytes32[] memory key,
@@ -53,6 +61,13 @@ contract StoreRead is IStoreRead {
     FieldLayout fieldLayout
   ) public view virtual returns (uint256) {
     return StoreCore.getFieldLength(tableId, key, schemaIndex, fieldLayout);
+  }
+
+  function loadFieldLength(
+    uint256 lengthStoragePointer,
+    uint8 dynamicSchemaIndex
+  ) public view virtual returns (uint256) {
+    return StoreCore.loadFieldLength(lengthStoragePointer, dynamicSchemaIndex);
   }
 
   function getFieldSlice(
@@ -64,5 +79,13 @@ contract StoreRead is IStoreRead {
     uint256 end
   ) public view virtual returns (bytes memory) {
     return StoreCore.getFieldSlice(tableId, key, schemaIndex, fieldLayout, start, end);
+  }
+
+  function loadFieldSlice(
+    uint256 storagePointer,
+    uint256 start,
+    uint256 end
+  ) public view virtual returns (bytes memory) {
+    return StoreCore.loadFieldSlice(storagePointer, start, end);
   }
 }

--- a/packages/store/src/StoreRead.sol
+++ b/packages/store/src/StoreRead.sol
@@ -38,6 +38,14 @@ contract StoreRead is IStoreRead {
     data = StoreCore.getField(table, key, schemaIndex, fieldLayout);
   }
 
+  function loadStaticField(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset
+  ) public view virtual returns (bytes32) {
+    return StoreCore.loadStaticField(storagePointer, length, offset);
+  }
+
   function getFieldLength(
     bytes32 tableId,
     bytes32[] memory key,

--- a/packages/store/src/StoreSwitch.sol
+++ b/packages/store/src/StoreSwitch.sol
@@ -263,6 +263,19 @@ library StoreSwitch {
     }
   }
 
+  function loadDynamicField(
+    uint256 storagePointer,
+    uint256 lengthStoragePointer,
+    uint8 dynamicSchemaIndex
+  ) public view returns (bytes memory) {
+    address _storeAddress = getStoreAddress();
+    if (_storeAddress == address(this)) {
+      return StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, dynamicSchemaIndex);
+    } else {
+      return IStore(_storeAddress).loadDynamicField(storagePointer, lengthStoragePointer, dynamicSchemaIndex);
+    }
+  }
+
   function getFieldLength(
     bytes32 table,
     bytes32[] memory key,
@@ -274,6 +287,15 @@ library StoreSwitch {
       return StoreCore.getFieldLength(table, key, fieldIndex, fieldLayout);
     } else {
       return IStore(_storeAddress).getFieldLength(table, key, fieldIndex, fieldLayout);
+    }
+  }
+
+  function loadFieldLength(uint256 lengthStoragePointer, uint8 dynamicSchemaIndex) internal view returns (uint256) {
+    address _storeAddress = getStoreAddress();
+    if (_storeAddress == address(this)) {
+      return StoreCore.loadFieldLength(lengthStoragePointer, dynamicSchemaIndex);
+    } else {
+      return IStore(_storeAddress).loadFieldLength(lengthStoragePointer, dynamicSchemaIndex);
     }
   }
 
@@ -290,6 +312,15 @@ library StoreSwitch {
       return StoreCore.getFieldSlice(table, key, fieldIndex, fieldLayout, start, end);
     } else {
       return IStore(_storeAddress).getFieldSlice(table, key, fieldIndex, fieldLayout, start, end);
+    }
+  }
+
+  function loadFieldSlice(uint256 storagePointer, uint256 start, uint256 end) internal view returns (bytes memory) {
+    address _storeAddress = getStoreAddress();
+    if (_storeAddress == address(this)) {
+      return StoreCore.loadFieldSlice(storagePointer, start, end);
+    } else {
+      return IStore(_storeAddress).loadFieldSlice(storagePointer, start, end);
     }
   }
 }

--- a/packages/store/src/StoreSwitch.sol
+++ b/packages/store/src/StoreSwitch.sol
@@ -131,6 +131,33 @@ library StoreSwitch {
     }
   }
 
+  function storeStaticField(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset,
+    bytes memory data,
+    bytes32 tableId,
+    bytes32[] memory key,
+    uint8 schemaIndex,
+    FieldLayout fieldLayout
+  ) internal {
+    address _storeAddress = getStoreAddress();
+    if (_storeAddress == address(this)) {
+      StoreCore.storeStaticField(storagePointer, length, offset, data, tableId, key, schemaIndex, fieldLayout);
+    } else {
+      IStore(_storeAddress).storeStaticField(
+        storagePointer,
+        length,
+        offset,
+        data,
+        tableId,
+        key,
+        schemaIndex,
+        fieldLayout
+      );
+    }
+  }
+
   function pushToField(
     bytes32 table,
     bytes32[] memory key,
@@ -224,6 +251,15 @@ library StoreSwitch {
       return StoreCore.getField(table, key, fieldIndex, fieldLayout);
     } else {
       return IStore(_storeAddress).getField(table, key, fieldIndex, fieldLayout);
+    }
+  }
+
+  function loadStaticField(uint256 storagePointer, uint256 length, uint256 offset) internal view returns (bytes32) {
+    address _storeAddress = getStoreAddress();
+    if (_storeAddress == address(this)) {
+      return StoreCore.loadStaticField(storagePointer, length, offset);
+    } else {
+      return IStore(_storeAddress).loadStaticField(storagePointer, length, offset);
     }
   }
 

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -71,6 +71,18 @@ library Callbacks {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -82,6 +94,15 @@ library Callbacks {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
+  }
+
+  /** Get value */
+  function _get(bytes32 key) internal view returns (bytes24[] memory value) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
@@ -102,6 +123,14 @@ library Callbacks {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
   }
 
+  /** Set value */
+  function _set(bytes32 key, bytes24[] memory value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
+  }
+
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, bytes24[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -116,6 +145,17 @@ library Callbacks {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 24;
+    }
+  }
+
+  /** Get the length of value */
+  function _length(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 24;
     }
@@ -142,6 +182,27 @@ library Callbacks {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 24,
+        (_index + 1) * 24
+      );
+      return (Bytes.slice24(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of value
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItem(bytes32 key, uint256 _index) internal view returns (bytes24) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -182,6 +243,14 @@ library Callbacks {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to value */
+  function _push(bytes32 key, bytes24 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, bytes24 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -196,6 +265,14 @@ library Callbacks {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 24, getFieldLayout());
+  }
+
+  /** Pop an element from value */
+  function _pop(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 24, getFieldLayout());
   }
 
   /** Pop an element from value (using the specified store) */
@@ -216,6 +293,19 @@ library Callbacks {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of value at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _update(bytes32 key, uint256 _index, bytes24 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 24, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -257,6 +347,14 @@ library Callbacks {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -90,28 +90,31 @@ library Callbacks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
   /** Get value */
   function _get(bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (bytes24[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes24());
   }
 
@@ -141,10 +144,10 @@ library Callbacks {
 
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 24;
     }
@@ -152,10 +155,10 @@ library Callbacks {
 
   /** Get the length of value */
   function _length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 24;
     }
@@ -163,10 +166,10 @@ library Callbacks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 24;
     }
@@ -177,18 +180,11 @@ library Callbacks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 key, uint256 _index) internal view returns (bytes24) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 24,
-        (_index + 1) * 24
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 24, (_index + 1) * 24);
       return (Bytes.slice24(_blob, 0));
     }
   }
@@ -198,18 +194,11 @@ library Callbacks {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 key, uint256 _index) internal view returns (bytes24) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 24,
-        (_index + 1) * 24
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 24, (_index + 1) * 24);
       return (Bytes.slice24(_blob, 0));
     }
   }
@@ -219,18 +208,11 @@ library Callbacks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes24) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 24,
-        (_index + 1) * 24
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 24, (_index + 1) * 24);
       return (Bytes.slice24(_blob, 0));
     }
   }

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -21,12 +21,14 @@ import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("Callbacks")));
 bytes32 constant CallbacksTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library Callbacks {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/Callbacks.sol
+++ b/packages/store/src/codegen/tables/Callbacks.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Callbacks {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -23,6 +23,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Hooks {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -18,12 +18,14 @@ import { FieldLayout, FieldLayoutLib } from "../../FieldLayout.sol";
 import { Schema, SchemaLib } from "../../Schema.sol";
 import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library Hooks {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -87,28 +87,31 @@ library Hooks {
 
   /** Get value */
   function get(bytes32 _tableId, bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value */
   function _get(bytes32 _tableId, bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -138,10 +141,10 @@ library Hooks {
 
   /** Get the length of value */
   function length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -149,10 +152,10 @@ library Hooks {
 
   /** Get the length of value */
   function _length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -160,10 +163,10 @@ library Hooks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -174,18 +177,11 @@ library Hooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -195,18 +191,11 @@ library Hooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -216,18 +205,11 @@ library Hooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }

--- a/packages/store/src/codegen/tables/Hooks.sol
+++ b/packages/store/src/codegen/tables/Hooks.sol
@@ -68,6 +68,18 @@ library Hooks {
     );
   }
 
+  /** Register the table with its config */
+  function _register(bytes32 _tableId) internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -79,6 +91,15 @@ library Hooks {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
+  }
+
+  /** Get value */
+  function _get(bytes32 _tableId, bytes32 key) internal view returns (bytes21[] memory value) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -99,6 +120,14 @@ library Hooks {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
   }
 
+  /** Set value */
+  function _set(bytes32 _tableId, bytes32 key, bytes21[] memory value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
+  }
+
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 key, bytes21[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -113,6 +142,17 @@ library Hooks {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 21;
+    }
+  }
+
+  /** Get the length of value */
+  function _length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 21;
     }
@@ -139,6 +179,27 @@ library Hooks {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 21,
+        (_index + 1) * 21
+      );
+      return (Bytes.slice21(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of value
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (bytes21) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -179,6 +240,14 @@ library Hooks {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to value */
+  function _push(bytes32 _tableId, bytes32 key, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 key, bytes21 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -193,6 +262,14 @@ library Hooks {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
+  }
+
+  /** Pop an element from value */
+  function _pop(bytes32 _tableId, bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
   }
 
   /** Pop an element from value (using the specified store) */
@@ -213,6 +290,19 @@ library Hooks {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of value at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _update(bytes32 _tableId, bytes32 key, uint256 _index, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -254,6 +344,14 @@ library Hooks {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 _tableId, bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -98,15 +98,8 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](6);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
@@ -121,15 +114,8 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](6);
-    _keyTuple[0] = bytes32(uint256(k1));
-    _keyTuple[1] = bytes32(uint256(int256(k2)));
-    _keyTuple[2] = bytes32(k3);
-    _keyTuple[3] = bytes32(uint256(uint160(k4)));
-    _keyTuple[4] = _boolToBytes32(k5);
-    _keyTuple[5] = bytes32(uint256(uint8(k6)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -111,6 +111,7 @@ library KeyEncoding {
     ExampleEnum k6
   ) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -126,6 +127,7 @@ library KeyEncoding {
     ExampleEnum k6
   ) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -142,6 +144,7 @@ library KeyEncoding {
     ExampleEnum k6
   ) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -157,7 +160,9 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -180,7 +185,9 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -212,7 +219,9 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -84,6 +84,18 @@ library KeyEncoding {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -101,6 +113,21 @@ library KeyEncoding {
     bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
+  }
+
+  /** Get value */
+  function _get(
+    uint256 k1,
+    int32 k2,
+    bytes16 k3,
+    address k4,
+    bool k5,
+    ExampleEnum k6
+  ) internal view returns (bool value) {
+    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
@@ -132,6 +159,29 @@ library KeyEncoding {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      0,
+      abi.encodePacked((value)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set value */
+  function _set(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, ExampleEnum k6, bool value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](6);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       0,
@@ -202,6 +252,19 @@ library KeyEncoding {
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(uint256 k1, int32 k2, bytes16 k3, address k4, bool k5, ExampleEnum k6) internal {
+    bytes32[] memory _keyTuple = new bytes32[](6);
+    _keyTuple[0] = bytes32(uint256(k1));
+    _keyTuple[1] = bytes32(uint256(int256(k2)));
+    _keyTuple[2] = bytes32(k3);
+    _keyTuple[3] = bytes32(uint256(uint160(k4)));
+    _keyTuple[4] = _boolToBytes32(k5);
+    _keyTuple[5] = bytes32(uint256(uint8(k6)));
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -29,6 +29,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library KeyEncoding {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -146,9 +148,15 @@ library KeyEncoding {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
-    return (_toBool(uint8(bytes1(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bool _blob;
+    assembly {
+      _blob := shr(248, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get value (using the specified store) */

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -110,7 +110,16 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
@@ -126,7 +135,16 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
@@ -143,7 +161,16 @@ library KeyEncoding {
     bool k5,
     ExampleEnum k6
   ) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
@@ -160,7 +187,16 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -185,7 +221,16 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -219,7 +264,16 @@ library KeyEncoding {
     _keyTuple[4] = _boolToBytes32(k5);
     _keyTuple[5] = bytes32(uint256(uint8(k6)));
 
-    bytes32 _keyHash = keccak256(abi.encode(k1, k2, k3, k4, k5, k6));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(k1)),
+        bytes32(uint256(int256(k2))),
+        bytes32(k3),
+        bytes32(uint256(uint160(k4))),
+        _boolToBytes32(k5),
+        bytes32(uint256(uint8(k6)))
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());

--- a/packages/store/src/codegen/tables/KeyEncoding.sol
+++ b/packages/store/src/codegen/tables/KeyEncoding.sol
@@ -24,13 +24,14 @@ import { ExampleEnum } from "./../Types.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("KeyEncoding")));
 bytes32 constant KeyEncodingTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0001010001000000000000000000000000000000000000000000000000000000
+);
+
 library KeyEncoding {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -104,6 +104,7 @@ library Mixed {
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -112,6 +113,7 @@ library Mixed {
   /** Get u32 */
   function _getU32(bytes32 key) internal view returns (uint32 u32) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -120,6 +122,7 @@ library Mixed {
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -130,7 +133,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       4,
@@ -148,7 +153,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -157,13 +164,16 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
@@ -172,6 +182,7 @@ library Mixed {
   /** Get u128 */
   function _getU128(bytes32 key) internal view returns (uint128 u128) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
@@ -180,6 +191,7 @@ library Mixed {
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
@@ -190,7 +202,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       16,
@@ -208,7 +222,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       16,
@@ -226,7 +242,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 16, 4, abi.encodePacked((u128)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -91,20 +91,16 @@ library Mixed {
 
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
 
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
@@ -138,20 +134,16 @@ library Mixed {
 
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
   }
 
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
   }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -103,7 +103,7 @@ library Mixed {
 
   /** Get u32 */
   function getU32(bytes32 key) internal view returns (uint32 u32) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
@@ -112,7 +112,7 @@ library Mixed {
 
   /** Get u32 */
   function _getU32(bytes32 key) internal view returns (uint32 u32) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
@@ -121,7 +121,7 @@ library Mixed {
 
   /** Get u32 (using the specified store) */
   function getU32(IStore _store, bytes32 key) internal view returns (uint32 u32) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
@@ -133,7 +133,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -153,7 +153,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -164,7 +164,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -172,7 +172,7 @@ library Mixed {
 
   /** Get u128 */
   function getU128(bytes32 key) internal view returns (uint128 u128) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 4);
@@ -181,7 +181,7 @@ library Mixed {
 
   /** Get u128 */
   function _getU128(bytes32 key) internal view returns (uint128 u128) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 4);
@@ -190,7 +190,7 @@ library Mixed {
 
   /** Get u128 (using the specified store) */
   function getU128(IStore _store, bytes32 key) internal view returns (uint128 u128) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 16, 4);
@@ -202,7 +202,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -222,7 +222,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -242,7 +242,7 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 16, 4, abi.encodePacked((u128)), _tableId, _keyTuple, 1, getFieldLayout());
@@ -250,28 +250,31 @@ library Mixed {
 
   /** Get a32 */
   function getA32(bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get a32 */
   function _getA32(bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
   /** Get a32 (using the specified store) */
   function getA32(IStore _store, bytes32 key) internal view returns (uint32[] memory a32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
@@ -301,10 +304,10 @@ library Mixed {
 
   /** Get the length of a32 */
   function lengthA32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -312,10 +315,10 @@ library Mixed {
 
   /** Get the length of a32 */
   function _lengthA32(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -323,10 +326,10 @@ library Mixed {
 
   /** Get the length of a32 (using the specified store) */
   function lengthA32(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 4;
     }
@@ -337,18 +340,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemA32(bytes32 key, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -358,18 +354,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemA32(bytes32 key, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 4,
-        (_index + 1) * 4
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -379,11 +368,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemA32(IStore _store, bytes32 key, uint256 _index) internal view returns (uint32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 2, getFieldLayout(), _index * 4, (_index + 1) * 4);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 4, (_index + 1) * 4);
       return (uint32(Bytes.slice4(_blob, 0)));
     }
   }
@@ -477,28 +466,31 @@ library Mixed {
 
   /** Get s */
   function getS(bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
   /** Get s */
   function _getS(bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
   /** Get s (using the specified store) */
   function getS(IStore _store, bytes32 key) internal view returns (string memory s) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (string(_blob));
   }
 
@@ -528,10 +520,10 @@ library Mixed {
 
   /** Get the length of s */
   function lengthS(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -539,10 +531,10 @@ library Mixed {
 
   /** Get the length of s */
   function _lengthS(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -550,10 +542,10 @@ library Mixed {
 
   /** Get the length of s (using the specified store) */
   function lengthS(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -564,18 +556,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemS(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }
@@ -585,18 +570,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemS(bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }
@@ -606,11 +584,11 @@ library Mixed {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemS(IStore _store, bytes32 key, uint256 _index) internal view returns (string memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (string(_blob));
     }
   }

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";
@@ -94,8 +94,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Get u32 (using the specified store) */
@@ -103,8 +104,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Set u32 */
@@ -112,7 +114,17 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      4,
+      0,
+      abi.encodePacked((u32)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set u32 (using the specified store) */
@@ -120,7 +132,8 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((u32)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get u128 */
@@ -128,8 +141,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint128(Bytes.slice16(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 4);
+    return (uint128(bytes16(_blob)));
   }
 
   /** Get u128 (using the specified store) */
@@ -137,8 +151,9 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint128(Bytes.slice16(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 16, 4);
+    return (uint128(bytes16(_blob)));
   }
 
   /** Set u128 */
@@ -146,7 +161,17 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      16,
+      4,
+      abi.encodePacked((u128)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set u128 (using the specified store) */
@@ -154,7 +179,8 @@ library Mixed {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((u128)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 16, 4, abi.encodePacked((u128)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
   /** Get a32 */

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -33,6 +33,8 @@ struct MixedData {
 }
 
 library Mixed {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -114,9 +116,15 @@ library Mixed {
   function _getU32(bytes32 key) internal view returns (uint32 u32) {
     bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
-    return (uint32(bytes4(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint32 _blob;
+    assembly {
+      _blob := shr(224, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get u32 (using the specified store) */
@@ -183,9 +191,15 @@ library Mixed {
   function _getU128(bytes32 key) internal view returns (uint128 u128) {
     bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 4);
-    return (uint128(bytes16(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint128 _blob;
+    assembly {
+      _blob := shr(96, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get u128 (using the specified store) */

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -84,6 +84,18 @@ library Mixed {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -94,6 +106,14 @@ library Mixed {
     bytes32 _keyHash = keccak256(abi.encode(key));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
+  }
+
+  /** Get u32 */
+  function _getU32(bytes32 key) internal view returns (uint32 u32) {
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
 
@@ -123,6 +143,15 @@ library Mixed {
     );
   }
 
+  /** Set u32 */
+  function _setU32(bytes32 key, uint32 u32) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((u32)), _tableId, _keyTuple, 0, getFieldLayout());
+  }
+
   /** Set u32 (using the specified store) */
   function setU32(IStore _store, bytes32 key, uint32 u32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -137,6 +166,14 @@ library Mixed {
     bytes32 _keyHash = keccak256(abi.encode(key));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 16, 4);
+    return (uint128(bytes16(_blob)));
+  }
+
+  /** Get u128 */
+  function _getU128(bytes32 key) internal view returns (uint128 u128) {
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 16, 4);
     return (uint128(bytes16(_blob)));
   }
 
@@ -166,6 +203,24 @@ library Mixed {
     );
   }
 
+  /** Set u128 */
+  function _setU128(bytes32 key, uint128 u128) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
+      storagePointer,
+      16,
+      4,
+      abi.encodePacked((u128)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
+  }
+
   /** Set u128 (using the specified store) */
   function setU128(IStore _store, bytes32 key, uint128 u128) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -181,6 +236,15 @@ library Mixed {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
+  }
+
+  /** Get a32 */
+  function _getA32(bytes32 key) internal view returns (uint32[] memory a32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint32());
   }
 
@@ -201,6 +265,14 @@ library Mixed {
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)), getFieldLayout());
   }
 
+  /** Set a32 */
+  function _setA32(bytes32 key, uint32[] memory a32) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 2, EncodeArray.encode((a32)), getFieldLayout());
+  }
+
   /** Set a32 (using the specified store) */
   function setA32(IStore _store, bytes32 key, uint32[] memory a32) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -215,6 +287,17 @@ library Mixed {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    unchecked {
+      return _byteLength / 4;
+    }
+  }
+
+  /** Get the length of a32 */
+  function _lengthA32(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
     unchecked {
       return _byteLength / 4;
     }
@@ -253,6 +336,27 @@ library Mixed {
   }
 
   /**
+   * Get an item of a32
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemA32(bytes32 key, uint256 _index) internal view returns (uint32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        2,
+        getFieldLayout(),
+        _index * 4,
+        (_index + 1) * 4
+      );
+      return (uint32(Bytes.slice4(_blob, 0)));
+    }
+  }
+
+  /**
    * Get an item of a32 (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -274,6 +378,14 @@ library Mixed {
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to a32 */
+  function _pushA32(bytes32 key, uint32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to a32 (using the specified store) */
   function pushA32(IStore _store, bytes32 key, uint32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -288,6 +400,14 @@ library Mixed {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 4, getFieldLayout());
+  }
+
+  /** Pop an element from a32 */
+  function _popA32(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 2, 4, getFieldLayout());
   }
 
   /** Pop an element from a32 (using the specified store) */
@@ -308,6 +428,19 @@ library Mixed {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of a32 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateA32(bytes32 key, uint256 _index, uint32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 2, _index * 4, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -333,6 +466,15 @@ library Mixed {
     return (string(_blob));
   }
 
+  /** Get s */
+  function _getS(bytes32 key) internal view returns (string memory s) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    return (string(_blob));
+  }
+
   /** Get s (using the specified store) */
   function getS(IStore _store, bytes32 key) internal view returns (string memory s) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -350,6 +492,14 @@ library Mixed {
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((s)), getFieldLayout());
   }
 
+  /** Set s */
+  function _setS(bytes32 key, string memory s) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 3, bytes((s)), getFieldLayout());
+  }
+
   /** Set s (using the specified store) */
   function setS(IStore _store, bytes32 key, string memory s) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -364,6 +514,17 @@ library Mixed {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of s */
+  function _lengthS(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -402,6 +563,27 @@ library Mixed {
   }
 
   /**
+   * Get an item of s
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemS(bytes32 key, uint256 _index) internal view returns (string memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        3,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (string(_blob));
+    }
+  }
+
+  /**
    * Get an item of s (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -423,6 +605,14 @@ library Mixed {
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)), getFieldLayout());
   }
 
+  /** Push a slice to s */
+  function _pushS(bytes32 key, string memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 3, bytes((_slice)), getFieldLayout());
+  }
+
   /** Push a slice to s (using the specified store) */
   function pushS(IStore _store, bytes32 key, string memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -437,6 +627,14 @@ library Mixed {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1, getFieldLayout());
+  }
+
+  /** Pop a slice from s */
+  function _popS(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 3, 1, getFieldLayout());
   }
 
   /** Pop a slice from s (using the specified store) */
@@ -457,6 +655,19 @@ library Mixed {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update a slice of s at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateS(bytes32 key, uint256 _index, string memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)), getFieldLayout());
     }
   }
 
@@ -482,6 +693,15 @@ library Mixed {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(bytes32 key) internal view returns (MixedData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (MixedData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -501,6 +721,16 @@ library Mixed {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
+    bytes memory _data = encode(u32, u128, a32, s);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 u32, uint128 u128, uint32[] memory a32, string memory s) internal {
     bytes memory _data = encode(u32, u128, a32, s);
@@ -513,6 +743,11 @@ library Mixed {
 
   /** Set the full data using the data struct */
   function set(bytes32 key, MixedData memory _table) internal {
+    set(key, _table.u32, _table.u128, _table.a32, _table.s);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 key, MixedData memory _table) internal {
     set(key, _table.u32, _table.u128, _table.a32, _table.s);
   }
 
@@ -576,6 +811,14 @@ library Mixed {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/Mixed.sol
+++ b/packages/store/src/codegen/tables/Mixed.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("Mixed")));
 bytes32 constant MixedTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0014020204100000000000000000000000000000000000000000000000000000
+);
+
 struct MixedData {
   uint32 u32;
   uint128 u128;
@@ -31,11 +35,7 @@ struct MixedData {
 library Mixed {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](2);
-    _fieldLayout[0] = 4;
-    _fieldLayout[1] = 16;
-
-    return FieldLayoutLib.encode(_fieldLayout, 2);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/StoreHooks.sol
+++ b/packages/store/src/codegen/tables/StoreHooks.sol
@@ -71,6 +71,18 @@ library StoreHooks {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -82,6 +94,15 @@ library StoreHooks {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
+  }
+
+  /** Get value */
+  function _get(bytes32 key) internal view returns (bytes21[] memory value) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -102,6 +123,14 @@ library StoreHooks {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
   }
 
+  /** Set value */
+  function _set(bytes32 key, bytes21[] memory value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
+  }
+
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 key, bytes21[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -116,6 +145,17 @@ library StoreHooks {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 21;
+    }
+  }
+
+  /** Get the length of value */
+  function _length(bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 21;
     }
@@ -142,6 +182,27 @@ library StoreHooks {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 21,
+        (_index + 1) * 21
+      );
+      return (Bytes.slice21(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of value
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItem(bytes32 key, uint256 _index) internal view returns (bytes21) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -182,6 +243,14 @@ library StoreHooks {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to value */
+  function _push(bytes32 key, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 key, bytes21 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -196,6 +265,14 @@ library StoreHooks {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
+  }
+
+  /** Pop an element from value */
+  function _pop(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
   }
 
   /** Pop an element from value (using the specified store) */
@@ -216,6 +293,19 @@ library StoreHooks {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of value at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _update(bytes32 key, uint256 _index, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -257,6 +347,14 @@ library StoreHooks {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/StoreHooks.sol
+++ b/packages/store/src/codegen/tables/StoreHooks.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";

--- a/packages/store/src/codegen/tables/StoreHooks.sol
+++ b/packages/store/src/codegen/tables/StoreHooks.sol
@@ -21,12 +21,14 @@ import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("StoreHooks")));
 bytes32 constant StoreHooksTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library StoreHooks {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/StoreHooks.sol
+++ b/packages/store/src/codegen/tables/StoreHooks.sol
@@ -90,28 +90,31 @@ library StoreHooks {
 
   /** Get value */
   function get(bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value */
   function _get(bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 key) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -141,10 +144,10 @@ library StoreHooks {
 
   /** Get the length of value */
   function length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -152,10 +155,10 @@ library StoreHooks {
 
   /** Get the length of value */
   function _length(bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -163,10 +166,10 @@ library StoreHooks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -177,18 +180,11 @@ library StoreHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -198,18 +194,11 @@ library StoreHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -219,18 +208,11 @@ library StoreHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 key, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }

--- a/packages/store/src/codegen/tables/StoreHooks.sol
+++ b/packages/store/src/codegen/tables/StoreHooks.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library StoreHooks {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -106,7 +106,7 @@ library Tables {
 
   /** Get fieldLayout */
   function getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -115,7 +115,7 @@ library Tables {
 
   /** Get fieldLayout */
   function _getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -124,7 +124,7 @@ library Tables {
 
   /** Get fieldLayout (using the specified store) */
   function getFieldLayout(IStore _store, bytes32 tableId) internal view returns (bytes32 fieldLayout) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -136,7 +136,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -156,7 +156,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -176,7 +176,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -193,7 +193,7 @@ library Tables {
 
   /** Get keySchema */
   function getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 32);
@@ -202,7 +202,7 @@ library Tables {
 
   /** Get keySchema */
   function _getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 32);
@@ -211,7 +211,7 @@ library Tables {
 
   /** Get keySchema (using the specified store) */
   function getKeySchema(IStore _store, bytes32 tableId) internal view returns (bytes32 keySchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 32);
@@ -223,7 +223,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -243,7 +243,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -263,7 +263,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -280,7 +280,7 @@ library Tables {
 
   /** Get valueSchema */
   function getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 64);
@@ -289,7 +289,7 @@ library Tables {
 
   /** Get valueSchema */
   function _getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 64);
@@ -298,7 +298,7 @@ library Tables {
 
   /** Get valueSchema (using the specified store) */
   function getValueSchema(IStore _store, bytes32 tableId) internal view returns (bytes32 valueSchema) {
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 64);
@@ -310,7 +310,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -330,7 +330,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -350,7 +350,7 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -367,19 +367,21 @@ library Tables {
 
   /** Get abiEncodedKeyNames */
   function getAbiEncodedKeyNames(bytes32 tableId) internal view returns (bytes memory abiEncodedKeyNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (bytes(_blob));
   }
 
   /** Get abiEncodedKeyNames */
   function _getAbiEncodedKeyNames(bytes32 tableId) internal view returns (bytes memory abiEncodedKeyNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (bytes(_blob));
   }
 
@@ -388,10 +390,11 @@ library Tables {
     IStore _store,
     bytes32 tableId
   ) internal view returns (bytes memory abiEncodedKeyNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (bytes(_blob));
   }
 
@@ -421,10 +424,10 @@ library Tables {
 
   /** Get the length of abiEncodedKeyNames */
   function lengthAbiEncodedKeyNames(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 1;
     }
@@ -432,10 +435,10 @@ library Tables {
 
   /** Get the length of abiEncodedKeyNames */
   function _lengthAbiEncodedKeyNames(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 1;
     }
@@ -443,10 +446,10 @@ library Tables {
 
   /** Get the length of abiEncodedKeyNames (using the specified store) */
   function lengthAbiEncodedKeyNames(IStore _store, bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 1;
     }
@@ -457,18 +460,11 @@ library Tables {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemAbiEncodedKeyNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -478,18 +474,11 @@ library Tables {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemAbiEncodedKeyNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -503,11 +492,11 @@ library Tables {
     bytes32 tableId,
     uint256 _index
   ) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 3, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -601,19 +590,21 @@ library Tables {
 
   /** Get abiEncodedFieldNames */
   function getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (bytes(_blob));
   }
 
   /** Get abiEncodedFieldNames */
   function _getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (bytes(_blob));
   }
 
@@ -622,10 +613,11 @@ library Tables {
     IStore _store,
     bytes32 tableId
   ) internal view returns (bytes memory abiEncodedFieldNames) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (bytes(_blob));
   }
 
@@ -655,10 +647,10 @@ library Tables {
 
   /** Get the length of abiEncodedFieldNames */
   function lengthAbiEncodedFieldNames(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -666,10 +658,10 @@ library Tables {
 
   /** Get the length of abiEncodedFieldNames */
   function _lengthAbiEncodedFieldNames(bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -677,10 +669,10 @@ library Tables {
 
   /** Get the length of abiEncodedFieldNames (using the specified store) */
   function lengthAbiEncodedFieldNames(IStore _store, bytes32 tableId) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 1;
     }
@@ -691,18 +683,11 @@ library Tables {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemAbiEncodedFieldNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -712,18 +697,11 @@ library Tables {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemAbiEncodedFieldNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 1,
-        (_index + 1) * 1
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }
@@ -737,11 +715,11 @@ library Tables {
     bytes32 tableId,
     uint256 _index
   ) internal view returns (bytes memory) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
+    bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(_tableId, _keyTuple, 4, getFieldLayout(), _index * 1, (_index + 1) * 1);
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 1, (_index + 1) * 1);
       return (bytes(_blob));
     }
   }

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -107,6 +107,7 @@ library Tables {
   /** Get fieldLayout */
   function getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -115,6 +116,7 @@ library Tables {
   /** Get fieldLayout */
   function _getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -123,6 +125,7 @@ library Tables {
   /** Get fieldLayout (using the specified store) */
   function getFieldLayout(IStore _store, bytes32 tableId) internal view returns (bytes32 fieldLayout) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -133,7 +136,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -151,7 +156,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -169,7 +176,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,
@@ -185,6 +194,7 @@ library Tables {
   /** Get keySchema */
   function getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 32);
     return (bytes32(_blob));
@@ -193,6 +203,7 @@ library Tables {
   /** Get keySchema */
   function _getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 32);
     return (bytes32(_blob));
@@ -201,6 +212,7 @@ library Tables {
   /** Get keySchema (using the specified store) */
   function getKeySchema(IStore _store, bytes32 tableId) internal view returns (bytes32 keySchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 32);
     return (bytes32(_blob));
@@ -211,7 +223,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -229,7 +243,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -247,7 +263,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,
@@ -263,6 +281,7 @@ library Tables {
   /** Get valueSchema */
   function getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 64);
     return (bytes32(_blob));
@@ -271,6 +290,7 @@ library Tables {
   /** Get valueSchema */
   function _getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 64);
     return (bytes32(_blob));
@@ -279,6 +299,7 @@ library Tables {
   /** Get valueSchema (using the specified store) */
   function getValueSchema(IStore _store, bytes32 tableId) internal view returns (bytes32 valueSchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 64);
     return (bytes32(_blob));
@@ -289,7 +310,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -307,7 +330,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -325,7 +350,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -87,6 +87,18 @@ library Tables {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -97,6 +109,14 @@ library Tables {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
+  }
+
+  /** Get fieldLayout */
+  function _getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
@@ -115,6 +135,24 @@ library Tables {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((fieldLayout)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set fieldLayout */
+  function _setFieldLayout(bytes32 tableId, bytes32 fieldLayout) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -152,6 +190,14 @@ library Tables {
     return (bytes32(_blob));
   }
 
+  /** Get keySchema */
+  function _getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 32);
+    return (bytes32(_blob));
+  }
+
   /** Get keySchema (using the specified store) */
   function getKeySchema(IStore _store, bytes32 tableId) internal view returns (bytes32 keySchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
@@ -167,6 +213,24 @@ library Tables {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      32,
+      abi.encodePacked((keySchema)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
+  }
+
+  /** Set keySchema */
+  function _setKeySchema(bytes32 tableId, bytes32 keySchema) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       32,
@@ -204,6 +268,14 @@ library Tables {
     return (bytes32(_blob));
   }
 
+  /** Get valueSchema */
+  function _getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 64);
+    return (bytes32(_blob));
+  }
+
   /** Get valueSchema (using the specified store) */
   function getValueSchema(IStore _store, bytes32 tableId) internal view returns (bytes32 valueSchema) {
     bytes32 _keyHash = keccak256(abi.encode(tableId));
@@ -219,6 +291,24 @@ library Tables {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      64,
+      abi.encodePacked((valueSchema)),
+      _tableId,
+      _keyTuple,
+      2,
+      getFieldLayout()
+    );
+  }
+
+  /** Set valueSchema */
+  function _setValueSchema(bytes32 tableId, bytes32 valueSchema) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       64,
@@ -257,6 +347,15 @@ library Tables {
     return (bytes(_blob));
   }
 
+  /** Get abiEncodedKeyNames */
+  function _getAbiEncodedKeyNames(bytes32 tableId) internal view returns (bytes memory abiEncodedKeyNames) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    return (bytes(_blob));
+  }
+
   /** Get abiEncodedKeyNames (using the specified store) */
   function getAbiEncodedKeyNames(
     IStore _store,
@@ -277,6 +376,14 @@ library Tables {
     StoreSwitch.setField(_tableId, _keyTuple, 3, bytes((abiEncodedKeyNames)), getFieldLayout());
   }
 
+  /** Set abiEncodedKeyNames */
+  function _setAbiEncodedKeyNames(bytes32 tableId, bytes memory abiEncodedKeyNames) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.setField(_tableId, _keyTuple, 3, bytes((abiEncodedKeyNames)), getFieldLayout());
+  }
+
   /** Set abiEncodedKeyNames (using the specified store) */
   function setAbiEncodedKeyNames(IStore _store, bytes32 tableId, bytes memory abiEncodedKeyNames) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -291,6 +398,17 @@ library Tables {
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of abiEncodedKeyNames */
+  function _lengthAbiEncodedKeyNames(bytes32 tableId) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -329,6 +447,27 @@ library Tables {
   }
 
   /**
+   * Get an item of abiEncodedKeyNames
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemAbiEncodedKeyNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        3,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (bytes(_blob));
+    }
+  }
+
+  /**
    * Get an item of abiEncodedKeyNames (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -354,6 +493,14 @@ library Tables {
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, bytes((_slice)), getFieldLayout());
   }
 
+  /** Push a slice to abiEncodedKeyNames */
+  function _pushAbiEncodedKeyNames(bytes32 tableId, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 3, bytes((_slice)), getFieldLayout());
+  }
+
   /** Push a slice to abiEncodedKeyNames (using the specified store) */
   function pushAbiEncodedKeyNames(IStore _store, bytes32 tableId, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -368,6 +515,14 @@ library Tables {
     _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 1, getFieldLayout());
+  }
+
+  /** Pop a slice from abiEncodedKeyNames */
+  function _popAbiEncodedKeyNames(bytes32 tableId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 3, 1, getFieldLayout());
   }
 
   /** Pop a slice from abiEncodedKeyNames (using the specified store) */
@@ -388,6 +543,19 @@ library Tables {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update a slice of abiEncodedKeyNames at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateAbiEncodedKeyNames(bytes32 tableId, uint256 _index, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 3, _index * 1, bytes((_slice)), getFieldLayout());
     }
   }
 
@@ -413,6 +581,15 @@ library Tables {
     return (bytes(_blob));
   }
 
+  /** Get abiEncodedFieldNames */
+  function _getAbiEncodedFieldNames(bytes32 tableId) internal view returns (bytes memory abiEncodedFieldNames) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    return (bytes(_blob));
+  }
+
   /** Get abiEncodedFieldNames (using the specified store) */
   function getAbiEncodedFieldNames(
     IStore _store,
@@ -433,6 +610,14 @@ library Tables {
     StoreSwitch.setField(_tableId, _keyTuple, 4, bytes((abiEncodedFieldNames)), getFieldLayout());
   }
 
+  /** Set abiEncodedFieldNames */
+  function _setAbiEncodedFieldNames(bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.setField(_tableId, _keyTuple, 4, bytes((abiEncodedFieldNames)), getFieldLayout());
+  }
+
   /** Set abiEncodedFieldNames (using the specified store) */
   function setAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory abiEncodedFieldNames) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -447,6 +632,17 @@ library Tables {
     _keyTuple[0] = tableId;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    unchecked {
+      return _byteLength / 1;
+    }
+  }
+
+  /** Get the length of abiEncodedFieldNames */
+  function _lengthAbiEncodedFieldNames(bytes32 tableId) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
     unchecked {
       return _byteLength / 1;
     }
@@ -485,6 +681,27 @@ library Tables {
   }
 
   /**
+   * Get an item of abiEncodedFieldNames
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemAbiEncodedFieldNames(bytes32 tableId, uint256 _index) internal view returns (bytes memory) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        4,
+        getFieldLayout(),
+        _index * 1,
+        (_index + 1) * 1
+      );
+      return (bytes(_blob));
+    }
+  }
+
+  /**
    * Get an item of abiEncodedFieldNames (using the specified store)
    * (unchecked, returns invalid data if index overflows)
    */
@@ -510,6 +727,14 @@ library Tables {
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, bytes((_slice)), getFieldLayout());
   }
 
+  /** Push a slice to abiEncodedFieldNames */
+  function _pushAbiEncodedFieldNames(bytes32 tableId, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 4, bytes((_slice)), getFieldLayout());
+  }
+
   /** Push a slice to abiEncodedFieldNames (using the specified store) */
   function pushAbiEncodedFieldNames(IStore _store, bytes32 tableId, bytes memory _slice) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -524,6 +749,14 @@ library Tables {
     _keyTuple[0] = tableId;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 1, getFieldLayout());
+  }
+
+  /** Pop a slice from abiEncodedFieldNames */
+  function _popAbiEncodedFieldNames(bytes32 tableId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 4, 1, getFieldLayout());
   }
 
   /** Pop a slice from abiEncodedFieldNames (using the specified store) */
@@ -548,6 +781,19 @@ library Tables {
   }
 
   /**
+   * Update a slice of abiEncodedFieldNames at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateAbiEncodedFieldNames(bytes32 tableId, uint256 _index, bytes memory _slice) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 4, _index * 1, bytes((_slice)), getFieldLayout());
+    }
+  }
+
+  /**
    * Update a slice of abiEncodedFieldNames (using the specified store) at `_index`
    * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
    */
@@ -566,6 +812,15 @@ library Tables {
     _keyTuple[0] = tableId;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
+  /** Get the full data */
+  function _get(bytes32 tableId) internal view returns (TablesData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
     return decode(_blob);
   }
 
@@ -595,6 +850,23 @@ library Tables {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(
+    bytes32 tableId,
+    bytes32 fieldLayout,
+    bytes32 keySchema,
+    bytes32 valueSchema,
+    bytes memory abiEncodedKeyNames,
+    bytes memory abiEncodedFieldNames
+  ) internal {
+    bytes memory _data = encode(fieldLayout, keySchema, valueSchema, abiEncodedKeyNames, abiEncodedFieldNames);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(
     IStore _store,
@@ -615,6 +887,18 @@ library Tables {
 
   /** Set the full data using the data struct */
   function set(bytes32 tableId, TablesData memory _table) internal {
+    set(
+      tableId,
+      _table.fieldLayout,
+      _table.keySchema,
+      _table.valueSchema,
+      _table.abiEncodedKeyNames,
+      _table.abiEncodedFieldNames
+    );
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 tableId, TablesData memory _table) internal {
     set(
       tableId,
       _table.fieldLayout,
@@ -709,6 +993,14 @@ library Tables {
     _keyTuple[0] = tableId;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 tableId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = tableId;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("Tables")));
 bytes32 constant TablesTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0060030220202000000000000000000000000000000000000000000000000000
+);
+
 struct TablesData {
   bytes32 fieldLayout;
   bytes32 keySchema;
@@ -32,12 +36,7 @@ struct TablesData {
 library Tables {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](3);
-    _fieldLayout[0] = 32;
-    _fieldLayout[1] = 32;
-    _fieldLayout[2] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 2);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -94,20 +94,16 @@ library Tables {
 
   /** Get fieldLayout */
   function getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
   /** Get fieldLayout (using the specified store) */
   function getFieldLayout(IStore _store, bytes32 tableId) internal view returns (bytes32 fieldLayout) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
@@ -150,20 +146,16 @@ library Tables {
 
   /** Get keySchema */
   function getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 32);
     return (bytes32(_blob));
   }
 
   /** Get keySchema (using the specified store) */
   function getKeySchema(IStore _store, bytes32 tableId) internal view returns (bytes32 keySchema) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 32);
     return (bytes32(_blob));
   }
@@ -206,20 +198,16 @@ library Tables {
 
   /** Get valueSchema */
   function getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 64);
     return (bytes32(_blob));
   }
 
   /** Get valueSchema (using the specified store) */
   function getValueSchema(IStore _store, bytes32 tableId) internal view returns (bytes32 valueSchema) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = tableId;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(tableId));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 64);
     return (bytes32(_blob));
   }

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -34,6 +34,8 @@ struct TablesData {
 }
 
 library Tables {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -117,9 +119,15 @@ library Tables {
   function _getFieldLayout(bytes32 tableId) internal view returns (bytes32 fieldLayout) {
     bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (bytes32(_blob));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bytes32 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get fieldLayout (using the specified store) */
@@ -204,9 +212,15 @@ library Tables {
   function _getKeySchema(bytes32 tableId) internal view returns (bytes32 keySchema) {
     bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 32);
-    return (bytes32(_blob));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 1;
+    }
+    bytes32 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get keySchema (using the specified store) */
@@ -291,9 +305,15 @@ library Tables {
   function _getValueSchema(bytes32 tableId) internal view returns (bytes32 valueSchema) {
     bytes32 _keyHash = keccak256(abi.encodePacked(tableId));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 64);
-    return (bytes32(_blob));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash) + 2;
+    }
+    bytes32 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get valueSchema (using the specified store) */

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";
@@ -98,8 +98,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Get fieldLayout (using the specified store) */
@@ -107,8 +108,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Set fieldLayout */
@@ -116,7 +118,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((fieldLayout)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((fieldLayout)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set fieldLayout (using the specified store) */
@@ -124,7 +136,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((fieldLayout)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((fieldLayout)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Get keySchema */
@@ -132,8 +154,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 32);
+    return (bytes32(_blob));
   }
 
   /** Get keySchema (using the specified store) */
@@ -141,8 +164,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 32);
+    return (bytes32(_blob));
   }
 
   /** Set keySchema */
@@ -150,7 +174,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((keySchema)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      32,
+      abi.encodePacked((keySchema)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set keySchema (using the specified store) */
@@ -158,7 +192,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((keySchema)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      32,
+      abi.encodePacked((keySchema)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Get valueSchema */
@@ -166,8 +210,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 64);
+    return (bytes32(_blob));
   }
 
   /** Get valueSchema (using the specified store) */
@@ -175,8 +220,9 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 64);
+    return (bytes32(_blob));
   }
 
   /** Set valueSchema */
@@ -184,7 +230,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 2, abi.encodePacked((valueSchema)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      64,
+      abi.encodePacked((valueSchema)),
+      _tableId,
+      _keyTuple,
+      2,
+      getFieldLayout()
+    );
   }
 
   /** Set valueSchema (using the specified store) */
@@ -192,7 +248,17 @@ library Tables {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = tableId;
 
-    _store.setField(_tableId, _keyTuple, 2, abi.encodePacked((valueSchema)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      64,
+      abi.encodePacked((valueSchema)),
+      _tableId,
+      _keyTuple,
+      2,
+      getFieldLayout()
+    );
   }
 
   /** Get abiEncodedKeyNames */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -98,6 +98,7 @@ library Vector2 {
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -106,6 +107,7 @@ library Vector2 {
   /** Get x */
   function _getX(bytes32 key) internal view returns (uint32 x) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -114,6 +116,7 @@ library Vector2 {
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
@@ -124,7 +127,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -133,7 +138,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -142,13 +149,16 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
@@ -157,6 +167,7 @@ library Vector2 {
   /** Get y */
   function _getY(bytes32 key) internal view returns (uint32 y) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
@@ -165,6 +176,7 @@ library Vector2 {
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
     bytes32 _keyHash = keccak256(abi.encode(key));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
@@ -175,7 +187,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
@@ -184,7 +198,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
@@ -193,7 +209,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -31,6 +31,8 @@ struct Vector2Data {
 }
 
 library Vector2 {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -108,9 +110,15 @@ library Vector2 {
   function _getX(bytes32 key) internal view returns (uint32 x) {
     bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
-    return (uint32(bytes4(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint32 _blob;
+    assembly {
+      _blob := shr(224, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get x (using the specified store) */
@@ -168,9 +176,15 @@ library Vector2 {
   function _getY(bytes32 key) internal view returns (uint32 y) {
     bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 4);
-    return (uint32(bytes4(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint32 _blob;
+    assembly {
+      _blob := shr(192, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get y (using the specified store) */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "../../IStore.sol";
 import { StoreSwitch } from "../../StoreSwitch.sol";
-import { StoreCore } from "../../StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "../../StoreCore.sol";
 import { Bytes } from "../../Bytes.sol";
 import { Memory } from "../../Memory.sol";
 import { SliceLib } from "../../Slice.sol";
@@ -88,8 +88,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Get x (using the specified store) */
@@ -97,8 +98,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Set x */
@@ -106,7 +108,8 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Set x (using the specified store) */
@@ -114,7 +117,8 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((x)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get y */
@@ -122,8 +126,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 4);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Get y (using the specified store) */
@@ -131,8 +136,9 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint32(Bytes.slice4(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 4, 4);
+    return (uint32(bytes4(_blob)));
   }
 
   /** Set y */
@@ -140,7 +146,8 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
   /** Set y (using the specified store) */
@@ -148,7 +155,8 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((y)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
   /** Get the full data */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "../../PackedCounter.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16("mudstore"), bytes16("Vector2")));
 bytes32 constant Vector2TableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0008020004040000000000000000000000000000000000000000000000000000
+);
+
 struct Vector2Data {
   uint32 x;
   uint32 y;
@@ -29,11 +33,7 @@ struct Vector2Data {
 library Vector2 {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](2);
-    _fieldLayout[0] = 4;
-    _fieldLayout[1] = 4;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -78,6 +78,18 @@ library Vector2 {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -88,6 +100,14 @@ library Vector2 {
     bytes32 _keyHash = keccak256(abi.encode(key));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
+    return (uint32(bytes4(_blob)));
+  }
+
+  /** Get x */
+  function _getX(bytes32 key) internal view returns (uint32 x) {
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
 
@@ -108,6 +128,15 @@ library Vector2 {
     StoreSwitch.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
+  /** Set x */
+  function _setX(bytes32 key, uint32 x) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
+  }
+
   /** Set x (using the specified store) */
   function setX(IStore _store, bytes32 key, uint32 x) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -122,6 +151,14 @@ library Vector2 {
     bytes32 _keyHash = keccak256(abi.encode(key));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 4);
+    return (uint32(bytes4(_blob)));
+  }
+
+  /** Get y */
+  function _getY(bytes32 key) internal view returns (uint32 y) {
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
   }
 
@@ -142,6 +179,15 @@ library Vector2 {
     StoreSwitch.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
+  /** Set y */
+  function _setY(bytes32 key, uint32 y) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
+  }
+
   /** Set y (using the specified store) */
   function setY(IStore _store, bytes32 key, uint32 y) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -157,6 +203,15 @@ library Vector2 {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
+  /** Get the full data */
+  function _get(bytes32 key) internal view returns (Vector2Data memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
     return decode(_blob);
   }
 
@@ -179,6 +234,16 @@ library Vector2 {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(bytes32 key, uint32 x, uint32 y) internal {
+    bytes memory _data = encode(x, y);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(IStore _store, bytes32 key, uint32 x, uint32 y) internal {
     bytes memory _data = encode(x, y);
@@ -191,6 +256,11 @@ library Vector2 {
 
   /** Set the full data using the data struct */
   function set(bytes32 key, Vector2Data memory _table) internal {
+    set(key, _table.x, _table.y);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 key, Vector2Data memory _table) internal {
     set(key, _table.x, _table.y);
   }
 
@@ -225,6 +295,14 @@ library Vector2 {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -85,20 +85,16 @@ library Vector2 {
 
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
 
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
     return (uint32(bytes4(_blob)));
   }
@@ -123,20 +119,16 @@ library Vector2 {
 
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
   }
 
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(key));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 4);
     return (uint32(bytes4(_blob)));
   }

--- a/packages/store/src/codegen/tables/Vector2.sol
+++ b/packages/store/src/codegen/tables/Vector2.sol
@@ -97,7 +97,7 @@ library Vector2 {
 
   /** Get x */
   function getX(bytes32 key) internal view returns (uint32 x) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 0);
@@ -106,7 +106,7 @@ library Vector2 {
 
   /** Get x */
   function _getX(bytes32 key) internal view returns (uint32 x) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 0);
@@ -115,7 +115,7 @@ library Vector2 {
 
   /** Get x (using the specified store) */
   function getX(IStore _store, bytes32 key) internal view returns (uint32 x) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 0);
@@ -127,7 +127,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -138,7 +138,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -149,7 +149,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 0, abi.encodePacked((x)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -157,7 +157,7 @@ library Vector2 {
 
   /** Get y */
   function getY(bytes32 key) internal view returns (uint32 y) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 4);
@@ -166,7 +166,7 @@ library Vector2 {
 
   /** Get y */
   function _getY(bytes32 key) internal view returns (uint32 y) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 4);
@@ -175,7 +175,7 @@ library Vector2 {
 
   /** Get y (using the specified store) */
   function getY(IStore _store, bytes32 key) internal view returns (uint32 y) {
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 4);
@@ -187,7 +187,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
@@ -198,7 +198,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());
@@ -209,7 +209,7 @@ library Vector2 {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = key;
 
-    bytes32 _keyHash = keccak256(abi.encode(key));
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 4, 4, abi.encodePacked((y)), _tableId, _keyTuple, 1, getFieldLayout());

--- a/packages/store/test/GasStorageLoad.t.sol
+++ b/packages/store/test/GasStorageLoad.t.sol
@@ -66,6 +66,8 @@ contract GasStorageLoadTest is Test, GasReporter {
     bytes memory encodedSimple = abi.encodePacked(valueSimple);
     bytes memory encodedPartial = abi.encodePacked(valuePartial);
     bytes memory encoded9Words = abi.encodePacked(value9Words.length, value9Words);
+    bytes32 encodedFieldSimple = valueSimple;
+    bytes32 encodedFieldPartial = valuePartial;
 
     startGasReport("MUD storage load (cold, 1 word)");
     encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
@@ -85,8 +87,16 @@ contract GasStorageLoadTest is Test, GasReporter {
     encodedSimple = Storage.load(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
     endGasReport();
 
+    startGasReport("MUD storage load field (warm, 1 word)");
+    encodedFieldSimple = Storage.loadField(SolidityStorage.STORAGE_SLOT_SIMPLE, encodedSimple.length, 0);
+    endGasReport();
+
     startGasReport("MUD storage load (warm, 1 word, partial)");
     encodedPartial = Storage.load(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedPartial.length, 16);
+    endGasReport();
+
+    startGasReport("MUD storage load field (warm, partial)");
+    encodedFieldPartial = Storage.loadField(SolidityStorage.STORAGE_SLOT_PARTIAL, encodedSimple.length, 16);
     endGasReport();
 
     startGasReport("MUD storage load (warm, 10 words)");

--- a/packages/store/test/StoreCoreGas.t.sol
+++ b/packages/store/test/StoreCoreGas.t.sol
@@ -290,6 +290,17 @@ contract StoreCoreGasTest is Test, GasReporter, StoreMock {
     StoreCore.getField(table, key, 0, fieldLayout);
     endGasReport();
 
+    {
+      // constants
+      uint256 staticByteLength = fieldLayout.atIndex(0);
+      uint256 offset = StoreCoreInternal._getStaticDataOffset(fieldLayout, 0);
+      startGasReport("get static field V2 (1 slot)");
+      // needs to be computed onchain
+      uint256 location = StoreCoreInternal._getStaticDataLocation(table, key);
+      StoreCore.loadStaticField(location, staticByteLength, offset);
+      endGasReport();
+    }
+
     // Set second field
     bytes32 secondDataBytes = keccak256("some data");
     bytes memory secondDataPacked = abi.encodePacked(secondDataBytes);

--- a/packages/store/test/StoreMock.sol
+++ b/packages/store/test/StoreMock.sol
@@ -37,6 +37,19 @@ contract StoreMock is IStore, StoreRead {
     StoreCore.setField(table, key, schemaIndex, data, fieldLayout);
   }
 
+  function storeStaticField(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset,
+    bytes memory data,
+    bytes32 tableId,
+    bytes32[] memory key,
+    uint8 schemaIndex,
+    FieldLayout fieldLayout
+  ) public virtual {
+    StoreCore.storeStaticField(storagePointer, length, offset, data, tableId, key, schemaIndex, fieldLayout);
+  }
+
   // Push encoded items to the dynamic field at schema index
   function pushToField(
     bytes32 table,

--- a/packages/store/test/Vector2.t.sol
+++ b/packages/store/test/Vector2.t.sol
@@ -42,6 +42,23 @@ contract Vector2Test is Test, GasReporter, StoreMock {
     Vector2Data memory vector = Vector2.get(key);
     endGasReport();
 
+    startGasReport("get Vector2 x");
+    uint256 x = Vector2.getX(key);
+    endGasReport();
+
+    bytes32 key2 = keccak256("somekey2");
+    startGasReport("_set Vector2 record");
+    Vector2._set({ key: key2, x: 1, y: 2 });
+    endGasReport();
+
+    startGasReport("_get Vector2 record");
+    Vector2Data memory _vector = Vector2._get(key2);
+    endGasReport();
+
+    startGasReport("_get Vector2 x");
+    uint256 x2 = Vector2._getX(key2);
+    endGasReport();
+
     assertEq(vector.x, 1);
     assertEq(vector.y, 2);
   }

--- a/packages/store/ts/codegen/ephemeral.ts
+++ b/packages/store/ts/codegen/ephemeral.ts
@@ -7,9 +7,9 @@ export function renderEphemeralMethods(options: RenderTableOptions) {
 
   let result = renderWithStore(
     storeArgument,
-    (_typedStore, _store, _commentSuffix) => `
+    (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
     /** Emit the ephemeral event using individual values${_commentSuffix} */
-    function emitEphemeral(${renderArguments([
+    function ${_methodNamePrefix}emitEphemeral(${renderArguments([
       _typedStore,
       _typedTableId,
       _typedKeyArgs,
@@ -27,9 +27,9 @@ export function renderEphemeralMethods(options: RenderTableOptions) {
   if (structName !== undefined) {
     result += renderWithStore(
       storeArgument,
-      (_typedStore, _store, _commentSuffix, _untypedStore) => `
+      (_typedStore, _store, _commentSuffix, _untypedStore, _methodNamePrefix) => `
       /** Emit the ephemeral event using the data struct${_commentSuffix} */
-      function emitEphemeral(${renderArguments([
+      function ${_methodNamePrefix}emitEphemeral(${renderArguments([
         _typedStore,
         _typedTableId,
         _typedKeyArgs,

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -58,8 +58,8 @@ export function renderFieldMethods(options: RenderTableOptions) {
           _typedTableId,
           _typedKeyArgs,
         ])}) internal view returns (${_typedFieldName}) {
-          ${_keyTupleDefinition}
-          uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+          bytes32 _keyHash = keccak256(abi.encode(${options.keyTuple.map(({ name }) => name).join(", ")}));
+          uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
           bytes32 _blob = ${_store}.loadStaticField(storagePointer, ${field.staticByteLength}, ${offset});
           return ${renderDecodeStaticValueType(field)};
         }

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -9,7 +9,7 @@ import { RenderTableOptions } from "./types";
 
 export function renderFieldMethods(options: RenderTableOptions) {
   const storeArgument = options.storeArgument;
-  const { _typedTableId, _typedKeyArgs, _keyTupleDefinition } = renderCommonData(options);
+  const { _typedTableId, _typedKeyArgs, _keyTupleDefinition, _keyhashDefinition } = renderCommonData(options);
 
   let result = "";
   let offset = 0;
@@ -58,7 +58,7 @@ export function renderFieldMethods(options: RenderTableOptions) {
           _typedTableId,
           _typedKeyArgs,
         ])}) internal view returns (${_typedFieldName}) {
-          bytes32 _keyHash = keccak256(abi.encode(${options.keyTuple.map(({ name }) => name).join(", ")}));
+          ${_keyhashDefinition}
           uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
           bytes32 _blob = ${_store}.loadStaticField(storagePointer, ${field.staticByteLength}, ${offset});
           return ${renderDecodeStaticValueType(field)};

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -77,7 +77,8 @@ export function renderFieldMethods(options: RenderTableOptions) {
           _typedFieldName,
         ])}) internal {
           ${_keyTupleDefinition}
-          uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+          ${_keyhashDefinition}
+          uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
           ${_store}.storeStaticField(storagePointer, ${field.staticByteLength}, ${offset}, ${renderEncodeFieldSingle(
           field
         )}, _tableId, _keyTuple, ${schemaIndex}, getFieldLayout());

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -19,9 +19,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
     if (field.isDynamic) {
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Get ${field.name}${_commentSuffix} */
-        function get${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}get${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -35,9 +35,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Set ${field.name}${_commentSuffix} */
-        function set${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}set${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -51,9 +51,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
     } else {
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Get ${field.name}${_commentSuffix} */
-        function get${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}get${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -68,9 +68,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Set ${field.name}${_commentSuffix} */
-        function set${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}set${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -91,9 +91,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Get the length of ${field.name}${_commentSuffix} */
-        function length${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}length${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -109,12 +109,12 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /**
          * Get an item of ${field.name}${_commentSuffix}
          * (unchecked, returns invalid data if index overflows)
          */
-        function getItem${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}getItem${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -138,9 +138,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Push ${portionData.title} to ${field.name}${_commentSuffix} */
-        function push${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}push${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -154,9 +154,9 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /** Pop ${portionData.title} from ${field.name}${_commentSuffix} */
-        function pop${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}pop${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,
@@ -169,12 +169,12 @@ export function renderFieldMethods(options: RenderTableOptions) {
 
       result += renderWithStore(
         storeArgument,
-        (_typedStore, _store, _commentSuffix) => `
+        (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
         /**
          * Update ${portionData.title} of ${field.name}${_commentSuffix} at \`_index\`
          * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
          */
-        function update${field.methodNameSuffix}(${renderArguments([
+        function ${_methodNamePrefix}update${field.methodNameSuffix}(${renderArguments([
           _typedStore,
           _typedTableId,
           _typedKeyArgs,

--- a/packages/store/ts/codegen/record.ts
+++ b/packages/store/ts/codegen/record.ts
@@ -1,9 +1,9 @@
 import {
-  renderList,
+  RenderDynamicField,
   renderArguments,
   renderCommonData,
+  renderList,
   renderWithStore,
-  RenderDynamicField,
 } from "@latticexyz/common/codegen";
 import { renderDecodeValueType } from "./field";
 import { RenderTableOptions } from "./types";
@@ -14,9 +14,9 @@ export function renderRecordMethods(options: RenderTableOptions) {
 
   let result = renderWithStore(
     storeArgument,
-    (_typedStore, _store, _commentSuffix) => `
+    (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
     /** Get the full data${_commentSuffix} */
-    function get(${renderArguments([
+    function ${_methodNamePrefix}get(${renderArguments([
       _typedStore,
       _typedTableId,
       _typedKeyArgs,
@@ -30,9 +30,9 @@ export function renderRecordMethods(options: RenderTableOptions) {
 
   result += renderWithStore(
     storeArgument,
-    (_typedStore, _store, _commentSuffix) => `
+    (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
     /** Set the full data using individual values${_commentSuffix} */
-    function set(${renderArguments([
+    function ${_methodNamePrefix}set(${renderArguments([
       _typedStore,
       _typedTableId,
       _typedKeyArgs,
@@ -50,9 +50,9 @@ export function renderRecordMethods(options: RenderTableOptions) {
   if (structName !== undefined) {
     result += renderWithStore(
       storeArgument,
-      (_typedStore, _store, _commentSuffix, _untypedStore) => `
+      (_typedStore, _store, _commentSuffix, _untypedStore, _methodNamePrefix) => `
       /** Set the full data using the data struct${_commentSuffix} */
-      function set(${renderArguments([
+      function ${_methodNamePrefix}set(${renderArguments([
         _typedStore,
         _typedTableId,
         _typedKeyArgs,

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -1,13 +1,13 @@
 import {
+  RenderDynamicField,
   renderArguments,
   renderCommonData,
   renderList,
-  renderedSolidityHeader,
   renderRelativeImports,
   renderTableId,
-  renderWithStore,
   renderTypeHelpers,
-  RenderDynamicField,
+  renderWithStore,
+  renderedSolidityHeader,
 } from "@latticexyz/common/codegen";
 import { renderEphemeralMethods } from "./ephemeral";
 import { renderEncodeFieldSingle, renderFieldMethods } from "./field";
@@ -42,7 +42,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "${storeImportPath}IStore.sol";
 import { StoreSwitch } from "${storeImportPath}StoreSwitch.sol";
-import { StoreCore } from "${storeImportPath}StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "${storeImportPath}StoreCore.sol";
 import { Bytes } from "${storeImportPath}Bytes.sol";
 import { Memory } from "${storeImportPath}Memory.sol";
 import { SliceLib } from "${storeImportPath}Slice.sol";

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -111,9 +111,9 @@ library ${libraryName} {
 
   ${renderWithStore(
     storeArgument,
-    (_typedStore, _store, _commentSuffix) => `
+    (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
     /** Register the table with its config${_commentSuffix} */
-    function register(${renderArguments([_typedStore, _typedTableId])}) internal {
+    function ${_methodNamePrefix}register(${renderArguments([_typedStore, _typedTableId])}) internal {
       ${_store}.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
     }
   `
@@ -148,9 +148,13 @@ library ${libraryName} {
     shouldRenderDelete
       ? renderWithStore(
           storeArgument,
-          (_typedStore, _store, _commentSuffix) => `
+          (_typedStore, _store, _commentSuffix, _, _methodNamePrefix) => `
     /* Delete all data for given keys${_commentSuffix} */
-    function deleteRecord(${renderArguments([_typedStore, _typedTableId, _typedKeyArgs])}) internal {
+    function ${_methodNamePrefix}deleteRecord(${renderArguments([
+            _typedStore,
+            _typedTableId,
+            _typedKeyArgs,
+          ])}) internal {
       ${_keyTupleDefinition}
       ${_store}.deleteRecord(_tableId, _keyTuple, getFieldLayout());
     }

--- a/packages/store/ts/codegen/renderTable.ts
+++ b/packages/store/ts/codegen/renderTable.ts
@@ -76,6 +76,8 @@ ${
 }
 
 library ${libraryName} {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
@@ -53,6 +53,56 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
@@ -18,27 +18,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json
@@ -39,17 +39,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
@@ -18,27 +18,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
@@ -39,17 +39,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
+++ b/packages/world/abi/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d.ts
@@ -53,6 +53,56 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
@@ -34,27 +34,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes4",
         "name": "functionSelector",
         "type": "bytes4"

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
@@ -120,17 +120,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "string",
         "name": "resource",
         "type": "string"

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json
@@ -172,6 +172,37 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
@@ -120,17 +120,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "string";
         name: "resource";
         type: "string";

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
@@ -34,27 +34,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes4";
         name: "functionSelector";
         type: "bytes4";

--- a/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
+++ b/packages/world/abi/BalanceTransferSystem.sol/BalanceTransferSystem.abi.json.d.ts
@@ -172,6 +172,37 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
@@ -2,27 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
@@ -23,17 +23,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json
@@ -37,6 +37,56 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
@@ -2,27 +2,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
@@ -37,6 +37,56 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/CallboundDelegationControl.sol/CallboundDelegationControl.abi.json.d.ts
@@ -23,17 +23,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/CoreModule.sol/CoreModule.abi.json
+++ b/packages/world/abi/CoreModule.sol/CoreModule.abi.json
@@ -159,6 +159,62 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/CoreModule.sol/CoreModule.abi.json
+++ b/packages/world/abi/CoreModule.sol/CoreModule.abi.json
@@ -28,17 +28,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "string",
         "name": "resourceSelector",
         "type": "string"

--- a/packages/world/abi/CoreModule.sol/CoreModule.abi.json.d.ts
+++ b/packages/world/abi/CoreModule.sol/CoreModule.abi.json.d.ts
@@ -159,6 +159,62 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/CoreModule.sol/CoreModule.abi.json.d.ts
+++ b/packages/world/abi/CoreModule.sol/CoreModule.abi.json.d.ts
@@ -28,17 +28,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "string";
         name: "resourceSelector";
         type: "string";

--- a/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
+++ b/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json
@@ -302,6 +302,25 @@
         "internalType": "bytes32[]",
         "name": "key",
         "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
       },
       {
         "indexed": false,
@@ -311,6 +330,87 @@
       }
     ],
     "name": "StoreEphemeralRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreEphemeralRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
     "type": "event"
   },
   {

--- a/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json.d.ts
+++ b/packages/world/abi/CoreSystem.sol/CoreSystem.abi.json.d.ts
@@ -302,6 +302,25 @@ declare const abi: [
         internalType: "bytes32[]";
         name: "key";
         type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
       },
       {
         indexed: false;
@@ -311,6 +330,87 @@ declare const abi: [
       }
     ];
     name: "StoreEphemeralRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreEphemeralRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
     type: "event";
   },
   {

--- a/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json
+++ b/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json
@@ -57,6 +57,31 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreEphemeralRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json
+++ b/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json
@@ -19,27 +19,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "expected",
         "type": "uint256"
       },

--- a/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json.d.ts
+++ b/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json.d.ts
@@ -57,6 +57,31 @@ declare const abi: [
     type: "event";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreEphemeralRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json.d.ts
+++ b/packages/world/abi/EphemeralRecordSystem.sol/EphemeralRecordSystem.abi.json.d.ts
@@ -19,27 +19,6 @@ declare const abi: [
     inputs: [
       {
         internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256";
         name: "expected";
         type: "uint256";
       },

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
@@ -747,6 +747,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -1086,6 +1115,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json
@@ -753,6 +753,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json.d.ts
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json.d.ts
@@ -753,6 +753,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json.d.ts
+++ b/packages/world/abi/IBaseWorld.sol/IBaseWorld.abi.json.d.ts
@@ -747,6 +747,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -1086,6 +1115,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/IStore.sol/IStore.abi.json
+++ b/packages/world/abi/IStore.sol/IStore.abi.json
@@ -479,6 +479,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/IStore.sol/IStore.abi.json
+++ b/packages/world/abi/IStore.sol/IStore.abi.json
@@ -473,6 +473,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -654,6 +683,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStore.abi.json.d.ts
@@ -479,6 +479,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStore.abi.json.d.ts
@@ -473,6 +473,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -654,6 +683,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/IStore.sol/IStoreData.abi.json
+++ b/packages/world/abi/IStore.sol/IStoreData.abi.json
@@ -298,6 +298,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -418,6 +447,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/IStore.sol/IStoreData.abi.json
+++ b/packages/world/abi/IStore.sol/IStoreData.abi.json
@@ -304,6 +304,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStoreData.abi.json.d.ts
@@ -298,6 +298,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -418,6 +447,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStoreData.abi.json.d.ts
@@ -304,6 +304,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/IStore.sol/IStoreRead.abi.json
+++ b/packages/world/abi/IStore.sol/IStoreRead.abi.json
@@ -196,5 +196,34 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/packages/world/abi/IStore.sol/IStoreRead.abi.json
+++ b/packages/world/abi/IStore.sol/IStoreRead.abi.json
@@ -206,6 +206,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStoreRead.abi.json.d.ts
@@ -196,6 +196,35 @@ declare const abi: [
     ];
     stateMutability: "view";
     type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
   }
 ];
 export default abi;

--- a/packages/world/abi/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStoreRead.abi.json.d.ts
@@ -206,6 +206,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/IStore.sol/IStoreWrite.abi.json
+++ b/packages/world/abi/IStore.sol/IStoreWrite.abi.json
@@ -227,6 +227,54 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"

--- a/packages/world/abi/IStore.sol/IStoreWrite.abi.json.d.ts
+++ b/packages/world/abi/IStore.sol/IStoreWrite.abi.json.d.ts
@@ -227,6 +227,54 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";

--- a/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json
+++ b/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json
@@ -7,27 +7,6 @@
         "type": "uint256"
       }
     ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
     "name": "PackedCounter_InvalidLength",
     "type": "error"
   },

--- a/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json
+++ b/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json
@@ -69,6 +69,81 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json.d.ts
+++ b/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json.d.ts
@@ -69,6 +69,81 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [
       {
         internalType: "bytes32";

--- a/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json.d.ts
+++ b/packages/world/abi/KeysInTableHook.sol/KeysInTableHook.abi.json.d.ts
@@ -7,27 +7,6 @@ declare const abi: [
         type: "uint256";
       }
     ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
     name: "PackedCounter_InvalidLength";
     type: "error";
   },

--- a/packages/world/abi/KeysInTableModule.sol/KeysInTableModule.abi.json
+++ b/packages/world/abi/KeysInTableModule.sol/KeysInTableModule.abi.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "NonRootInstallNotSupported",
     "type": "error"

--- a/packages/world/abi/KeysInTableModule.sol/KeysInTableModule.abi.json.d.ts
+++ b/packages/world/abi/KeysInTableModule.sol/KeysInTableModule.abi.json.d.ts
@@ -1,26 +1,5 @@
 declare const abi: [
   {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
     inputs: [];
     name: "NonRootInstallNotSupported";
     type: "error";

--- a/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
+++ b/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
@@ -7,27 +7,6 @@
         "type": "uint256"
       }
     ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
     "name": "PackedCounter_InvalidLength",
     "type": "error"
   },

--- a/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
+++ b/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json
@@ -53,6 +53,56 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json.d.ts
+++ b/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json.d.ts
@@ -7,27 +7,6 @@ declare const abi: [
         type: "uint256";
       }
     ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
     name: "PackedCounter_InvalidLength";
     type: "error";
   },

--- a/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json.d.ts
+++ b/packages/world/abi/KeysWithValueHook.sol/KeysWithValueHook.abi.json.d.ts
@@ -53,6 +53,56 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [
       {
         internalType: "bytes32";

--- a/packages/world/abi/KeysWithValueModule.sol/KeysWithValueModule.abi.json
+++ b/packages/world/abi/KeysWithValueModule.sol/KeysWithValueModule.abi.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "NonRootInstallNotSupported",
     "type": "error"

--- a/packages/world/abi/KeysWithValueModule.sol/KeysWithValueModule.abi.json.d.ts
+++ b/packages/world/abi/KeysWithValueModule.sol/KeysWithValueModule.abi.json.d.ts
@@ -1,26 +1,5 @@
 declare const abi: [
   {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
     inputs: [];
     name: "NonRootInstallNotSupported";
     type: "error";

--- a/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json
+++ b/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json
@@ -2,27 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "address",
         "name": "contractAddress",
         "type": "address"

--- a/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json
+++ b/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json
@@ -53,6 +53,31 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json.d.ts
+++ b/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json.d.ts
@@ -2,27 +2,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "address";
         name: "contractAddress";
         type: "address";

--- a/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json.d.ts
+++ b/packages/world/abi/ModuleInstallationSystem.sol/ModuleInstallationSystem.abi.json.d.ts
@@ -53,6 +53,31 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/StandardDelegationsModule.sol/StandardDelegationsModule.abi.json
+++ b/packages/world/abi/StandardDelegationsModule.sol/StandardDelegationsModule.abi.json
@@ -159,6 +159,31 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/StandardDelegationsModule.sol/StandardDelegationsModule.abi.json.d.ts
+++ b/packages/world/abi/StandardDelegationsModule.sol/StandardDelegationsModule.abi.json.d.ts
@@ -159,6 +159,31 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/StoreRead.sol/StoreRead.abi.json
+++ b/packages/world/abi/StoreRead.sol/StoreRead.abi.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "StoreCore_NotDynamicField",
     "type": "error"
@@ -233,6 +212,35 @@
       {
         "internalType": "Schema",
         "name": "schema",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
         "type": "bytes32"
       }
     ],

--- a/packages/world/abi/StoreRead.sol/StoreRead.abi.json
+++ b/packages/world/abi/StoreRead.sol/StoreRead.abi.json
@@ -227,6 +227,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/StoreRead.sol/StoreRead.abi.json.d.ts
+++ b/packages/world/abi/StoreRead.sol/StoreRead.abi.json.d.ts
@@ -227,6 +227,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/StoreRead.sol/StoreRead.abi.json.d.ts
+++ b/packages/world/abi/StoreRead.sol/StoreRead.abi.json.d.ts
@@ -1,26 +1,5 @@
 declare const abi: [
   {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
     inputs: [];
     name: "StoreCore_NotDynamicField";
     type: "error";
@@ -233,6 +212,35 @@ declare const abi: [
       {
         internalType: "Schema";
         name: "schema";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
         type: "bytes32";
       }
     ];

--- a/packages/world/abi/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json
+++ b/packages/world/abi/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json
@@ -289,6 +289,62 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json.d.ts
+++ b/packages/world/abi/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json.d.ts
@@ -289,6 +289,62 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/StoreSwitch.sol/StoreSwitch.abi.json
+++ b/packages/world/abi/StoreSwitch.sol/StoreSwitch.abi.json
@@ -1,1 +1,31 @@
-[]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/world/abi/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
+++ b/packages/world/abi/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
@@ -1,0 +1,32 @@
+declare const abi: [
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  }
+];
+export default abi;

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
@@ -2,27 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
@@ -37,6 +37,37 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json
@@ -23,17 +23,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
@@ -2,27 +2,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
@@ -37,6 +37,37 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
+++ b/packages/world/abi/TimeboundDelegationControl.sol/TimeboundDelegationControl.abi.json.d.ts
@@ -23,17 +23,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/UniqueEntityModule.sol/UniqueEntityModule.abi.json
+++ b/packages/world/abi/UniqueEntityModule.sol/UniqueEntityModule.abi.json
@@ -1,26 +1,5 @@
 [
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "NonRootInstallNotSupported",
     "type": "error"

--- a/packages/world/abi/UniqueEntityModule.sol/UniqueEntityModule.abi.json.d.ts
+++ b/packages/world/abi/UniqueEntityModule.sol/UniqueEntityModule.abi.json.d.ts
@@ -1,26 +1,5 @@
 declare const abi: [
   {
-    inputs: [
-      {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
     inputs: [];
     name: "NonRootInstallNotSupported";
     type: "error";

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
@@ -2,27 +2,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
@@ -37,6 +37,37 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json
@@ -23,17 +23,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "PackedCounter_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes",
         "name": "data",
         "type": "bytes"

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
@@ -2,27 +2,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
@@ -37,6 +37,37 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
+++ b/packages/world/abi/UniqueEntitySystem.sol/UniqueEntitySystem.abi.json.d.ts
@@ -23,17 +23,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "PackedCounter_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes";
         name: "data";
         type: "bytes";

--- a/packages/world/abi/World.sol/World.abi.json
+++ b/packages/world/abi/World.sol/World.abi.json
@@ -711,6 +711,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/World.sol/World.abi.json
+++ b/packages/world/abi/World.sol/World.abi.json
@@ -263,6 +263,25 @@
         "internalType": "bytes32[]",
         "name": "key",
         "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
       },
       {
         "indexed": false,
@@ -278,6 +297,62 @@
       }
     ],
     "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
     "type": "event"
   },
   {

--- a/packages/world/abi/World.sol/World.abi.json
+++ b/packages/world/abi/World.sol/World.abi.json
@@ -651,6 +651,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "tableId",
         "type": "bytes32"
@@ -771,6 +800,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/World.sol/World.abi.json
+++ b/packages/world/abi/World.sol/World.abi.json
@@ -39,27 +39,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes4",
         "name": "functionSelector",
         "type": "bytes4"

--- a/packages/world/abi/World.sol/World.abi.json.d.ts
+++ b/packages/world/abi/World.sol/World.abi.json.d.ts
@@ -39,27 +39,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes4";
         name: "functionSelector";
         type: "bytes4";

--- a/packages/world/abi/World.sol/World.abi.json.d.ts
+++ b/packages/world/abi/World.sol/World.abi.json.d.ts
@@ -263,6 +263,25 @@ declare const abi: [
         internalType: "bytes32[]";
         name: "key";
         type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
       },
       {
         indexed: false;
@@ -278,6 +297,62 @@ declare const abi: [
       }
     ];
     name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
     type: "event";
   },
   {

--- a/packages/world/abi/World.sol/World.abi.json.d.ts
+++ b/packages/world/abi/World.sol/World.abi.json.d.ts
@@ -651,6 +651,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "tableId";
         type: "bytes32";
@@ -771,6 +800,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/World.sol/World.abi.json.d.ts
+++ b/packages/world/abi/World.sol/World.abi.json.d.ts
@@ -711,6 +711,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
@@ -34,27 +34,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "length",
-        "type": "uint256"
-      }
-    ],
-    "name": "FieldLayoutLib_InvalidLength",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthDoesNotFitInAWord",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FieldLayoutLib_StaticLengthIsZero",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bytes4",
         "name": "functionSelector",
         "type": "bytes4"

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json
@@ -188,6 +188,81 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "StoreDeleteRecord",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "fieldIndex",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetField",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "table",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "StoreSetRecord",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "_msgSender",
     "outputs": [

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json.d.ts
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json.d.ts
@@ -34,27 +34,6 @@ declare const abi: [
   {
     inputs: [
       {
-        internalType: "uint256";
-        name: "length";
-        type: "uint256";
-      }
-    ];
-    name: "FieldLayoutLib_InvalidLength";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthDoesNotFitInAWord";
-    type: "error";
-  },
-  {
-    inputs: [];
-    name: "FieldLayoutLib_StaticLengthIsZero";
-    type: "error";
-  },
-  {
-    inputs: [
-      {
         internalType: "bytes4";
         name: "functionSelector";
         type: "bytes4";

--- a/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json.d.ts
+++ b/packages/world/abi/WorldRegistrationSystem.sol/WorldRegistrationSystem.abi.json.d.ts
@@ -188,6 +188,81 @@ declare const abi: [
     type: "error";
   },
   {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      }
+    ];
+    name: "StoreDeleteRecord";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "uint8";
+        name: "fieldIndex";
+        type: "uint8";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetField";
+    type: "event";
+  },
+  {
+    anonymous: false;
+    inputs: [
+      {
+        indexed: false;
+        internalType: "bytes32";
+        name: "table";
+        type: "bytes32";
+      },
+      {
+        indexed: false;
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        indexed: false;
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    name: "StoreSetRecord";
+    type: "event";
+  },
+  {
     inputs: [];
     name: "_msgSender";
     outputs: [

--- a/packages/world/abi/src/IStore.sol/IStore.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStore.abi.json
@@ -479,6 +479,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/src/IStore.sol/IStore.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStore.abi.json
@@ -473,6 +473,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -654,6 +683,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/src/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStore.abi.json.d.ts
@@ -479,6 +479,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/src/IStore.sol/IStore.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStore.abi.json.d.ts
@@ -473,6 +473,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -654,6 +683,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/src/IStore.sol/IStoreData.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStoreData.abi.json
@@ -298,6 +298,35 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"
@@ -418,6 +447,54 @@
       }
     ],
     "name": "setRecord",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/world/abi/src/IStore.sol/IStoreData.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStoreData.abi.json
@@ -304,6 +304,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/src/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStoreData.abi.json.d.ts
@@ -298,6 +298,35 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";
@@ -418,6 +447,54 @@ declare const abi: [
       }
     ];
     name: "setRecord";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
     outputs: [];
     stateMutability: "nonpayable";
     type: "function";

--- a/packages/world/abi/src/IStore.sol/IStoreData.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStoreData.abi.json.d.ts
@@ -304,6 +304,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/src/IStore.sol/IStoreRead.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStoreRead.abi.json
@@ -196,5 +196,34 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadStaticField",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/packages/world/abi/src/IStore.sol/IStoreRead.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStoreRead.abi.json
@@ -206,6 +206,88 @@
       },
       {
         "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadFieldLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "start",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "end",
+        "type": "uint256"
+      }
+    ],
+    "name": "loadFieldSlice",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "length",
         "type": "uint256"
       },

--- a/packages/world/abi/src/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStoreRead.abi.json.d.ts
@@ -196,6 +196,35 @@ declare const abi: [
     ];
     stateMutability: "view";
     type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      }
+    ];
+    name: "loadStaticField";
+    outputs: [
+      {
+        internalType: "bytes32";
+        name: "";
+        type: "bytes32";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
   }
 ];
 export default abi;

--- a/packages/world/abi/src/IStore.sol/IStoreRead.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStoreRead.abi.json.d.ts
@@ -206,6 +206,88 @@ declare const abi: [
       },
       {
         internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadFieldLength";
+    outputs: [
+      {
+        internalType: "uint256";
+        name: "";
+        type: "uint256";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "start";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "end";
+        type: "uint256";
+      }
+    ];
+    name: "loadFieldSlice";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
         name: "length";
         type: "uint256";
       },

--- a/packages/world/abi/src/IStore.sol/IStoreWrite.abi.json
+++ b/packages/world/abi/src/IStore.sol/IStoreWrite.abi.json
@@ -227,6 +227,54 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "tableId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "key",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint8",
+        "name": "schemaIndex",
+        "type": "uint8"
+      },
+      {
+        "internalType": "FieldLayout",
+        "name": "fieldLayout",
+        "type": "bytes32"
+      }
+    ],
+    "name": "storeStaticField",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "table",
         "type": "bytes32"

--- a/packages/world/abi/src/IStore.sol/IStoreWrite.abi.json.d.ts
+++ b/packages/world/abi/src/IStore.sol/IStoreWrite.abi.json.d.ts
@@ -227,6 +227,54 @@ declare const abi: [
   {
     inputs: [
       {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "length";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "offset";
+        type: "uint256";
+      },
+      {
+        internalType: "bytes";
+        name: "data";
+        type: "bytes";
+      },
+      {
+        internalType: "bytes32";
+        name: "tableId";
+        type: "bytes32";
+      },
+      {
+        internalType: "bytes32[]";
+        name: "key";
+        type: "bytes32[]";
+      },
+      {
+        internalType: "uint8";
+        name: "schemaIndex";
+        type: "uint8";
+      },
+      {
+        internalType: "FieldLayout";
+        name: "fieldLayout";
+        type: "bytes32";
+      }
+    ];
+    name: "storeStaticField";
+    outputs: [];
+    stateMutability: "nonpayable";
+    type: "function";
+  },
+  {
+    inputs: [
+      {
         internalType: "bytes32";
         name: "table";
         type: "bytes32";

--- a/packages/world/abi/src/StoreSwitch.sol/StoreSwitch.abi.json
+++ b/packages/world/abi/src/StoreSwitch.sol/StoreSwitch.abi.json
@@ -1,1 +1,31 @@
-[]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "storagePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lengthStoragePointer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "dynamicSchemaIndex",
+        "type": "uint8"
+      }
+    ],
+    "name": "loadDynamicField",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/world/abi/src/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
+++ b/packages/world/abi/src/StoreSwitch.sol/StoreSwitch.abi.json.d.ts
@@ -1,0 +1,32 @@
+declare const abi: [
+  {
+    inputs: [
+      {
+        internalType: "uint256";
+        name: "storagePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint256";
+        name: "lengthStoragePointer";
+        type: "uint256";
+      },
+      {
+        internalType: "uint8";
+        name: "dynamicSchemaIndex";
+        type: "uint8";
+      }
+    ];
+    name: "loadDynamicField";
+    outputs: [
+      {
+        internalType: "bytes";
+        name: "";
+        type: "bytes";
+      }
+    ];
+    stateMutability: "view";
+    type: "function";
+  }
+];
+export default abi;

--- a/packages/world/foundry.toml
+++ b/packages/world/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.13'
+solc = '0.8.21'
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,31 +3,31 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (cold)",
-    "gasUsed": 13860
+    "gasUsed": 9383
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm, namespace only)",
-    "gasUsed": 4007
+    "gasUsed": 1763
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 7892
+    "gasUsed": 3403
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (cold)",
-    "gasUsed": 13903
+    "gasUsed": 9425
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (warm)",
-    "gasUsed": 7909
+    "gasUsed": 3427
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,73 +39,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1519669
+    "gasUsed": 1480423
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1519669
+    "gasUsed": 1480423
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 183388
+    "gasUsed": 165957
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1519669
+    "gasUsed": 1480423
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1519669
+    "gasUsed": 1480423
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 28498
+    "gasUsed": 21591
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 251457
+    "gasUsed": 206998
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1519669
+    "gasUsed": 1480423
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 27221
+    "gasUsed": 20316
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 132823
+    "gasUsed": 109355
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 728673
+    "gasUsed": 704708
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 7508
+    "gasUsed": 7253
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,264 +117,264 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 728673
+    "gasUsed": 704708
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 157348
+    "gasUsed": 143753
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 728673
+    "gasUsed": 704708
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 126291
+    "gasUsed": 112785
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 49099
+    "gasUsed": 40938
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 728673
+    "gasUsed": 704708
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 163792
+    "gasUsed": 150085
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 128551
+    "gasUsed": 114844
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 141196
+    "gasUsed": 120889
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 69053
+    "gasUsed": 61774
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 184150
+    "gasUsed": 151551
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 121994
+    "gasUsed": 96025
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 117772
+    "gasUsed": 97975
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 19164
+    "gasUsed": 18654
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 27950
+    "gasUsed": 21465
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 7068010
+    "gasUsed": 7032583
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 672230
+    "gasUsed": 662903
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 9259
+    "gasUsed": 9004
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 62652
+    "gasUsed": 55373
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 133325
+    "gasUsed": 130960
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 49383
+    "gasUsed": 43856
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 127681
+    "gasUsed": 125308
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 38474
+    "gasUsed": 33358
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 787953
+    "gasUsed": 752184
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 67456
+    "gasUsed": 60321
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 771494
+    "gasUsed": 734020
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 67456
+    "gasUsed": 60321
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 19564
+    "gasUsed": 16907
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 59044
+    "gasUsed": 57779
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 19950
+    "gasUsed": 17286
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 13886
+    "gasUsed": 11252
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 93261
+    "gasUsed": 90145
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 75414
+    "gasUsed": 69501
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 68663
+    "gasUsed": 62775
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 96008
+    "gasUsed": 90094
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 146371
+    "gasUsed": 141471
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 90581
+    "gasUsed": 84693
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 685337
+    "gasUsed": 671238
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 41899
+    "gasUsed": 39266
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 41344
+    "gasUsed": 38440
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 32940
+    "gasUsed": 29877
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 19729
+    "gasUsed": 16667
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 35373
+    "gasUsed": 32484
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 22578
+    "gasUsed": 19689
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,31 +3,31 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (cold)",
-    "gasUsed": 5823
+    "gasUsed": 5233
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm, namespace only)",
-    "gasUsed": 985
+    "gasUsed": 690
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 1838
+    "gasUsed": 1248
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (cold)",
-    "gasUsed": 5868
+    "gasUsed": 5278
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (warm)",
-    "gasUsed": 1870
+    "gasUsed": 1280
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,67 +39,67 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1400227
+    "gasUsed": 1397689
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1400227
+    "gasUsed": 1397689
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 148294
+    "gasUsed": 146870
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1400227
+    "gasUsed": 1397689
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1400227
+    "gasUsed": 1397689
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 17756
+    "gasUsed": 17480
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 146647
+    "gasUsed": 141768
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1400227
+    "gasUsed": 1397689
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 16479
+    "gasUsed": 16203
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 75790
+    "gasUsed": 73207
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 641429
+    "gasUsed": 639895
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,49 +117,49 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 641429
+    "gasUsed": 639895
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 130549
+    "gasUsed": 129114
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 641429
+    "gasUsed": 639895
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 97389
+    "gasUsed": 95954
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 30507
+    "gasUsed": 29646
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 641429
+    "gasUsed": 639895
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 136791
+    "gasUsed": 135356
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 99196
+    "gasUsed": 97761
   },
   {
     "file": "test/query.t.sol",
@@ -237,7 +237,7 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 31181
+    "gasUsed": 30917
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
@@ -249,37 +249,37 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 25019
+    "gasUsed": 24755
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 664260
+    "gasUsed": 661716
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 48236
+    "gasUsed": 47960
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 652175
+    "gasUsed": 649367
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 48236
+    "gasUsed": 47960
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 11328
+    "gasUsed": 11041
   },
   {
     "file": "test/World.t.sol",
@@ -291,90 +291,90 @@
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 11653
+    "gasUsed": 11389
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 7863
+    "gasUsed": 7576
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 86778
+    "gasUsed": 86491
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 56654
+    "gasUsed": 56150
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 50051
+    "gasUsed": 49547
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 77219
+    "gasUsed": 76715
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 118305
+    "gasUsed": 118046
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 71969
+    "gasUsed": 71465
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 637025
+    "gasUsed": 636259
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 35856
+    "gasUsed": 35569
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 33305
+    "gasUsed": 33018
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 24549
+    "gasUsed": 24262
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 13339
+    "gasUsed": 13052
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 27105
+    "gasUsed": 26818
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 16310
+    "gasUsed": 16023
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,31 +3,31 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (cold)",
-    "gasUsed": 5811
+    "gasUsed": 5823
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm, namespace only)",
-    "gasUsed": 980
+    "gasUsed": 985
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 1826
+    "gasUsed": 1838
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (cold)",
-    "gasUsed": 5856
+    "gasUsed": 5868
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (warm)",
-    "gasUsed": 1858
+    "gasUsed": 1870
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,73 +39,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1416072
+    "gasUsed": 1400227
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1416072
+    "gasUsed": 1400227
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 153517
+    "gasUsed": 148294
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1416072
+    "gasUsed": 1400227
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1416072
+    "gasUsed": 1400227
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 18972
+    "gasUsed": 17756
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 164995
+    "gasUsed": 146647
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1416072
+    "gasUsed": 1400227
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 17695
+    "gasUsed": 16479
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 85505
+    "gasUsed": 75790
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 654938
+    "gasUsed": 641429
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 6182
+    "gasUsed": 4125
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,264 +117,264 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 654938
+    "gasUsed": 641429
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 132560
+    "gasUsed": 130549
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 654938
+    "gasUsed": 641429
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 101521
+    "gasUsed": 97389
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 33800
+    "gasUsed": 30507
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 654938
+    "gasUsed": 641429
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 138824
+    "gasUsed": 136791
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 103583
+    "gasUsed": 99196
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 102568
+    "gasUsed": 73340
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 53513
+    "gasUsed": 39589
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 125324
+    "gasUsed": 85081
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 79151
+    "gasUsed": 54556
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 81810
+    "gasUsed": 56770
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 16499
+    "gasUsed": 12315
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 17515
+    "gasUsed": 11859
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 5889061
+    "gasUsed": 3888279
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 552736
+    "gasUsed": 351166
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 7924
+    "gasUsed": 5832
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 47113
+    "gasUsed": 33189
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 114569
+    "gasUsed": 110829
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 33728
+    "gasUsed": 31181
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 109149
+    "gasUsed": 105422
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 26307
+    "gasUsed": 25019
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 682922
+    "gasUsed": 664260
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 50671
+    "gasUsed": 48236
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 669563
+    "gasUsed": 652175
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 50671
+    "gasUsed": 48236
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 12564
+    "gasUsed": 11328
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 48892
+    "gasUsed": 46419
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 12929
+    "gasUsed": 11653
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 9146
+    "gasUsed": 7863
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 87916
+    "gasUsed": 86778
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 59147
+    "gasUsed": 56654
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 52545
+    "gasUsed": 50051
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 79713
+    "gasUsed": 77219
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 123299
+    "gasUsed": 118305
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 74463
+    "gasUsed": 71969
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 644416
+    "gasUsed": 637025
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 37095
+    "gasUsed": 35856
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 34499
+    "gasUsed": 33305
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 25753
+    "gasUsed": 24549
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 14543
+    "gasUsed": 13339
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 28249
+    "gasUsed": 27105
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 17454
+    "gasUsed": 16310
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -39,73 +39,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1415958
+    "gasUsed": 1416072
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1415958
+    "gasUsed": 1416072
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 153445
+    "gasUsed": 153517
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1415958
+    "gasUsed": 1416072
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1415958
+    "gasUsed": 1416072
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 18938
+    "gasUsed": 18972
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 164749
+    "gasUsed": 164995
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1415958
+    "gasUsed": 1416072
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 17660
+    "gasUsed": 17695
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 85363
+    "gasUsed": 85505
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 654648
+    "gasUsed": 654938
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 6181
+    "gasUsed": 6182
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,37 +117,37 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 654648
+    "gasUsed": 654938
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 132483
+    "gasUsed": 132560
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 654648
+    "gasUsed": 654938
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 101496
+    "gasUsed": 101521
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 33695
+    "gasUsed": 33800
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 654648
+    "gasUsed": 654938
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -165,25 +165,25 @@
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 102556
+    "gasUsed": 102568
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 53502
+    "gasUsed": 53513
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 125333
+    "gasUsed": 125324
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 79137
+    "gasUsed": 79151
   },
   {
     "file": "test/query.t.sol",
@@ -195,186 +195,186 @@
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 16492
+    "gasUsed": 16499
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 17513
+    "gasUsed": 17515
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 5893051
+    "gasUsed": 5889061
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 553126
+    "gasUsed": 552736
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 7923
+    "gasUsed": 7924
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 47102
+    "gasUsed": 47113
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 114525
+    "gasUsed": 114569
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 33757
+    "gasUsed": 33728
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 109080
+    "gasUsed": 109149
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 26396
+    "gasUsed": 26307
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 682471
+    "gasUsed": 682922
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 50623
+    "gasUsed": 50671
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 669152
+    "gasUsed": 669563
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 50623
+    "gasUsed": 50671
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 12612
+    "gasUsed": 12564
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 48855
+    "gasUsed": 48892
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 12976
+    "gasUsed": 12929
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 9089
+    "gasUsed": 9146
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 87953
+    "gasUsed": 87916
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 59161
+    "gasUsed": 59147
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 52437
+    "gasUsed": 52545
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 79755
+    "gasUsed": 79713
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 123244
+    "gasUsed": 123299
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 74355
+    "gasUsed": 74463
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 644364
+    "gasUsed": 644416
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 37103
+    "gasUsed": 37095
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 34522
+    "gasUsed": 34499
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 25695
+    "gasUsed": 25753
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 14485
+    "gasUsed": 14543
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 28291
+    "gasUsed": 28249
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 17496
+    "gasUsed": 17454
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,31 +3,31 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (cold)",
-    "gasUsed": 9383
+    "gasUsed": 8391
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm, namespace only)",
-    "gasUsed": 1763
+    "gasUsed": 1270
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 3402
+    "gasUsed": 2406
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (cold)",
-    "gasUsed": 9425
+    "gasUsed": 8436
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (warm)",
-    "gasUsed": 3427
+    "gasUsed": 2438
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,73 +39,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1432704
+    "gasUsed": 1427904
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1432704
+    "gasUsed": 1427904
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 158816
+    "gasUsed": 155801
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1432704
+    "gasUsed": 1427904
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1432704
+    "gasUsed": 1427904
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 20521
+    "gasUsed": 19522
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 181331
+    "gasUsed": 172727
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1432704
+    "gasUsed": 1427904
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 19244
+    "gasUsed": 18244
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 94316
+    "gasUsed": 89797
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 667088
+    "gasUsed": 664461
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 6190
+    "gasUsed": 6181
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,264 +117,264 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 667088
+    "gasUsed": 664461
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 137364
+    "gasUsed": 134851
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 667088
+    "gasUsed": 664461
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 106394
+    "gasUsed": 103864
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 36668
+    "gasUsed": 35177
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 667088
+    "gasUsed": 664461
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 143696
+    "gasUsed": 141192
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 108455
+    "gasUsed": 105951
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 104884
+    "gasUsed": 102556
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 54296
+    "gasUsed": 53502
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 129177
+    "gasUsed": 125333
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 82178
+    "gasUsed": 79137
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 84120
+    "gasUsed": 81810
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 16510
+    "gasUsed": 16492
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 18271
+    "gasUsed": 17513
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 5902791
+    "gasUsed": 5893051
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 554766
+    "gasUsed": 553126
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 7932
+    "gasUsed": 7923
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 47896
+    "gasUsed": 47102
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 117527
+    "gasUsed": 117540
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 36602
+    "gasUsed": 35308
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 111876
+    "gasUsed": 111890
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 28649
+    "gasUsed": 27645
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 700756
+    "gasUsed": 696667
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 53083
+    "gasUsed": 52375
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 687294
+    "gasUsed": 682817
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 53083
+    "gasUsed": 52375
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 14017
+    "gasUsed": 13520
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 50530
+    "gasUsed": 50539
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 14396
+    "gasUsed": 13884
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 10181
+    "gasUsed": 9685
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 89074
+    "gasUsed": 88549
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 61909
+    "gasUsed": 61181
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 55183
+    "gasUsed": 54457
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 82501
+    "gasUsed": 81775
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 129142
+    "gasUsed": 128769
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 77101
+    "gasUsed": 76375
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 651315
+    "gasUsed": 649804
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 38195
+    "gasUsed": 37699
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 35916
+    "gasUsed": 35419
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 28806
+    "gasUsed": 28291
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 15596
+    "gasUsed": 15081
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 31413
+    "gasUsed": 30887
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 18618
+    "gasUsed": 18092
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -39,67 +39,67 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1416840
+    "gasUsed": 1415958
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1416840
+    "gasUsed": 1415958
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 153433
+    "gasUsed": 153445
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1416840
+    "gasUsed": 1415958
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1416840
+    "gasUsed": 1415958
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 18926
+    "gasUsed": 18938
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 165011
+    "gasUsed": 164749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1416840
+    "gasUsed": 1415958
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 17648
+    "gasUsed": 17660
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 85625
+    "gasUsed": 85363
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 655705
+    "gasUsed": 654648
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,7 +117,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 655705
+    "gasUsed": 654648
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -129,7 +129,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 655705
+    "gasUsed": 654648
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -147,7 +147,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 655705
+    "gasUsed": 654648
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -231,49 +231,49 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 115118
+    "gasUsed": 114525
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 33756
+    "gasUsed": 33757
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 109551
+    "gasUsed": 109080
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 26395
+    "gasUsed": 26396
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 683903
+    "gasUsed": 682471
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 50844
+    "gasUsed": 50623
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 670584
+    "gasUsed": 669152
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 50844
+    "gasUsed": 50623
   },
   {
     "file": "test/World.t.sol",
@@ -285,7 +285,7 @@
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 49090
+    "gasUsed": 48855
   },
   {
     "file": "test/World.t.sol",
@@ -327,7 +327,7 @@
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 123860
+    "gasUsed": 123244
   },
   {
     "file": "test/World.t.sol",
@@ -339,7 +339,7 @@
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 645145
+    "gasUsed": 644364
   },
   {
     "file": "test/World.t.sol",
@@ -351,7 +351,7 @@
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 34791
+    "gasUsed": 34522
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -15,7 +15,7 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 3403
+    "gasUsed": 3402
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,73 +39,73 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1480423
+    "gasUsed": 1432704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1480423
+    "gasUsed": 1432704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 165957
+    "gasUsed": 158816
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1480423
+    "gasUsed": 1432704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1480423
+    "gasUsed": 1432704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 21591
+    "gasUsed": 20521
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 206998
+    "gasUsed": 181331
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1480423
+    "gasUsed": 1432704
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 20316
+    "gasUsed": 19244
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 109355
+    "gasUsed": 94316
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 704708
+    "gasUsed": 667088
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "Get list of keys with a given value",
-    "gasUsed": 7253
+    "gasUsed": 6190
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,264 +117,264 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 704708
+    "gasUsed": 667088
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 143753
+    "gasUsed": 137364
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 704708
+    "gasUsed": 667088
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 112785
+    "gasUsed": 106394
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 40938
+    "gasUsed": 36668
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 704708
+    "gasUsed": 667088
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 150085
+    "gasUsed": 143696
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 114844
+    "gasUsed": 108455
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueNotQuery",
     "name": "CombinedHasHasValueNotQuery",
-    "gasUsed": 120889
+    "gasUsed": 104884
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasHasValueQuery",
     "name": "CombinedHasHasValueQuery",
-    "gasUsed": 61774
+    "gasUsed": 54296
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasNotQuery",
     "name": "CombinedHasNotQuery",
-    "gasUsed": 151551
+    "gasUsed": 129177
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasQuery",
     "name": "CombinedHasQuery",
-    "gasUsed": 96025
+    "gasUsed": 82178
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueNotQuery",
     "name": "CombinedHasValueNotQuery",
-    "gasUsed": 97975
+    "gasUsed": 84120
   },
   {
     "file": "test/query.t.sol",
     "test": "testCombinedHasValueQuery",
     "name": "CombinedHasValueQuery",
-    "gasUsed": 18654
+    "gasUsed": 16510
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery",
     "name": "HasQuery",
-    "gasUsed": 21465
+    "gasUsed": 18271
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery1000Keys",
     "name": "HasQuery with 1000 keys",
-    "gasUsed": 7032583
+    "gasUsed": 5902791
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasQuery100Keys",
     "name": "HasQuery with 100 keys",
-    "gasUsed": 662903
+    "gasUsed": 554766
   },
   {
     "file": "test/query.t.sol",
     "test": "testHasValueQuery",
     "name": "HasValueQuery",
-    "gasUsed": 9004
+    "gasUsed": 7932
   },
   {
     "file": "test/query.t.sol",
     "test": "testNotValueQuery",
     "name": "NotValueQuery",
-    "gasUsed": 55373
+    "gasUsed": 47896
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 130960
+    "gasUsed": 117527
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 43856
+    "gasUsed": 36602
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 125308
+    "gasUsed": 111876
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 33358
+    "gasUsed": 28649
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 752184
+    "gasUsed": 700756
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 60321
+    "gasUsed": 53083
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 734020
+    "gasUsed": 687294
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 60321
+    "gasUsed": 53083
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 16907
+    "gasUsed": 14017
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 57779
+    "gasUsed": 50530
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 17286
+    "gasUsed": 14396
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 11252
+    "gasUsed": 10181
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 90145
+    "gasUsed": 89074
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 69501
+    "gasUsed": 61909
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 62775
+    "gasUsed": 55183
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 90094
+    "gasUsed": 82501
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 141471
+    "gasUsed": 129142
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 84693
+    "gasUsed": 77101
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 671238
+    "gasUsed": 651315
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 39266
+    "gasUsed": 38195
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 38440
+    "gasUsed": 35916
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 29877
+    "gasUsed": 28806
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 16667
+    "gasUsed": 15596
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 32484
+    "gasUsed": 31413
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 19689
+    "gasUsed": 18618
   }
 ]

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -3,31 +3,31 @@
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (cold)",
-    "gasUsed": 8391
+    "gasUsed": 5811
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm, namespace only)",
-    "gasUsed": 1270
+    "gasUsed": 980
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testAccessControl",
     "name": "AccessControl: hasAccess (warm)",
-    "gasUsed": 2406
+    "gasUsed": 1826
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (cold)",
-    "gasUsed": 8436
+    "gasUsed": 5856
   },
   {
     "file": "test/AccessControl.t.sol",
     "test": "testRequireAccess",
     "name": "AccessControl: requireAccess (warm)",
-    "gasUsed": 2438
+    "gasUsed": 1858
   },
   {
     "file": "test/AccessControl.t.sol",
@@ -39,67 +39,67 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1427904
+    "gasUsed": 1416840
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1427904
+    "gasUsed": 1416840
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "set a record on a table with keysInTableModule installed",
-    "gasUsed": 155801
+    "gasUsed": 153433
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1427904
+    "gasUsed": 1416840
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1427904
+    "gasUsed": 1416840
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "change a composite record on a table with keysInTableModule installed",
-    "gasUsed": 19522
+    "gasUsed": 18926
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "delete a composite record on a table with keysInTableModule installed",
-    "gasUsed": 172727
+    "gasUsed": 165011
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1427904
+    "gasUsed": 1416840
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "change a record on a table with keysInTableModule installed",
-    "gasUsed": 18244
+    "gasUsed": 17648
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "delete a record on a table with keysInTableModule installed",
-    "gasUsed": 89797
+    "gasUsed": 85625
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 664461
+    "gasUsed": 655705
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -117,49 +117,49 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 664461
+    "gasUsed": 655705
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "set a record on a table with KeysWithValueModule installed",
-    "gasUsed": 134851
+    "gasUsed": 132483
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 664461
+    "gasUsed": 655705
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "change a record on a table with KeysWithValueModule installed",
-    "gasUsed": 103864
+    "gasUsed": 101496
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "delete a record on a table with KeysWithValueModule installed",
-    "gasUsed": 35177
+    "gasUsed": 33695
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 664461
+    "gasUsed": 655705
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "set a field on a table with KeysWithValueModule installed",
-    "gasUsed": 141192
+    "gasUsed": 138824
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "change a field on a table with KeysWithValueModule installed",
-    "gasUsed": 105951
+    "gasUsed": 103583
   },
   {
     "file": "test/query.t.sol",
@@ -231,150 +231,150 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 117540
+    "gasUsed": 115118
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "call a system via a callbound delegation",
-    "gasUsed": 35308
+    "gasUsed": 33756
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 111890
+    "gasUsed": 109551
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "call a system via a timebound delegation",
-    "gasUsed": 27645
+    "gasUsed": 26395
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 696667
+    "gasUsed": 683903
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 52375
+    "gasUsed": 50844
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 682817
+    "gasUsed": 670584
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 52375
+    "gasUsed": 50844
   },
   {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",
-    "gasUsed": 13520
+    "gasUsed": 12612
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 50539
+    "gasUsed": 49090
   },
   {
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "call a system via an unlimited delegation",
-    "gasUsed": 13884
+    "gasUsed": 12976
   },
   {
     "file": "test/World.t.sol",
     "test": "testDeleteRecord",
     "name": "Delete record",
-    "gasUsed": 9685
+    "gasUsed": 9089
   },
   {
     "file": "test/World.t.sol",
     "test": "testPushToField",
     "name": "Push data to the table",
-    "gasUsed": 88549
+    "gasUsed": 87953
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a fallback system",
-    "gasUsed": 61181
+    "gasUsed": 59161
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFallbackSystem",
     "name": "Register a root fallback system",
-    "gasUsed": 54457
+    "gasUsed": 52437
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 81775
+    "gasUsed": 79755
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 128769
+    "gasUsed": 123860
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 76375
+    "gasUsed": 74355
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 649804
+    "gasUsed": 645145
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetField",
     "name": "Write data to a table field",
-    "gasUsed": 37699
+    "gasUsed": 37103
   },
   {
     "file": "test/World.t.sol",
     "test": "testSetRecord",
     "name": "Write data to the table",
-    "gasUsed": 35419
+    "gasUsed": 34791
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (cold)",
-    "gasUsed": 28291
+    "gasUsed": 25695
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testPopFromField",
     "name": "pop 1 address (warm)",
-    "gasUsed": 15081
+    "gasUsed": 14485
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (cold)",
-    "gasUsed": 30887
+    "gasUsed": 28291
   },
   {
     "file": "test/WorldDynamicUpdate.t.sol",
     "test": "testUpdateInField",
     "name": "updateInField 1 item (warm)",
-    "gasUsed": 18092
+    "gasUsed": 17496
   }
 ]

--- a/packages/world/hardhat.config.ts
+++ b/packages/world/hardhat.config.ts
@@ -6,7 +6,7 @@ const config: HardhatUserConfig = {
     sources: "./src",
   },
   solidity: {
-    version: "0.8.13",
+    version: "0.8.21",
     settings: {
       optimizer: {
         enabled: true,

--- a/packages/world/src/AccessControl.sol
+++ b/packages/world/src/AccessControl.sol
@@ -16,8 +16,8 @@ library AccessControl {
   function hasAccess(bytes32 resourceSelector, address caller) internal view returns (bool) {
     return
       address(this) == caller || // First check if the World is calling itself
-      ResourceAccess.get(resourceSelector.getNamespace(), caller) || // Then check access based on the namespace
-      ResourceAccess.get(resourceSelector, caller); // If caller has no namespace access, check access on the name
+      ResourceAccess._get(resourceSelector.getNamespace(), caller) || // Then check access based on the namespace
+      ResourceAccess._get(resourceSelector, caller); // If caller has no namespace access, check access on the name
   }
 
   /**
@@ -36,7 +36,7 @@ library AccessControl {
    * Reverts with AccessDenied if the check fails.
    */
   function requireOwner(bytes32 resourceSelector, address caller) internal view {
-    if (NamespaceOwner.get(resourceSelector.getNamespace()) != caller) {
+    if (NamespaceOwner._get(resourceSelector.getNamespace()) != caller) {
       revert IWorldErrors.AccessDenied(resourceSelector.toString(), caller);
     }
   }

--- a/packages/world/src/SystemCall.sol
+++ b/packages/world/src/SystemCall.sol
@@ -34,7 +34,7 @@ library SystemCall {
     bytes memory funcSelectorAndArgs
   ) internal returns (bool success, bytes memory data) {
     // Load the system data
-    (address systemAddress, bool publicAccess) = Systems.get(resourceSelector);
+    (address systemAddress, bool publicAccess) = Systems._get(resourceSelector);
 
     // Check if the system exists
     if (systemAddress == address(0)) revert IWorldErrors.ResourceNotFound(resourceSelector.toString());
@@ -45,8 +45,8 @@ library SystemCall {
     // If the msg.value is non-zero, update the namespace's balance
     if (value > 0) {
       bytes16 namespace = resourceSelector.getNamespace();
-      uint256 currentBalance = Balances.get(namespace);
-      Balances.set(namespace, currentBalance + value);
+      uint256 currentBalance = Balances._get(namespace);
+      Balances._set(namespace, currentBalance + value);
     }
 
     // Call the system and forward any return data
@@ -76,7 +76,7 @@ library SystemCall {
     uint256 value
   ) internal returns (bool success, bytes memory data) {
     // Get system hooks
-    bytes21[] memory hooks = SystemHooks.get(resourceSelector);
+    bytes21[] memory hooks = SystemHooks._get(resourceSelector);
 
     // Call onBeforeCallSystem hooks (before calling the system)
     for (uint256 i; i < hooks.length; i++) {

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -52,7 +52,7 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     }
 
     // The World can only be initialized once
-    if (InstalledModules.getModuleAddress(CORE_MODULE_NAME, keccak256("")) != address(0)) {
+    if (InstalledModules._getModuleAddress(CORE_MODULE_NAME, keccak256("")) != address(0)) {
       revert WorldAlreadyInitialized();
     }
 
@@ -82,7 +82,7 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     });
 
     // Register the module in the InstalledModules table
-    InstalledModules.set(module.getName(), keccak256(args), address(module));
+    InstalledModules._set(module.getName(), keccak256(args), address(module));
   }
 
   /************************************************************************
@@ -242,7 +242,7 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     }
 
     // Check if there is an explicit authorization for this caller to perform actions on behalf of the delegator
-    Delegation explicitDelegation = Delegation.wrap(Delegations.get({ delegator: delegator, delegatee: msg.sender }));
+    Delegation explicitDelegation = Delegation.wrap(Delegations._get({ delegator: delegator, delegatee: msg.sender }));
 
     if (explicitDelegation.verify(delegator, msg.sender, resourceSelector, funcSelectorAndArgs)) {
       // forward the call as `delegator`
@@ -250,7 +250,7 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     }
 
     // Check if the delegator has a fallback delegation control set
-    Delegation fallbackDelegation = Delegation.wrap(Delegations.get({ delegator: delegator, delegatee: address(0) }));
+    Delegation fallbackDelegation = Delegation.wrap(Delegations._get({ delegator: delegator, delegatee: address(0) }));
     if (fallbackDelegation.verify(delegator, msg.sender, resourceSelector, funcSelectorAndArgs)) {
       // forward the call with `from` as `msgSender`
       return SystemCall.callWithHooksOrRevert(delegator, resourceSelector, funcSelectorAndArgs, msg.value);
@@ -269,15 +269,15 @@ contract World is StoreRead, IStoreData, IWorldKernel {
    * ETH sent to the World without calldata is added to the root namespace's balance
    */
   receive() external payable {
-    uint256 rootBalance = Balances.get(ROOT_NAMESPACE);
-    Balances.set(ROOT_NAMESPACE, rootBalance + msg.value);
+    uint256 rootBalance = Balances._get(ROOT_NAMESPACE);
+    Balances._set(ROOT_NAMESPACE, rootBalance + msg.value);
   }
 
   /**
    * Fallback function to call registered function selectors
    */
   fallback() external payable {
-    (bytes32 resourceSelector, bytes4 systemFunctionSelector) = FunctionSelectors.get(msg.sig);
+    (bytes32 resourceSelector, bytes4 systemFunctionSelector) = FunctionSelectors._get(msg.sig);
 
     if (resourceSelector == 0) revert FunctionSelectorNotFound(msg.sig);
 

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -126,6 +126,23 @@ contract World is StoreRead, IStoreData, IWorldKernel {
     StoreCore.setField(tableId, key, schemaIndex, data, fieldLayout);
   }
 
+  function storeStaticField(
+    uint256 storagePointer,
+    uint256 length,
+    uint256 offset,
+    bytes memory data,
+    bytes32 tableId,
+    bytes32[] memory key,
+    uint8 schemaIndex,
+    FieldLayout fieldLayout
+  ) public virtual {
+    // Require access to namespace or name
+    AccessControl.requireAccess(tableId, msg.sender);
+
+    // Set the field
+    StoreCore.storeStaticField(storagePointer, length, offset, data, tableId, key, schemaIndex, fieldLayout);
+  }
+
   /**
    * Push data to the end of a field in the table at the given tableId.
    * Requires the caller to have access to the table's namespace or name (encoded in the tableId).

--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -76,9 +76,9 @@ contract CoreModule is Module {
     SystemRegistry.register();
     ResourceType.register();
 
-    NamespaceOwner.set(ROOT_NAMESPACE, _msgSender());
-    ResourceAccess.set(ROOT_NAMESPACE, _msgSender(), true);
-    ResourceType.set(ROOT_NAMESPACE, Resource.NAMESPACE);
+    NamespaceOwner._set(ROOT_NAMESPACE, _msgSender());
+    ResourceAccess._set(ROOT_NAMESPACE, _msgSender(), true);
+    ResourceType._set(ROOT_NAMESPACE, Resource.NAMESPACE);
   }
 
   /**

--- a/packages/world/src/modules/core/implementations/AccessManagementSystem.sol
+++ b/packages/world/src/modules/core/implementations/AccessManagementSystem.sol
@@ -22,7 +22,7 @@ contract AccessManagementSystem is System {
     AccessControl.requireOwner(resourceSelector, _msgSender());
 
     // Grant access to the given resource
-    ResourceAccess.set(resourceSelector, grantee, true);
+    ResourceAccess._set(resourceSelector, grantee, true);
   }
 
   /**
@@ -47,12 +47,12 @@ contract AccessManagementSystem is System {
     AccessControl.requireOwner(namespace, _msgSender());
 
     // Set namespace new owner
-    NamespaceOwner.set(namespace, newOwner);
+    NamespaceOwner._set(namespace, newOwner);
 
     // Revoke access from old owner
     ResourceAccess.deleteRecord(namespace, _msgSender());
 
     // Grant access to new owner
-    ResourceAccess.set(namespace, newOwner, true);
+    ResourceAccess._set(namespace, newOwner, true);
   }
 }

--- a/packages/world/src/modules/core/implementations/BalanceTransferSystem.sol
+++ b/packages/world/src/modules/core/implementations/BalanceTransferSystem.sol
@@ -20,14 +20,14 @@ contract BalanceTransferSystem is System, IWorldErrors {
     AccessControl.requireAccess(fromNamespace, _msgSender());
 
     // Get current namespace balance
-    uint256 balance = Balances.get(fromNamespace);
+    uint256 balance = Balances._get(fromNamespace);
 
     // Require the balance balance to be greater or equal to the amount to transfer
     if (amount > balance) revert InsufficientBalance(balance, amount);
 
     // Update the balances
-    Balances.set(fromNamespace, balance - amount);
-    Balances.set(toNamespace, Balances.get(toNamespace) + amount);
+    Balances._set(fromNamespace, balance - amount);
+    Balances._set(toNamespace, Balances._get(toNamespace) + amount);
   }
 
   /**
@@ -38,13 +38,13 @@ contract BalanceTransferSystem is System, IWorldErrors {
     AccessControl.requireAccess(fromNamespace, _msgSender());
 
     // Get current namespace balance
-    uint256 balance = Balances.get(fromNamespace);
+    uint256 balance = Balances._get(fromNamespace);
 
     // Require the balance balance to be greater or equal to the amount to transfer
     if (amount > balance) revert InsufficientBalance(balance, amount);
 
     // Update the balances
-    Balances.set(fromNamespace, balance - amount);
+    Balances._set(fromNamespace, balance - amount);
 
     // Transfer the balance to the given address, revert on failure
     (bool success, bytes memory data) = payable(toAddress).call{ value: amount }("");

--- a/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
+++ b/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
@@ -28,6 +28,6 @@ contract ModuleInstallationSystem is System {
     });
 
     // Register the module in the InstalledModules table
-    InstalledModules.set(module.getName(), keccak256(args), address(module));
+    InstalledModules._set(module.getName(), keccak256(args), address(module));
   }
 }

--- a/packages/world/src/modules/core/implementations/StoreRegistrationSystem.sol
+++ b/packages/world/src/modules/core/implementations/StoreRegistrationSystem.sol
@@ -49,10 +49,10 @@ contract StoreRegistrationSystem is System, IWorldErrors {
 
     // If the namespace doesn't exist yet, register it
     bytes16 namespace = resourceSelector.getNamespace();
-    if (ResourceType.get(namespace) == Resource.NONE) {
+    if (ResourceType._get(namespace) == Resource.NONE) {
       // We can't call IBaseWorld(this).registerNamespace directly because it would be handled like
       // an external call, so msg.sender would be the address of the World contract
-      (address systemAddress, ) = Systems.get(ResourceSelector.from(ROOT_NAMESPACE, CORE_SYSTEM_NAME));
+      (address systemAddress, ) = Systems._get(ResourceSelector.from(ROOT_NAMESPACE, CORE_SYSTEM_NAME));
       WorldContextProvider.delegatecallWithContextOrRevert({
         msgSender: _msgSender(),
         msgValue: 0,
@@ -65,12 +65,12 @@ contract StoreRegistrationSystem is System, IWorldErrors {
     }
 
     // Require no resource to exist at this selector yet
-    if (ResourceType.get(resourceSelector) != Resource.NONE) {
+    if (ResourceType._get(resourceSelector) != Resource.NONE) {
       revert ResourceExists(resourceSelector.toString());
     }
 
     // Store the table resource type
-    ResourceType.set(resourceSelector, Resource.TABLE);
+    ResourceType._set(resourceSelector, Resource.TABLE);
 
     // Register the table's schema
     StoreCore.registerTable(resourceSelector, fieldLayout, keySchema, valueSchema, keyNames, fieldNames);

--- a/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
+++ b/packages/world/src/modules/core/implementations/WorldRegistrationSystem.sol
@@ -39,16 +39,16 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     bytes32 resourceSelector = ResourceSelector.from(namespace);
 
     // Require namespace to not exist yet
-    if (ResourceType.get(namespace) != Resource.NONE) revert ResourceExists(resourceSelector.toString());
+    if (ResourceType._get(namespace) != Resource.NONE) revert ResourceExists(resourceSelector.toString());
 
     // Register namespace resource
-    ResourceType.set(namespace, Resource.NAMESPACE);
+    ResourceType._set(namespace, Resource.NAMESPACE);
 
     // Register caller as the namespace owner
-    NamespaceOwner.set(namespace, _msgSender());
+    NamespaceOwner._set(namespace, _msgSender());
 
     // Give caller access to the new namespace
-    ResourceAccess.set(resourceSelector, _msgSender(), true);
+    ResourceAccess._set(resourceSelector, _msgSender(), true);
   }
 
   /**
@@ -97,7 +97,7 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     if (resourceSelector.getName() == ROOT_NAME) revert InvalidSelector(resourceSelector.toString());
 
     // Require this system to not be registered at a different resource selector yet
-    bytes32 existingResourceSelector = SystemRegistry.get(address(system));
+    bytes32 existingResourceSelector = SystemRegistry._get(address(system));
     if (existingResourceSelector != 0 && existingResourceSelector != resourceSelector) {
       revert SystemExists(address(system));
     }
@@ -105,17 +105,17 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     // If the namespace doesn't exist yet, register it
     // otherwise require caller to own the namespace
     bytes16 namespace = resourceSelector.getNamespace();
-    if (ResourceType.get(namespace) == Resource.NONE) registerNamespace(namespace);
+    if (ResourceType._get(namespace) == Resource.NONE) registerNamespace(namespace);
     else AccessControl.requireOwner(namespace, _msgSender());
 
     // Require no resource other than a system to exist at this selector yet
-    Resource resourceType = ResourceType.get(resourceSelector);
+    Resource resourceType = ResourceType._get(resourceSelector);
     if (resourceType != Resource.NONE && resourceType != Resource.SYSTEM) {
       revert ResourceExists(resourceSelector.toString());
     }
 
     // Check if a system already exists at this resource selector
-    address existingSystem = Systems.getSystem(resourceSelector);
+    address existingSystem = Systems._getSystem(resourceSelector);
 
     // If there is an existing system with this resource selector, remove it
     if (existingSystem != address(0)) {
@@ -126,17 +126,17 @@ contract WorldRegistrationSystem is System, IWorldErrors {
       ResourceAccess.deleteRecord(namespace, existingSystem);
     } else {
       // Otherwise, this is a new system, so register its resource type
-      ResourceType.set(resourceSelector, Resource.SYSTEM);
+      ResourceType._set(resourceSelector, Resource.SYSTEM);
     }
 
     // Systems = mapping from resourceSelector to system address and publicAccess
-    Systems.set(resourceSelector, address(system), publicAccess);
+    Systems._set(resourceSelector, address(system), publicAccess);
 
     // SystemRegistry = mapping from system address to resourceSelector
-    SystemRegistry.set(address(system), resourceSelector);
+    SystemRegistry._set(address(system), resourceSelector);
 
     // Grant the system access to its namespace
-    ResourceAccess.set(namespace, address(system), true);
+    ResourceAccess._set(namespace, address(system), true);
   }
 
   /**
@@ -162,7 +162,7 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     );
 
     // Require the function selector to be globally unique
-    bytes32 existingResourceSelector = FunctionSelectors.getResourceSelector(worldFunctionSelector);
+    bytes32 existingResourceSelector = FunctionSelectors._getResourceSelector(worldFunctionSelector);
 
     if (existingResourceSelector != 0) revert FunctionSelectorExists(worldFunctionSelector);
 
@@ -171,7 +171,7 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     bytes4 systemFunctionSelector = systemFunctionSignature.length == 0
       ? bytes4(0) // Save gas by storing 0x0 for empty function signatures (= fallback function)
       : bytes4(keccak256(systemFunctionSignature));
-    FunctionSelectors.set(worldFunctionSelector, resourceSelector, systemFunctionSelector);
+    FunctionSelectors._set(worldFunctionSelector, resourceSelector, systemFunctionSelector);
   }
 
   /**
@@ -190,12 +190,12 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     AccessControl.requireOwner(ROOT_NAMESPACE, _msgSender());
 
     // Require the function selector to be globally unique
-    bytes32 existingResourceSelector = FunctionSelectors.getResourceSelector(worldFunctionSelector);
+    bytes32 existingResourceSelector = FunctionSelectors._getResourceSelector(worldFunctionSelector);
 
     if (existingResourceSelector != 0) revert FunctionSelectorExists(worldFunctionSelector);
 
     // Register the function selector
-    FunctionSelectors.set(worldFunctionSelector, resourceSelector, systemFunctionSelector);
+    FunctionSelectors._set(worldFunctionSelector, resourceSelector, systemFunctionSelector);
 
     return worldFunctionSelector;
   }
@@ -209,12 +209,12 @@ contract WorldRegistrationSystem is System, IWorldErrors {
     bytes memory initFuncSelectorAndArgs
   ) public {
     // Store the delegation control contract address
-    Delegations.set({ delegator: _msgSender(), delegatee: delegatee, delegationControlId: delegationControlId });
+    Delegations._set({ delegator: _msgSender(), delegatee: delegatee, delegationControlId: delegationControlId });
 
     // If the delegation is not unlimited...
     if (delegationControlId != UNLIMITED_DELEGATION && initFuncSelectorAndArgs.length > 0) {
       // Require the delegationControl contract to implement the IDelegationControl interface
-      (address delegationControl, ) = Systems.get(delegationControlId);
+      (address delegationControl, ) = Systems._get(delegationControlId);
       requireInterface(delegationControl, DELEGATION_CONTROL_INTERFACE_ID);
 
       // Call the delegation control contract's init function

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -71,6 +71,18 @@ library Balances {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -81,6 +93,14 @@ library Balances {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /** Get balance */
+  function _get(bytes16 namespace) internal view returns (uint256 balance) {
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
@@ -99,6 +119,24 @@ library Balances {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((balance)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set balance */
+  function _set(bytes16 namespace, uint256 balance) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(namespace);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -147,6 +185,14 @@ library Balances {
     _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes16 namespace) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(namespace);
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -78,20 +78,16 @@ library Balances {
 
   /** Get balance */
   function get(bytes16 namespace) internal view returns (uint256 balance) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(namespace);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
   /** Get balance (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (uint256 balance) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(namespace);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Balances {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -101,9 +103,15 @@ library Balances {
   function _get(bytes16 namespace) internal view returns (uint256 balance) {
     bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (uint256(bytes32(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get balance (using the specified store) */

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -91,6 +91,7 @@ library Balances {
   /** Get balance */
   function get(bytes16 namespace) internal view returns (uint256 balance) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -99,6 +100,7 @@ library Balances {
   /** Get balance */
   function _get(bytes16 namespace) internal view returns (uint256 balance) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -107,6 +109,7 @@ library Balances {
   /** Get balance (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (uint256 balance) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -117,7 +120,9 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -135,7 +140,9 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -153,7 +160,9 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Balances")));
 bytes32 constant BalancesTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library Balances {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/Balances.sol
+++ b/packages/world/src/modules/core/tables/Balances.sol
@@ -90,7 +90,7 @@ library Balances {
 
   /** Get balance */
   function get(bytes16 namespace) internal view returns (uint256 balance) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -99,7 +99,7 @@ library Balances {
 
   /** Get balance */
   function _get(bytes16 namespace) internal view returns (uint256 balance) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -108,7 +108,7 @@ library Balances {
 
   /** Get balance (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (uint256 balance) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -120,7 +120,7 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -140,7 +140,7 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -160,7 +160,7 @@ library Balances {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -93,6 +93,7 @@ library FunctionSelectors {
   /** Get resourceSelector */
   function getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -101,6 +102,7 @@ library FunctionSelectors {
   /** Get resourceSelector */
   function _getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -112,6 +114,7 @@ library FunctionSelectors {
     bytes4 functionSelector
   ) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -122,7 +125,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -140,7 +145,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -158,7 +165,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,
@@ -174,6 +183,7 @@ library FunctionSelectors {
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
     return (bytes4(_blob));
@@ -182,6 +192,7 @@ library FunctionSelectors {
   /** Get systemFunctionSelector */
   function _getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
     return (bytes4(_blob));
@@ -193,6 +204,7 @@ library FunctionSelectors {
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
     return (bytes4(_blob));
@@ -203,7 +215,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       4,
@@ -221,7 +235,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       4,
@@ -239,7 +255,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       4,

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -73,6 +73,18 @@ library FunctionSelectors {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -83,6 +95,14 @@ library FunctionSelectors {
     bytes32 _keyHash = keccak256(abi.encode(functionSelector));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
+  }
+
+  /** Get resourceSelector */
+  function _getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
@@ -104,6 +124,24 @@ library FunctionSelectors {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set resourceSelector */
+  function _setResourceSelector(bytes4 functionSelector, bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(functionSelector);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -141,6 +179,14 @@ library FunctionSelectors {
     return (bytes4(_blob));
   }
 
+  /** Get systemFunctionSelector */
+  function _getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
+    return (bytes4(_blob));
+  }
+
   /** Get systemFunctionSelector (using the specified store) */
   function getSystemFunctionSelector(
     IStore _store,
@@ -159,6 +205,24 @@ library FunctionSelectors {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      4,
+      32,
+      abi.encodePacked((systemFunctionSelector)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
+  }
+
+  /** Set systemFunctionSelector */
+  function _setSystemFunctionSelector(bytes4 functionSelector, bytes4 systemFunctionSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(functionSelector);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       4,
       32,
@@ -199,6 +263,17 @@ library FunctionSelectors {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(
+    bytes4 functionSelector
+  ) internal view returns (bytes32 resourceSelector, bytes4 systemFunctionSelector) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(functionSelector);
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(
     IStore _store,
@@ -219,6 +294,16 @@ library FunctionSelectors {
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
+  /** Set the full data using individual values */
+  function _set(bytes4 functionSelector, bytes32 resourceSelector, bytes4 systemFunctionSelector) internal {
+    bytes memory _data = encode(resourceSelector, systemFunctionSelector);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(functionSelector);
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
   /** Set the full data using individual values (using the specified store) */
@@ -262,6 +347,14 @@ library FunctionSelectors {
     _keyTuple[0] = bytes32(functionSelector);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes4 functionSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(functionSelector);
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -92,7 +92,7 @@ library FunctionSelectors {
 
   /** Get resourceSelector */
   function getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -101,7 +101,7 @@ library FunctionSelectors {
 
   /** Get resourceSelector */
   function _getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -113,7 +113,7 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -125,7 +125,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -145,7 +145,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -165,7 +165,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -182,7 +182,7 @@ library FunctionSelectors {
 
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
@@ -191,7 +191,7 @@ library FunctionSelectors {
 
   /** Get systemFunctionSelector */
   function _getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 4, 32);
@@ -203,7 +203,7 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
@@ -215,7 +215,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -235,7 +235,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -255,7 +255,7 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(functionSelector)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -80,10 +80,8 @@ library FunctionSelectors {
 
   /** Get resourceSelector */
   function getResourceSelector(bytes4 functionSelector) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(functionSelector);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
@@ -93,10 +91,8 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(functionSelector);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
@@ -139,10 +135,8 @@ library FunctionSelectors {
 
   /** Get systemFunctionSelector */
   function getSystemFunctionSelector(bytes4 functionSelector) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(functionSelector);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
     return (bytes4(_blob));
   }
@@ -152,10 +146,8 @@ library FunctionSelectors {
     IStore _store,
     bytes4 functionSelector
   ) internal view returns (bytes4 systemFunctionSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(functionSelector);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(functionSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
     return (bytes4(_blob));
   }

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -83,8 +83,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Get resourceSelector (using the specified store) */
@@ -95,8 +96,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Set resourceSelector */
@@ -104,7 +106,17 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set resourceSelector (using the specified store) */
@@ -112,7 +124,17 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Get systemFunctionSelector */
@@ -120,8 +142,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (Bytes.slice4(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 4, 32);
+    return (bytes4(_blob));
   }
 
   /** Get systemFunctionSelector (using the specified store) */
@@ -132,8 +155,9 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (Bytes.slice4(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 4, 32);
+    return (bytes4(_blob));
   }
 
   /** Set systemFunctionSelector */
@@ -141,7 +165,17 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((systemFunctionSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      4,
+      32,
+      abi.encodePacked((systemFunctionSelector)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set systemFunctionSelector (using the specified store) */
@@ -149,7 +183,17 @@ library FunctionSelectors {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(functionSelector);
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((systemFunctionSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      4,
+      32,
+      abi.encodePacked((systemFunctionSelector)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Get the full data */

--- a/packages/world/src/modules/core/tables/FunctionSelectors.sol
+++ b/packages/world/src/modules/core/tables/FunctionSelectors.sol
@@ -21,14 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("FunctionSelector")));
 bytes32 constant FunctionSelectorsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0024020020040000000000000000000000000000000000000000000000000000
+);
+
 library FunctionSelectors {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](2);
-    _fieldLayout[0] = 32;
-    _fieldLayout[1] = 4;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -93,7 +93,7 @@ library ResourceType {
 
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
@@ -102,7 +102,7 @@ library ResourceType {
 
   /** Get resourceType */
   function _get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
@@ -111,7 +111,7 @@ library ResourceType {
 
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
@@ -123,7 +123,7 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -143,7 +143,7 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -163,7 +163,7 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -81,20 +81,16 @@ library ResourceType {
 
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
   }
 
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
   }

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -74,6 +74,18 @@ library ResourceType {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -84,6 +96,14 @@ library ResourceType {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return Resource(uint8(bytes1(_blob)));
+  }
+
+  /** Get resourceType */
+  function _get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
   }
 
@@ -102,6 +122,24 @@ library ResourceType {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      0,
+      abi.encodePacked(uint8(resourceType)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set resourceType */
+  function _set(bytes32 resourceSelector, Resource resourceType) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       0,
@@ -150,6 +188,14 @@ library ResourceType {
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -24,13 +24,14 @@ import { Resource } from "./../../../Types.sol";
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("ResourceType")));
 bytes32 constant ResourceTypeTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0001010001000000000000000000000000000000000000000000000000000000
+);
+
 library ResourceType {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/ResourceType.sol
+++ b/packages/world/src/modules/core/tables/ResourceType.sol
@@ -94,6 +94,7 @@ library ResourceType {
   /** Get resourceType */
   function get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
@@ -102,6 +103,7 @@ library ResourceType {
   /** Get resourceType */
   function _get(bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
@@ -110,6 +112,7 @@ library ResourceType {
   /** Get resourceType (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (Resource resourceType) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return Resource(uint8(bytes1(_blob)));
@@ -120,7 +123,9 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -138,7 +143,9 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -156,7 +163,9 @@ library ResourceType {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       1,

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -90,28 +90,31 @@ library SystemHooks {
 
   /** Get value */
   function get(bytes32 resourceSelector) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value */
   function _get(bytes32 resourceSelector) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (bytes21[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -141,10 +144,10 @@ library SystemHooks {
 
   /** Get the length of value */
   function length(bytes32 resourceSelector) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -152,10 +155,10 @@ library SystemHooks {
 
   /** Get the length of value */
   function _length(bytes32 resourceSelector) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -163,10 +166,10 @@ library SystemHooks {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 resourceSelector) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 21;
     }
@@ -177,18 +180,11 @@ library SystemHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 resourceSelector, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -198,18 +194,11 @@ library SystemHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 resourceSelector, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }
@@ -219,18 +208,11 @@ library SystemHooks {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 resourceSelector, uint256 _index) internal view returns (bytes21) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 21,
-        (_index + 1) * 21
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 21, (_index + 1) * 21);
       return (Bytes.slice21(_blob, 0));
     }
   }

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -71,6 +71,18 @@ library SystemHooks {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -82,6 +94,15 @@ library SystemHooks {
     _keyTuple[0] = resourceSelector;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
+  }
+
+  /** Get value */
+  function _get(bytes32 resourceSelector) internal view returns (bytes21[] memory value) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes21());
   }
 
@@ -102,6 +123,14 @@ library SystemHooks {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
   }
 
+  /** Set value */
+  function _set(bytes32 resourceSelector, bytes21[] memory value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
+  }
+
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 resourceSelector, bytes21[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -116,6 +145,17 @@ library SystemHooks {
     _keyTuple[0] = resourceSelector;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 21;
+    }
+  }
+
+  /** Get the length of value */
+  function _length(bytes32 resourceSelector) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 21;
     }
@@ -142,6 +182,27 @@ library SystemHooks {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 21,
+        (_index + 1) * 21
+      );
+      return (Bytes.slice21(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of value
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItem(bytes32 resourceSelector, uint256 _index) internal view returns (bytes21) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -182,6 +243,14 @@ library SystemHooks {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to value */
+  function _push(bytes32 resourceSelector, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 resourceSelector, bytes21 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -196,6 +265,14 @@ library SystemHooks {
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
+  }
+
+  /** Pop an element from value */
+  function _pop(bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 21, getFieldLayout());
   }
 
   /** Pop an element from value (using the specified store) */
@@ -216,6 +293,19 @@ library SystemHooks {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of value at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _update(bytes32 resourceSelector, uint256 _index, bytes21 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 21, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -257,6 +347,14 @@ library SystemHooks {
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library SystemHooks {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/world/src/modules/core/tables/SystemHooks.sol
+++ b/packages/world/src/modules/core/tables/SystemHooks.sol
@@ -21,12 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("SystemHooks")));
 bytes32 constant SystemHooksTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library SystemHooks {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -78,20 +78,16 @@ library SystemRegistry {
 
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(system));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(uint256(uint160(system)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(system));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -71,6 +71,18 @@ library SystemRegistry {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -81,6 +93,14 @@ library SystemRegistry {
     bytes32 _keyHash = keccak256(abi.encode(system));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
+  }
+
+  /** Get resourceSelector */
+  function _get(address system) internal view returns (bytes32 resourceSelector) {
+    bytes32 _keyHash = keccak256(abi.encode(system));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
@@ -99,6 +119,24 @@ library SystemRegistry {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set resourceSelector */
+  function _set(address system, bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -147,6 +185,14 @@ library SystemRegistry {
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(address system) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(uint256(uint160(system)));
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("SystemRegistry")));
 bytes32 constant SystemRegistryTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library SystemRegistry {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -90,7 +90,7 @@ library SystemRegistry {
 
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -99,7 +99,7 @@ library SystemRegistry {
 
   /** Get resourceSelector */
   function _get(address system) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -108,7 +108,7 @@ library SystemRegistry {
 
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -120,7 +120,7 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -140,7 +140,7 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -160,7 +160,7 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    bytes32 _keyHash = keccak256(abi.encode(system));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(uint256(uint160(system)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -80,8 +80,9 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Get resourceSelector (using the specified store) */
@@ -89,8 +90,9 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Set resourceSelector */
@@ -98,7 +100,17 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set resourceSelector (using the specified store) */
@@ -106,7 +118,17 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((resourceSelector)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((resourceSelector)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/modules/core/tables/SystemRegistry.sol
+++ b/packages/world/src/modules/core/tables/SystemRegistry.sol
@@ -91,6 +91,7 @@ library SystemRegistry {
   /** Get resourceSelector */
   function get(address system) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(system));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -99,6 +100,7 @@ library SystemRegistry {
   /** Get resourceSelector */
   function _get(address system) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(system));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -107,6 +109,7 @@ library SystemRegistry {
   /** Get resourceSelector (using the specified store) */
   function get(IStore _store, address system) internal view returns (bytes32 resourceSelector) {
     bytes32 _keyHash = keccak256(abi.encode(system));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -117,7 +120,9 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(system));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -135,7 +140,9 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(system));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -153,7 +160,9 @@ library SystemRegistry {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(uint256(uint160(system)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(system));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -73,6 +73,18 @@ library Systems {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -83,6 +95,14 @@ library Systems {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
+  }
+
+  /** Get system */
+  function _getSystem(bytes32 resourceSelector) internal view returns (address system) {
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
 
@@ -101,6 +121,24 @@ library Systems {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((system)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set system */
+  function _setSystem(bytes32 resourceSelector, address system) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       20,
       0,
@@ -138,6 +176,14 @@ library Systems {
     return (_toBool(uint8(bytes1(_blob))));
   }
 
+  /** Get publicAccess */
+  function _getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 20);
+    return (_toBool(uint8(bytes1(_blob))));
+  }
+
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
@@ -153,6 +199,24 @@ library Systems {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      20,
+      abi.encodePacked((publicAccess)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
+  }
+
+  /** Set publicAccess */
+  function _setPublicAccess(bytes32 resourceSelector, bool publicAccess) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       20,
@@ -191,6 +255,15 @@ library Systems {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector) internal view returns (address system, bool publicAccess) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -208,6 +281,16 @@ library Systems {
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
+  /** Set the full data using individual values */
+  function _set(bytes32 resourceSelector, address system, bool publicAccess) internal {
+    bytes memory _data = encode(system, publicAccess);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
   /** Set the full data using individual values (using the specified store) */
@@ -246,6 +329,14 @@ library Systems {
     _keyTuple[0] = resourceSelector;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 resourceSelector) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = resourceSelector;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -80,20 +80,16 @@ library Systems {
 
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
 
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
@@ -136,20 +132,16 @@ library Systems {
 
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 20);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = resourceSelector;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 20);
     return (_toBool(uint8(bytes1(_blob))));
   }

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -21,14 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Systems")));
 bytes32 constant SystemsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0015020014010000000000000000000000000000000000000000000000000000
+);
+
 library Systems {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](2);
-    _fieldLayout[0] = 20;
-    _fieldLayout[1] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -83,8 +83,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Get system (using the specified store) */
@@ -92,8 +93,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Set system */
@@ -101,7 +103,17 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((system)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set system (using the specified store) */
@@ -109,7 +121,17 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((system)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((system)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Get publicAccess */
@@ -117,8 +139,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 20);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get publicAccess (using the specified store) */
@@ -126,8 +149,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 20);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Set publicAccess */
@@ -135,7 +159,17 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      20,
+      abi.encodePacked((publicAccess)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set publicAccess (using the specified store) */
@@ -143,7 +177,17 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((publicAccess)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      1,
+      20,
+      abi.encodePacked((publicAccess)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Get the full data */

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -92,7 +92,7 @@ library Systems {
 
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
@@ -101,7 +101,7 @@ library Systems {
 
   /** Get system */
   function _getSystem(bytes32 resourceSelector) internal view returns (address system) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
@@ -110,7 +110,7 @@ library Systems {
 
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
@@ -122,7 +122,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -142,7 +142,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -162,7 +162,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
@@ -179,7 +179,7 @@ library Systems {
 
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 20);
@@ -188,7 +188,7 @@ library Systems {
 
   /** Get publicAccess */
   function _getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 20);
@@ -197,7 +197,7 @@ library Systems {
 
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 20);
@@ -209,7 +209,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -229,7 +229,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -249,7 +249,7 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -93,6 +93,7 @@ library Systems {
   /** Get system */
   function getSystem(bytes32 resourceSelector) internal view returns (address system) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -101,6 +102,7 @@ library Systems {
   /** Get system */
   function _getSystem(bytes32 resourceSelector) internal view returns (address system) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -109,6 +111,7 @@ library Systems {
   /** Get system (using the specified store) */
   function getSystem(IStore _store, bytes32 resourceSelector) internal view returns (address system) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -119,7 +122,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       20,
@@ -137,7 +142,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       20,
@@ -155,7 +162,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       20,
@@ -171,6 +180,7 @@ library Systems {
   /** Get publicAccess */
   function getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 20);
     return (_toBool(uint8(bytes1(_blob))));
@@ -179,6 +189,7 @@ library Systems {
   /** Get publicAccess */
   function _getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 20);
     return (_toBool(uint8(bytes1(_blob))));
@@ -187,6 +198,7 @@ library Systems {
   /** Get publicAccess (using the specified store) */
   function getPublicAccess(IStore _store, bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 20);
     return (_toBool(uint8(bytes1(_blob))));
@@ -197,7 +209,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -215,7 +229,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -233,7 +249,9 @@ library Systems {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = resourceSelector;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       1,

--- a/packages/world/src/modules/core/tables/Systems.sol
+++ b/packages/world/src/modules/core/tables/Systems.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Systems {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -103,9 +105,15 @@ library Systems {
   function _getSystem(bytes32 resourceSelector) internal view returns (address system) {
     bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
-    return (address(bytes20(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    address _blob;
+    assembly {
+      _blob := shr(96, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get system (using the specified store) */
@@ -190,9 +198,15 @@ library Systems {
   function _getPublicAccess(bytes32 resourceSelector) internal view returns (bool publicAccess) {
     bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 20);
-    return (_toBool(uint8(bytes1(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bool _blob;
+    assembly {
+      _blob := shr(88, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get publicAccess (using the specified store) */

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -34,6 +34,8 @@ struct KeysInTableData {
 }
 
 library KeysInTable {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -87,6 +87,18 @@ library KeysInTable {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -98,6 +110,15 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
+  /** Get keys0 */
+  function _getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -118,6 +139,14 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)), getFieldLayout());
   }
 
+  /** Set keys0 */
+  function _setKeys0(bytes32 sourceTable, bytes32[] memory keys0) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((keys0)), getFieldLayout());
+  }
+
   /** Set keys0 (using the specified store) */
   function setKeys0(IStore _store, bytes32 sourceTable, bytes32[] memory keys0) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -132,6 +161,17 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
+  /** Get the length of keys0 */
+  function _lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 32;
     }
@@ -158,6 +198,27 @@ library KeysInTable {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of keys0
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemKeys0(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -198,6 +259,14 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to keys0 */
+  function _pushKeys0(bytes32 sourceTable, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to keys0 (using the specified store) */
   function pushKeys0(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -212,6 +281,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 32, getFieldLayout());
+  }
+
+  /** Pop an element from keys0 */
+  function _popKeys0(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 32, getFieldLayout());
   }
 
   /** Pop an element from keys0 (using the specified store) */
@@ -232,6 +309,19 @@ library KeysInTable {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of keys0 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateKeys0(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 32, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -257,6 +347,15 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
+  /** Get keys1 */
+  function _getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
   /** Get keys1 (using the specified store) */
   function getKeys1(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -274,6 +373,14 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)), getFieldLayout());
   }
 
+  /** Set keys1 */
+  function _setKeys1(bytes32 sourceTable, bytes32[] memory keys1) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setField(_tableId, _keyTuple, 1, EncodeArray.encode((keys1)), getFieldLayout());
+  }
+
   /** Set keys1 (using the specified store) */
   function setKeys1(IStore _store, bytes32 sourceTable, bytes32[] memory keys1) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -288,6 +395,17 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
+  /** Get the length of keys1 */
+  function _lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
     unchecked {
       return _byteLength / 32;
     }
@@ -314,6 +432,27 @@ library KeysInTable {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        1,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of keys1
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemKeys1(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         1,
@@ -354,6 +493,14 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to keys1 */
+  function _pushKeys1(bytes32 sourceTable, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 1, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to keys1 (using the specified store) */
   function pushKeys1(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -368,6 +515,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 1, 32, getFieldLayout());
+  }
+
+  /** Pop an element from keys1 */
+  function _popKeys1(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 1, 32, getFieldLayout());
   }
 
   /** Pop an element from keys1 (using the specified store) */
@@ -388,6 +543,19 @@ library KeysInTable {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of keys1 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateKeys1(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 1, _index * 32, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -413,6 +581,15 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
+  /** Get keys2 */
+  function _getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
   /** Get keys2 (using the specified store) */
   function getKeys2(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -430,6 +607,14 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)), getFieldLayout());
   }
 
+  /** Set keys2 */
+  function _setKeys2(bytes32 sourceTable, bytes32[] memory keys2) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setField(_tableId, _keyTuple, 2, EncodeArray.encode((keys2)), getFieldLayout());
+  }
+
   /** Set keys2 (using the specified store) */
   function setKeys2(IStore _store, bytes32 sourceTable, bytes32[] memory keys2) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -444,6 +629,17 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
+  /** Get the length of keys2 */
+  function _lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
     unchecked {
       return _byteLength / 32;
     }
@@ -470,6 +666,27 @@ library KeysInTable {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        2,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of keys2
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemKeys2(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         2,
@@ -510,6 +727,14 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to keys2 */
+  function _pushKeys2(bytes32 sourceTable, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 2, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to keys2 (using the specified store) */
   function pushKeys2(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -524,6 +749,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 2, 32, getFieldLayout());
+  }
+
+  /** Pop an element from keys2 */
+  function _popKeys2(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 2, 32, getFieldLayout());
   }
 
   /** Pop an element from keys2 (using the specified store) */
@@ -544,6 +777,19 @@ library KeysInTable {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of keys2 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateKeys2(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 2, _index * 32, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -569,6 +815,15 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
+  /** Get keys3 */
+  function _getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
   /** Get keys3 (using the specified store) */
   function getKeys3(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -586,6 +841,14 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)), getFieldLayout());
   }
 
+  /** Set keys3 */
+  function _setKeys3(bytes32 sourceTable, bytes32[] memory keys3) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setField(_tableId, _keyTuple, 3, EncodeArray.encode((keys3)), getFieldLayout());
+  }
+
   /** Set keys3 (using the specified store) */
   function setKeys3(IStore _store, bytes32 sourceTable, bytes32[] memory keys3) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -600,6 +863,17 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
+  /** Get the length of keys3 */
+  function _lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
     unchecked {
       return _byteLength / 32;
     }
@@ -626,6 +900,27 @@ library KeysInTable {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        3,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of keys3
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemKeys3(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         3,
@@ -666,6 +961,14 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to keys3 */
+  function _pushKeys3(bytes32 sourceTable, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 3, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to keys3 (using the specified store) */
   function pushKeys3(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -680,6 +983,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 3, 32, getFieldLayout());
+  }
+
+  /** Pop an element from keys3 */
+  function _popKeys3(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 3, 32, getFieldLayout());
   }
 
   /** Pop an element from keys3 (using the specified store) */
@@ -700,6 +1011,19 @@ library KeysInTable {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of keys3 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateKeys3(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 3, _index * 32, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -725,6 +1049,15 @@ library KeysInTable {
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
+  /** Get keys4 */
+  function _getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
+  }
+
   /** Get keys4 (using the specified store) */
   function getKeys4(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -742,6 +1075,14 @@ library KeysInTable {
     StoreSwitch.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)), getFieldLayout());
   }
 
+  /** Set keys4 */
+  function _setKeys4(bytes32 sourceTable, bytes32[] memory keys4) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setField(_tableId, _keyTuple, 4, EncodeArray.encode((keys4)), getFieldLayout());
+  }
+
   /** Set keys4 (using the specified store) */
   function setKeys4(IStore _store, bytes32 sourceTable, bytes32[] memory keys4) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -756,6 +1097,17 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    unchecked {
+      return _byteLength / 32;
+    }
+  }
+
+  /** Get the length of keys4 */
+  function _lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
     unchecked {
       return _byteLength / 32;
     }
@@ -782,6 +1134,27 @@ library KeysInTable {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        4,
+        getFieldLayout(),
+        _index * 32,
+        (_index + 1) * 32
+      );
+      return (Bytes.slice32(_blob, 0));
+    }
+  }
+
+  /**
+   * Get an item of keys4
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItemKeys4(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         4,
@@ -822,6 +1195,14 @@ library KeysInTable {
     StoreSwitch.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to keys4 */
+  function _pushKeys4(bytes32 sourceTable, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 4, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to keys4 (using the specified store) */
   function pushKeys4(IStore _store, bytes32 sourceTable, bytes32 _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -836,6 +1217,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 4, 32, getFieldLayout());
+  }
+
+  /** Pop an element from keys4 */
+  function _popKeys4(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 4, 32, getFieldLayout());
   }
 
   /** Pop an element from keys4 (using the specified store) */
@@ -860,6 +1249,19 @@ library KeysInTable {
   }
 
   /**
+   * Update an element of keys4 at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _updateKeys4(bytes32 sourceTable, uint256 _index, bytes32 _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 4, _index * 32, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
    * Update an element of keys4 (using the specified store) at `_index`
    * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
    */
@@ -878,6 +1280,15 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     bytes memory _blob = StoreSwitch.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
+  /** Get the full data */
+  function _get(bytes32 sourceTable) internal view returns (KeysInTableData memory _table) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
     return decode(_blob);
   }
 
@@ -907,6 +1318,23 @@ library KeysInTable {
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
+  /** Set the full data using individual values */
+  function _set(
+    bytes32 sourceTable,
+    bytes32[] memory keys0,
+    bytes32[] memory keys1,
+    bytes32[] memory keys2,
+    bytes32[] memory keys3,
+    bytes32[] memory keys4
+  ) internal {
+    bytes memory _data = encode(keys0, keys1, keys2, keys3, keys4);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
   /** Set the full data using individual values (using the specified store) */
   function set(
     IStore _store,
@@ -927,6 +1355,11 @@ library KeysInTable {
 
   /** Set the full data using the data struct */
   function set(bytes32 sourceTable, KeysInTableData memory _table) internal {
+    set(sourceTable, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
+  }
+
+  /** Set the full data using the data struct */
+  function _set(bytes32 sourceTable, KeysInTableData memory _table) internal {
     set(sourceTable, _table.keys0, _table.keys1, _table.keys2, _table.keys3, _table.keys4);
   }
 
@@ -1024,6 +1457,14 @@ library KeysInTable {
     _keyTuple[0] = sourceTable;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 sourceTable) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = sourceTable;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -106,28 +106,31 @@ library KeysInTable {
 
   /** Get keys0 */
   function getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys0 */
   function _getKeys0(bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys0 (using the specified store) */
   function getKeys0(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys0) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -157,10 +160,10 @@ library KeysInTable {
 
   /** Get the length of keys0 */
   function lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -168,10 +171,10 @@ library KeysInTable {
 
   /** Get the length of keys0 */
   function _lengthKeys0(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -179,10 +182,10 @@ library KeysInTable {
 
   /** Get the length of keys0 (using the specified store) */
   function lengthKeys0(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -193,18 +196,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys0(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -214,18 +210,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemKeys0(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -235,18 +224,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys0(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -340,28 +322,31 @@ library KeysInTable {
 
   /** Get keys1 */
   function getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys1 */
   function _getKeys1(bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys1 (using the specified store) */
   function getKeys1(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys1) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 1);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -391,10 +376,10 @@ library KeysInTable {
 
   /** Get the length of keys1 */
   function lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 32;
     }
@@ -402,10 +387,10 @@ library KeysInTable {
 
   /** Get the length of keys1 */
   function _lengthKeys1(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 32;
     }
@@ -413,10 +398,10 @@ library KeysInTable {
 
   /** Get the length of keys1 (using the specified store) */
   function lengthKeys1(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 1, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 1);
     unchecked {
       return _byteLength / 32;
     }
@@ -427,18 +412,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys1(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -448,18 +426,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemKeys1(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -469,18 +440,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys1(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 1);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        1,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -574,28 +538,31 @@ library KeysInTable {
 
   /** Get keys2 */
   function getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys2 */
   function _getKeys2(bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys2 (using the specified store) */
   function getKeys2(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys2) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 2);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -625,10 +592,10 @@ library KeysInTable {
 
   /** Get the length of keys2 */
   function lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 32;
     }
@@ -636,10 +603,10 @@ library KeysInTable {
 
   /** Get the length of keys2 */
   function _lengthKeys2(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 32;
     }
@@ -647,10 +614,10 @@ library KeysInTable {
 
   /** Get the length of keys2 (using the specified store) */
   function lengthKeys2(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 2, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 2);
     unchecked {
       return _byteLength / 32;
     }
@@ -661,18 +628,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys2(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -682,18 +642,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemKeys2(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -703,18 +656,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys2(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 2);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        2,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -808,28 +754,31 @@ library KeysInTable {
 
   /** Get keys3 */
   function getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys3 */
   function _getKeys3(bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys3 (using the specified store) */
   function getKeys3(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys3) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 3);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -859,10 +808,10 @@ library KeysInTable {
 
   /** Get the length of keys3 */
   function lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 32;
     }
@@ -870,10 +819,10 @@ library KeysInTable {
 
   /** Get the length of keys3 */
   function _lengthKeys3(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 32;
     }
@@ -881,10 +830,10 @@ library KeysInTable {
 
   /** Get the length of keys3 (using the specified store) */
   function lengthKeys3(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 3, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 3);
     unchecked {
       return _byteLength / 32;
     }
@@ -895,18 +844,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys3(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -916,18 +858,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemKeys3(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -937,18 +872,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys3(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 3);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        3,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -1042,28 +970,31 @@ library KeysInTable {
 
   /** Get keys4 */
   function getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys4 */
   function _getKeys4(bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keys4 (using the specified store) */
   function getKeys4(IStore _store, bytes32 sourceTable) internal view returns (bytes32[] memory keys4) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 4);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -1093,10 +1024,10 @@ library KeysInTable {
 
   /** Get the length of keys4 */
   function lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 32;
     }
@@ -1104,10 +1035,10 @@ library KeysInTable {
 
   /** Get the length of keys4 */
   function _lengthKeys4(bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 32;
     }
@@ -1115,10 +1046,10 @@ library KeysInTable {
 
   /** Get the length of keys4 (using the specified store) */
   function lengthKeys4(IStore _store, bytes32 sourceTable) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 4, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 4);
     unchecked {
       return _byteLength / 32;
     }
@@ -1129,18 +1060,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys4(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -1150,18 +1074,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItemKeys4(bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -1171,18 +1088,11 @@ library KeysInTable {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItemKeys4(IStore _store, bytes32 sourceTable, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = sourceTable;
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 4);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        4,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }

--- a/packages/world/src/modules/keysintable/tables/KeysInTable.sol
+++ b/packages/world/src/modules/keysintable/tables/KeysInTable.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("KeysInTable")));
 bytes32 constant KeysInTableTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000500000000000000000000000000000000000000000000000000000000
+);
+
 struct KeysInTableData {
   bytes32[] keys0;
   bytes32[] keys1;
@@ -32,9 +36,7 @@ struct KeysInTableData {
 library KeysInTable {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 5);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -86,8 +86,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get has (using the specified store) */
@@ -96,8 +97,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Set has */
@@ -106,7 +108,17 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      0,
+      abi.encodePacked((has)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set has (using the specified store) */
@@ -115,7 +127,8 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((has)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get index */
@@ -124,8 +137,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint40(Bytes.slice5(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 5, 1);
+    return (uint40(bytes5(_blob)));
   }
 
   /** Get index (using the specified store) */
@@ -134,8 +148,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 1, getFieldLayout());
-    return (uint40(Bytes.slice5(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 5, 1);
+    return (uint40(bytes5(_blob)));
   }
 
   /** Set index */
@@ -144,7 +159,17 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      5,
+      1,
+      abi.encodePacked((index)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
   }
 
   /** Set index (using the specified store) */
@@ -153,7 +178,8 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    _store.setField(_tableId, _keyTuple, 1, abi.encodePacked((index)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 5, 1, abi.encodePacked((index)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 
   /** Get the full data */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -82,22 +82,16 @@ library UsedKeysIndex {
 
   /** Get has */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get has (using the specified store) */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
@@ -133,22 +127,16 @@ library UsedKeysIndex {
 
   /** Get index */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
   }
 
   /** Get index (using the specified store) */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = sourceTable;
-    _keyTuple[1] = keysHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
   }

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -75,6 +75,18 @@ library UsedKeysIndex {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -85,6 +97,14 @@ library UsedKeysIndex {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
+  }
+
+  /** Get has */
+  function _getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
@@ -115,6 +135,16 @@ library UsedKeysIndex {
     );
   }
 
+  /** Set has */
+  function _setHas(bytes32 sourceTable, bytes32 keysHash, bool has) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
+  }
+
   /** Set has (using the specified store) */
   function setHas(IStore _store, bytes32 sourceTable, bytes32 keysHash, bool has) internal {
     bytes32[] memory _keyTuple = new bytes32[](2);
@@ -130,6 +160,14 @@ library UsedKeysIndex {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 5, 1);
+    return (uint40(bytes5(_blob)));
+  }
+
+  /** Get index */
+  function _getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
   }
 
@@ -149,6 +187,25 @@ library UsedKeysIndex {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      5,
+      1,
+      abi.encodePacked((index)),
+      _tableId,
+      _keyTuple,
+      1,
+      getFieldLayout()
+    );
+  }
+
+  /** Set index */
+  function _setIndex(bytes32 sourceTable, bytes32 keysHash, uint40 index) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       5,
       1,
@@ -180,6 +237,16 @@ library UsedKeysIndex {
     return decode(_blob);
   }
 
+  /** Get the full data */
+  function _get(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
+
+    bytes memory _blob = StoreCore.getRecord(_tableId, _keyTuple, getFieldLayout());
+    return decode(_blob);
+  }
+
   /** Get the full data (using the specified store) */
   function get(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has, uint40 index) {
     bytes32[] memory _keyTuple = new bytes32[](2);
@@ -199,6 +266,17 @@ library UsedKeysIndex {
     _keyTuple[1] = keysHash;
 
     StoreSwitch.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
+  }
+
+  /** Set the full data using individual values */
+  function _set(bytes32 sourceTable, bytes32 keysHash, bool has, uint40 index) internal {
+    bytes memory _data = encode(has, index);
+
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
+
+    StoreCore.setRecord(_tableId, _keyTuple, _data, getFieldLayout());
   }
 
   /** Set the full data using individual values (using the specified store) */
@@ -240,6 +318,15 @@ library UsedKeysIndex {
     _keyTuple[1] = keysHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 sourceTable, bytes32 keysHash) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = sourceTable;
+    _keyTuple[1] = keysHash;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -95,6 +95,7 @@ library UsedKeysIndex {
   /** Get has */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -103,6 +104,7 @@ library UsedKeysIndex {
   /** Get has */
   function _getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -111,6 +113,7 @@ library UsedKeysIndex {
   /** Get has (using the specified store) */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -122,7 +125,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -141,7 +146,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
@@ -151,13 +158,16 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Get index */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
@@ -166,6 +176,7 @@ library UsedKeysIndex {
   /** Get index */
   function _getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
@@ -174,6 +185,7 @@ library UsedKeysIndex {
   /** Get index (using the specified store) */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 5, 1);
     return (uint40(bytes5(_blob)));
@@ -185,7 +197,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       5,
@@ -204,7 +218,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       5,
@@ -223,7 +239,9 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 5, 1, abi.encodePacked((index)), _tableId, _keyTuple, 1, getFieldLayout());
   }
 

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library UsedKeysIndex {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -105,9 +107,15 @@ library UsedKeysIndex {
   function _getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
     bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
-    return (_toBool(uint8(bytes1(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bool _blob;
+    assembly {
+      _blob := shr(248, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get has (using the specified store) */
@@ -177,9 +185,15 @@ library UsedKeysIndex {
   function _getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
     bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 5, 1);
-    return (uint40(bytes5(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint40 _blob;
+    assembly {
+      _blob := shr(208, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get index (using the specified store) */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -21,14 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("UsedKeysIndex")));
 bytes32 constant UsedKeysIndexTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0006020001050000000000000000000000000000000000000000000000000000
+);
+
 library UsedKeysIndex {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](2);
-    _fieldLayout[0] = 1;
-    _fieldLayout[1] = 5;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -94,7 +94,7 @@ library UsedKeysIndex {
 
   /** Get has */
   function getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
@@ -103,7 +103,7 @@ library UsedKeysIndex {
 
   /** Get has */
   function _getHas(bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
@@ -112,7 +112,7 @@ library UsedKeysIndex {
 
   /** Get has (using the specified store) */
   function getHas(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (bool has) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
@@ -125,7 +125,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -146,7 +146,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -158,7 +158,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((has)), _tableId, _keyTuple, 0, getFieldLayout());
@@ -166,7 +166,7 @@ library UsedKeysIndex {
 
   /** Get index */
   function getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 5, 1);
@@ -175,7 +175,7 @@ library UsedKeysIndex {
 
   /** Get index */
   function _getIndex(bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 5, 1);
@@ -184,7 +184,7 @@ library UsedKeysIndex {
 
   /** Get index (using the specified store) */
   function getIndex(IStore _store, bytes32 sourceTable, bytes32 keysHash) internal view returns (uint40 index) {
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 5, 1);
@@ -197,7 +197,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -218,7 +218,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -239,7 +239,7 @@ library UsedKeysIndex {
     _keyTuple[0] = sourceTable;
     _keyTuple[1] = keysHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(sourceTable, keysHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(sourceTable, keysHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 5, 1, abi.encodePacked((index)), _tableId, _keyTuple, 1, getFieldLayout());

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -87,19 +87,21 @@ library KeysWithValue {
 
   /** Get keysWithValue */
   function get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
   /** Get keysWithValue */
   function _get(bytes32 _tableId, bytes32 valueHash) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -109,10 +111,11 @@ library KeysWithValue {
     bytes32 _tableId,
     bytes32 valueHash
   ) internal view returns (bytes32[] memory keysWithValue) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_bytes32());
   }
 
@@ -142,10 +145,10 @@ library KeysWithValue {
 
   /** Get the length of keysWithValue */
   function length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -153,10 +156,10 @@ library KeysWithValue {
 
   /** Get the length of keysWithValue */
   function _length(bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -164,10 +167,10 @@ library KeysWithValue {
 
   /** Get the length of keysWithValue (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 valueHash) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 32;
     }
@@ -178,18 +181,11 @@ library KeysWithValue {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -199,18 +195,11 @@ library KeysWithValue {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }
@@ -220,18 +209,11 @@ library KeysWithValue {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 _tableId, bytes32 valueHash, uint256 _index) internal view returns (bytes32) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = valueHash;
+    bytes32 _keyHash = keccak256(abi.encodePacked(valueHash));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 32,
-        (_index + 1) * 32
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 32, (_index + 1) * 32);
       return (Bytes.slice32(_blob, 0));
     }
   }

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -23,6 +23,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library KeysWithValue {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
+++ b/packages/world/src/modules/keyswithvalue/tables/KeysWithValue.sol
@@ -18,12 +18,14 @@ import { FieldLayout, FieldLayoutLib } from "@latticexyz/store/src/FieldLayout.s
 import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library KeysWithValue {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -89,13 +89,8 @@ library CallboundDelegations {
     bytes32 resourceSelector,
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-    _keyTuple[2] = resourceSelector;
-    _keyTuple[3] = funcSelectorAndArgsHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
@@ -108,13 +103,8 @@ library CallboundDelegations {
     bytes32 resourceSelector,
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
-    bytes32[] memory _keyTuple = new bytes32[](4);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-    _keyTuple[2] = resourceSelector;
-    _keyTuple[3] = funcSelectorAndArgsHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -102,6 +102,7 @@ library CallboundDelegations {
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -115,6 +116,7 @@ library CallboundDelegations {
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -129,6 +131,7 @@ library CallboundDelegations {
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -148,7 +151,9 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -175,7 +180,9 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -203,7 +210,9 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library CallboundDelegations {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -131,9 +133,15 @@ library CallboundDelegations {
       )
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (uint256(bytes32(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get availableCalls (using the specified store) */

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -77,6 +77,18 @@ library CallboundDelegations {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -92,6 +104,19 @@ library CallboundDelegations {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /** Get availableCalls */
+  function _get(
+    address delegator,
+    address delegatee,
+    bytes32 resourceSelector,
+    bytes32 funcSelectorAndArgsHash
+  ) internal view returns (uint256 availableCalls) {
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
@@ -125,6 +150,33 @@ library CallboundDelegations {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((availableCalls)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set availableCalls */
+  function _set(
+    address delegator,
+    address delegatee,
+    bytes32 resourceSelector,
+    bytes32 funcSelectorAndArgsHash,
+    uint256 availableCalls
+  ) internal {
+    bytes32[] memory _keyTuple = new bytes32[](4);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+    _keyTuple[2] = resourceSelector;
+    _keyTuple[3] = funcSelectorAndArgsHash;
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -199,6 +251,22 @@ library CallboundDelegations {
     _keyTuple[3] = funcSelectorAndArgsHash;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(
+    address delegator,
+    address delegatee,
+    bytes32 resourceSelector,
+    bytes32 funcSelectorAndArgsHash
+  ) internal {
+    bytes32[] memory _keyTuple = new bytes32[](4);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+    _keyTuple[2] = resourceSelector;
+    _keyTuple[3] = funcSelectorAndArgsHash;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -94,8 +94,9 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Get availableCalls (using the specified store) */
@@ -112,8 +113,9 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Set availableCalls */
@@ -130,7 +132,17 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((availableCalls)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((availableCalls)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set availableCalls (using the specified store) */
@@ -148,7 +160,17 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((availableCalls)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((availableCalls)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("CallboundDelegat")));
 bytes32 constant CallboundDelegationsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library CallboundDelegations {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/CallboundDelegations.sol
@@ -101,7 +101,14 @@ library CallboundDelegations {
     bytes32 resourceSelector,
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -115,7 +122,14 @@ library CallboundDelegations {
     bytes32 resourceSelector,
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -130,7 +144,14 @@ library CallboundDelegations {
     bytes32 resourceSelector,
     bytes32 funcSelectorAndArgsHash
   ) internal view returns (uint256 availableCalls) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -151,7 +172,14 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -180,7 +208,14 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -210,7 +245,14 @@ library CallboundDelegations {
     _keyTuple[2] = resourceSelector;
     _keyTuple[3] = funcSelectorAndArgsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee, resourceSelector, funcSelectorAndArgsHash));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(
+        bytes32(uint256(uint160(delegator))),
+        bytes32(uint256(uint160(delegatee))),
+        resourceSelector,
+        funcSelectorAndArgsHash
+      )
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -83,8 +83,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Get maxTimestamp (using the specified store) */
@@ -93,8 +94,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Set maxTimestamp */
@@ -103,7 +105,17 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((maxTimestamp)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((maxTimestamp)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set maxTimestamp (using the specified store) */
@@ -112,7 +124,17 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((maxTimestamp)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((maxTimestamp)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library TimeboundDelegations {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -107,9 +109,15 @@ library TimeboundDelegations {
       abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (uint256(bytes32(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get maxTimestamp (using the specified store) */

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -80,22 +80,16 @@ library TimeboundDelegations {
 
   /** Get maxTimestamp */
   function get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
   /** Get maxTimestamp (using the specified store) */
   function get(IStore _store, address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("TimeboundDelegat")));
 bytes32 constant TimeboundDelegationsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library TimeboundDelegations {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -92,7 +92,9 @@ library TimeboundDelegations {
 
   /** Get maxTimestamp */
   function get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -101,7 +103,9 @@ library TimeboundDelegations {
 
   /** Get maxTimestamp */
   function _get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -110,7 +114,9 @@ library TimeboundDelegations {
 
   /** Get maxTimestamp (using the specified store) */
   function get(IStore _store, address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -123,7 +129,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -144,7 +152,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -165,7 +175,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -93,6 +93,7 @@ library TimeboundDelegations {
   /** Get maxTimestamp */
   function get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -101,6 +102,7 @@ library TimeboundDelegations {
   /** Get maxTimestamp */
   function _get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -109,6 +111,7 @@ library TimeboundDelegations {
   /** Get maxTimestamp (using the specified store) */
   function get(IStore _store, address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -120,7 +123,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -139,7 +144,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -158,7 +165,9 @@ library TimeboundDelegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
+++ b/packages/world/src/modules/std-delegations/tables/TimeboundDelegations.sol
@@ -73,6 +73,18 @@ library TimeboundDelegations {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -83,6 +95,14 @@ library TimeboundDelegations {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /** Get maxTimestamp */
+  function _get(address delegator, address delegatee) internal view returns (uint256 maxTimestamp) {
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
@@ -102,6 +122,25 @@ library TimeboundDelegations {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((maxTimestamp)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set maxTimestamp */
+  function _set(address delegator, address delegatee, uint256 maxTimestamp) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -153,6 +192,15 @@ library TimeboundDelegations {
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(address delegator, address delegatee) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -74,30 +74,43 @@ library UniqueEntity {
   function get(bytes32 _tableId) internal view returns (uint256 value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (uint256(Bytes.slice32(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
   }
 
   /** Set value */
   function set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((value)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -85,7 +85,7 @@ library UniqueEntity {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -94,7 +94,7 @@ library UniqueEntity {
 
   /** Get value */
   function _get(bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -103,7 +103,7 @@ library UniqueEntity {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -114,7 +114,7 @@ library UniqueEntity {
   function set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -133,7 +133,7 @@ library UniqueEntity {
   function _set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -152,7 +152,7 @@ library UniqueEntity {
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -73,18 +73,16 @@ library UniqueEntity {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -86,6 +86,7 @@ library UniqueEntity {
   /** Get value */
   function get(bytes32 _tableId) internal view returns (uint256 value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -94,6 +95,7 @@ library UniqueEntity {
   /** Get value */
   function _get(bytes32 _tableId) internal view returns (uint256 value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -102,6 +104,7 @@ library UniqueEntity {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (uint256 value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
@@ -111,7 +114,9 @@ library UniqueEntity {
   function set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -128,7 +133,9 @@ library UniqueEntity {
   function _set(bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -145,7 +152,9 @@ library UniqueEntity {
   function set(IStore _store, bytes32 _tableId, uint256 value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 32, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -23,6 +23,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library UniqueEntity {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -96,9 +98,15 @@ library UniqueEntity {
   function _get(bytes32 _tableId) internal view returns (uint256 value) {
     bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (uint256(bytes32(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    uint256 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get value (using the specified store) */

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -18,13 +18,14 @@ import { FieldLayout, FieldLayoutLib } from "@latticexyz/store/src/FieldLayout.s
 import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library UniqueEntity {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
+++ b/packages/world/src/modules/uniqueentity/tables/UniqueEntity.sol
@@ -66,6 +66,18 @@ library UniqueEntity {
     );
   }
 
+  /** Register the table with its config */
+  function _register(bytes32 _tableId) internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -76,6 +88,14 @@ library UniqueEntity {
     bytes32 _keyHash = keccak256(abi.encode());
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (uint256(bytes32(_blob)));
+  }
+
+  /** Get value */
+  function _get(bytes32 _tableId) internal view returns (uint256 value) {
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (uint256(bytes32(_blob)));
   }
 
@@ -93,6 +113,23 @@ library UniqueEntity {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((value)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set value */
+  function _set(bytes32 _tableId, uint256 value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -129,6 +166,13 @@ library UniqueEntity {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 _tableId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("Delegations")));
 bytes32 constant DelegationsTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0020010020000000000000000000000000000000000000000000000000000000
+);
+
 library Delegations {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 32;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Delegations {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -107,9 +109,15 @@ library Delegations {
       abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
     );
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
-    return (bytes32(_blob));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bytes32 _blob;
+    assembly {
+      _blob := sload(storagePointer)
+    }
+    return _blob;
   }
 
   /** Get delegationControlId (using the specified store) */

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -92,7 +92,9 @@ library Delegations {
 
   /** Get delegationControlId */
   function get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
@@ -101,7 +103,9 @@ library Delegations {
 
   /** Get delegationControlId */
   function _get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
@@ -114,7 +118,9 @@ library Delegations {
     address delegator,
     address delegatee
   ) internal view returns (bytes32 delegationControlId) {
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
@@ -127,7 +133,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -148,7 +156,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -169,7 +179,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    bytes32 _keyHash = keccak256(
+      abi.encodePacked(bytes32(uint256(uint160(delegator))), bytes32(uint256(uint160(delegatee))))
+    );
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -93,6 +93,7 @@ library Delegations {
   /** Get delegationControlId */
   function get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -101,6 +102,7 @@ library Delegations {
   /** Get delegationControlId */
   function _get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -113,6 +115,7 @@ library Delegations {
     address delegatee
   ) internal view returns (bytes32 delegationControlId) {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
@@ -124,7 +127,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       32,
@@ -143,7 +148,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       32,
@@ -162,7 +169,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       32,

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -80,11 +80,8 @@ library Delegations {
 
   /** Get delegationControlId */
   function get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
@@ -95,11 +92,8 @@ library Delegations {
     address delegator,
     address delegatee
   ) internal view returns (bytes32 delegationControlId) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
-    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -73,6 +73,18 @@ library Delegations {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -83,6 +95,14 @@ library Delegations {
     bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
+  }
+
+  /** Get delegationControlId */
+  function _get(address delegator, address delegatee) internal view returns (bytes32 delegationControlId) {
+    bytes32 _keyHash = keccak256(abi.encode(delegator, delegatee));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 32, 0);
     return (bytes32(_blob));
   }
 
@@ -106,6 +126,25 @@ library Delegations {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((delegationControlId)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set delegationControlId */
+  function _set(address delegator, address delegatee, bytes32 delegationControlId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       32,
       0,
@@ -157,6 +196,15 @@ library Delegations {
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(address delegator, address delegatee) internal {
+    bytes32[] memory _keyTuple = new bytes32[](2);
+    _keyTuple[0] = bytes32(uint256(uint160(delegator)));
+    _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/tables/Delegations.sol
+++ b/packages/world/src/tables/Delegations.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -83,8 +83,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Get delegationControlId (using the specified store) */
@@ -97,8 +98,9 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (Bytes.slice32(_blob, 0));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 32, 0);
+    return (bytes32(_blob));
   }
 
   /** Set delegationControlId */
@@ -107,7 +109,17 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((delegationControlId)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((delegationControlId)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set delegationControlId (using the specified store) */
@@ -116,7 +128,17 @@ library Delegations {
     _keyTuple[0] = bytes32(uint256(uint160(delegator)));
     _keyTuple[1] = bytes32(uint256(uint160(delegatee)));
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((delegationControlId)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      32,
+      0,
+      abi.encodePacked((delegationControlId)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -21,6 +21,10 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("InstalledModules")));
 bytes32 constant InstalledModulesTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0014010014000000000000000000000000000000000000000000000000000000
+);
+
 struct InstalledModulesData {
   address moduleAddress;
 }
@@ -28,10 +32,7 @@ struct InstalledModulesData {
 library InstalledModules {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 20;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -97,6 +97,7 @@ library InstalledModules {
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
     bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -105,6 +106,7 @@ library InstalledModules {
   /** Get moduleAddress */
   function _getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
     bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -117,6 +119,7 @@ library InstalledModules {
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
     bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -128,7 +131,9 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       20,
@@ -147,7 +152,9 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       20,
@@ -166,7 +173,9 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(
       storagePointer,
       20,

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -84,11 +84,8 @@ library InstalledModules {
 
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
@@ -99,11 +96,8 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = bytes32(moduleName);
-    _keyTuple[1] = argumentsHash;
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -87,8 +87,9 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Get moduleAddress (using the specified store) */
@@ -101,8 +102,9 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Set moduleAddress */
@@ -111,7 +113,17 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((moduleAddress)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set moduleAddress (using the specified store) */
@@ -120,7 +132,17 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((moduleAddress)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((moduleAddress)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Get the full data */

--- a/packages/world/src/tables/InstalledModules.sol
+++ b/packages/world/src/tables/InstalledModules.sol
@@ -96,7 +96,7 @@ library InstalledModules {
 
   /** Get moduleAddress */
   function getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
@@ -105,7 +105,7 @@ library InstalledModules {
 
   /** Get moduleAddress */
   function _getModuleAddress(bytes16 moduleName, bytes32 argumentsHash) internal view returns (address moduleAddress) {
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
@@ -118,7 +118,7 @@ library InstalledModules {
     bytes16 moduleName,
     bytes32 argumentsHash
   ) internal view returns (address moduleAddress) {
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
@@ -131,7 +131,7 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -152,7 +152,7 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -173,7 +173,7 @@ library InstalledModules {
     _keyTuple[0] = bytes32(moduleName);
     _keyTuple[1] = argumentsHash;
 
-    bytes32 _keyHash = keccak256(abi.encode(moduleName, argumentsHash));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(moduleName), argumentsHash));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("NamespaceOwner")));
 bytes32 constant NamespaceOwnerTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0014010014000000000000000000000000000000000000000000000000000000
+);
+
 library NamespaceOwner {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 20;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -26,6 +26,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library NamespaceOwner {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -101,9 +103,15 @@ library NamespaceOwner {
   function _get(bytes16 namespace) internal view returns (address owner) {
     bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
-    return (address(bytes20(_blob)));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    address _blob;
+    assembly {
+      _blob := shr(96, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get owner (using the specified store) */

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -91,6 +91,7 @@ library NamespaceOwner {
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -99,6 +100,7 @@ library NamespaceOwner {
   /** Get owner */
   function _get(bytes16 namespace) internal view returns (address owner) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -107,6 +109,7 @@ library NamespaceOwner {
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
@@ -117,7 +120,9 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       20,
@@ -135,7 +140,9 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       20,
@@ -153,7 +160,9 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 20, 0, abi.encodePacked((owner)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -71,6 +71,18 @@ library NamespaceOwner {
     );
   }
 
+  /** Register the table with its config */
+  function _register() internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -81,6 +93,14 @@ library NamespaceOwner {
     bytes32 _keyHash = keccak256(abi.encode(namespace));
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
+  }
+
+  /** Get owner */
+  function _get(bytes16 namespace) internal view returns (address owner) {
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
 
@@ -99,6 +119,24 @@ library NamespaceOwner {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((owner)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set owner */
+  function _set(bytes16 namespace, address owner) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(namespace);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       20,
       0,
@@ -138,6 +176,14 @@ library NamespaceOwner {
     _keyTuple[0] = bytes32(namespace);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes16 namespace) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = bytes32(namespace);
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -80,8 +80,9 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Get owner (using the specified store) */
@@ -89,8 +90,9 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (address(Bytes.slice20(_blob, 0)));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
+    return (address(bytes20(_blob)));
   }
 
   /** Set owner */
@@ -98,7 +100,17 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      20,
+      0,
+      abi.encodePacked((owner)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set owner (using the specified store) */
@@ -106,7 +118,8 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((owner)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 20, 0, abi.encodePacked((owner)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -78,20 +78,16 @@ library NamespaceOwner {
 
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(namespace);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }
 
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = bytes32(namespace);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
     return (address(bytes20(_blob)));
   }

--- a/packages/world/src/tables/NamespaceOwner.sol
+++ b/packages/world/src/tables/NamespaceOwner.sol
@@ -90,7 +90,7 @@ library NamespaceOwner {
 
   /** Get owner */
   function get(bytes16 namespace) internal view returns (address owner) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 20, 0);
@@ -99,7 +99,7 @@ library NamespaceOwner {
 
   /** Get owner */
   function _get(bytes16 namespace) internal view returns (address owner) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 20, 0);
@@ -108,7 +108,7 @@ library NamespaceOwner {
 
   /** Get owner (using the specified store) */
   function get(IStore _store, bytes16 namespace) internal view returns (address owner) {
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 20, 0);
@@ -120,7 +120,7 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -140,7 +140,7 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -160,7 +160,7 @@ library NamespaceOwner {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = bytes32(namespace);
 
-    bytes32 _keyHash = keccak256(abi.encode(namespace));
+    bytes32 _keyHash = keccak256(abi.encodePacked(bytes32(namespace)));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 20, 0, abi.encodePacked((owner)), _tableId, _keyTuple, 0, getFieldLayout());

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -93,6 +93,7 @@ library ResourceAccess {
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -101,6 +102,7 @@ library ResourceAccess {
   /** Get access */
   function _get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -109,6 +111,7 @@ library ResourceAccess {
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
     bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -120,7 +123,9 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -139,7 +144,9 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -158,7 +165,9 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((access)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -21,13 +21,14 @@ import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCou
 bytes32 constant _tableId = bytes32(abi.encodePacked(bytes16(""), bytes16("ResourceAccess")));
 bytes32 constant ResourceAccessTableId = _tableId;
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0001010001000000000000000000000000000000000000000000000000000000
+);
+
 library ResourceAccess {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -92,7 +92,7 @@ library ResourceAccess {
 
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
@@ -101,7 +101,7 @@ library ResourceAccess {
 
   /** Get access */
   function _get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
@@ -110,7 +110,7 @@ library ResourceAccess {
 
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
@@ -123,7 +123,7 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -144,7 +144,7 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -165,7 +165,7 @@ library ResourceAccess {
     _keyTuple[0] = resourceSelector;
     _keyTuple[1] = bytes32(uint256(uint160(caller)));
 
-    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    bytes32 _keyHash = keccak256(abi.encodePacked(resourceSelector, bytes32(uint256(uint160(caller)))));
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((access)), _tableId, _keyTuple, 0, getFieldLayout());

--- a/packages/world/src/tables/ResourceAccess.sol
+++ b/packages/world/src/tables/ResourceAccess.sol
@@ -80,22 +80,16 @@ library ResourceAccess {
 
   /** Get access */
   function get(bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get access (using the specified store) */
   function get(IStore _store, bytes32 resourceSelector, address caller) internal view returns (bool access) {
-    bytes32[] memory _keyTuple = new bytes32[](2);
-    _keyTuple[0] = resourceSelector;
-    _keyTuple[1] = bytes32(uint256(uint160(caller)));
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode(resourceSelector, caller));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -87,28 +87,31 @@ library AddressArray {
 
   /** Get value */
   function get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreSwitch.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get value */
   function _get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = StoreCore.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    bytes memory _blob = _store.loadDynamicField(storagePointer, lengthStoragePointer, 0);
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
@@ -138,10 +141,10 @@ library AddressArray {
 
   /** Get the length of value */
   function length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreSwitch.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 20;
     }
@@ -149,10 +152,10 @@ library AddressArray {
 
   /** Get the length of value */
   function _length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = StoreCore.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 20;
     }
@@ -160,10 +163,10 @@ library AddressArray {
 
   /** Get the length of value (using the specified store) */
   function length(IStore _store, bytes32 _tableId, bytes32 key) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
-    uint256 _byteLength = _store.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    uint256 lengthStoragePointer = StoreCoreInternal._getDynamicDataLengthLocation(_tableId, _keyHash);
+    uint256 _byteLength = _store.loadFieldLength(lengthStoragePointer, 0);
     unchecked {
       return _byteLength / 20;
     }
@@ -174,18 +177,11 @@ library AddressArray {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreSwitch.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = StoreSwitch.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }
@@ -195,18 +191,11 @@ library AddressArray {
    * (unchecked, returns invalid data if index overflows)
    */
   function _getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = StoreCore.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = StoreCore.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }
@@ -216,18 +205,11 @@ library AddressArray {
    * (unchecked, returns invalid data if index overflows)
    */
   function getItem(IStore _store, bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = key;
+    bytes32 _keyHash = keccak256(abi.encodePacked(key));
 
+    uint256 storagePointer = StoreCoreInternal._getDynamicDataLocation(_tableId, _keyHash, 0);
     unchecked {
-      bytes memory _blob = _store.getFieldSlice(
-        _tableId,
-        _keyTuple,
-        0,
-        getFieldLayout(),
-        _index * 20,
-        (_index + 1) * 20
-      );
+      bytes memory _blob = _store.loadFieldSlice(storagePointer, _index * 20, (_index + 1) * 20);
       return (address(Bytes.slice20(_blob, 0)));
     }
   }

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -68,6 +68,18 @@ library AddressArray {
     );
   }
 
+  /** Register the table with its config */
+  function _register(bytes32 _tableId) internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -79,6 +91,15 @@ library AddressArray {
     _keyTuple[0] = key;
 
     bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
+    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
+  }
+
+  /** Get value */
+  function _get(bytes32 _tableId, bytes32 key) internal view returns (address[] memory value) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    bytes memory _blob = StoreCore.getField(_tableId, _keyTuple, 0, getFieldLayout());
     return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_address());
   }
 
@@ -99,6 +120,14 @@ library AddressArray {
     StoreSwitch.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
   }
 
+  /** Set value */
+  function _set(bytes32 _tableId, bytes32 key, address[] memory value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.setField(_tableId, _keyTuple, 0, EncodeArray.encode((value)), getFieldLayout());
+  }
+
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bytes32 key, address[] memory value) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -113,6 +142,17 @@ library AddressArray {
     _keyTuple[0] = key;
 
     uint256 _byteLength = StoreSwitch.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
+    unchecked {
+      return _byteLength / 20;
+    }
+  }
+
+  /** Get the length of value */
+  function _length(bytes32 _tableId, bytes32 key) internal view returns (uint256) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    uint256 _byteLength = StoreCore.getFieldLength(_tableId, _keyTuple, 0, getFieldLayout());
     unchecked {
       return _byteLength / 20;
     }
@@ -139,6 +179,27 @@ library AddressArray {
 
     unchecked {
       bytes memory _blob = StoreSwitch.getFieldSlice(
+        _tableId,
+        _keyTuple,
+        0,
+        getFieldLayout(),
+        _index * 20,
+        (_index + 1) * 20
+      );
+      return (address(Bytes.slice20(_blob, 0)));
+    }
+  }
+
+  /**
+   * Get an item of value
+   * (unchecked, returns invalid data if index overflows)
+   */
+  function _getItem(bytes32 _tableId, bytes32 key, uint256 _index) internal view returns (address) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      bytes memory _blob = StoreCore.getFieldSlice(
         _tableId,
         _keyTuple,
         0,
@@ -179,6 +240,14 @@ library AddressArray {
     StoreSwitch.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
   }
 
+  /** Push an element to value */
+  function _push(bytes32 _tableId, bytes32 key, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.pushToField(_tableId, _keyTuple, 0, abi.encodePacked((_element)), getFieldLayout());
+  }
+
   /** Push an element to value (using the specified store) */
   function push(IStore _store, bytes32 _tableId, bytes32 key, address _element) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
@@ -193,6 +262,14 @@ library AddressArray {
     _keyTuple[0] = key;
 
     StoreSwitch.popFromField(_tableId, _keyTuple, 0, 20, getFieldLayout());
+  }
+
+  /** Pop an element from value */
+  function _pop(bytes32 _tableId, bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.popFromField(_tableId, _keyTuple, 0, 20, getFieldLayout());
   }
 
   /** Pop an element from value (using the specified store) */
@@ -213,6 +290,19 @@ library AddressArray {
 
     unchecked {
       StoreSwitch.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)), getFieldLayout());
+    }
+  }
+
+  /**
+   * Update an element of value at `_index`
+   * (checked only to prevent modifying other tables; can corrupt own data if index overflows)
+   */
+  function _update(bytes32 _tableId, bytes32 key, uint256 _index, address _element) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    unchecked {
+      StoreCore.updateInField(_tableId, _keyTuple, 0, _index * 20, abi.encodePacked((_element)), getFieldLayout());
     }
   }
 
@@ -254,6 +344,14 @@ library AddressArray {
     _keyTuple[0] = key;
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 _tableId, bytes32 key) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = key;
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -18,12 +18,14 @@ import { FieldLayout, FieldLayoutLib } from "@latticexyz/store/src/FieldLayout.s
 import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0000000100000000000000000000000000000000000000000000000000000000
+);
+
 library AddressArray {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](0);
-
-    return FieldLayoutLib.encode(_fieldLayout, 1);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/test/tables/AddressArray.sol
+++ b/packages/world/test/tables/AddressArray.sol
@@ -23,6 +23,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library AddressArray {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -23,6 +23,8 @@ FieldLayout constant _fieldLayout = FieldLayout.wrap(
 );
 
 library Bool {
+  bytes32 internal constant SLOT = keccak256("mud.store");
+
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
     return _fieldLayout;
@@ -96,9 +98,15 @@ library Bool {
   function _get(bytes32 _tableId) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encodePacked());
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
-    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
-    return (_toBool(uint8(bytes1(_blob))));
+    uint256 storagePointer;
+    unchecked {
+      storagePointer = uint256(_tableId ^ SLOT ^ _keyHash);
+    }
+    bool _blob;
+    assembly {
+      _blob := shr(248, sload(storagePointer))
+    }
+    return _blob;
   }
 
   /** Get value (using the specified store) */

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -73,18 +73,16 @@ library Bool {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
-    bytes32[] memory _keyTuple = new bytes32[](0);
-
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -86,6 +86,7 @@ library Bool {
   /** Get value */
   function get(bytes32 _tableId) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -94,6 +95,7 @@ library Bool {
   /** Get value */
   function _get(bytes32 _tableId) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -102,6 +104,7 @@ library Bool {
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
     bytes32 _keyHash = keccak256(abi.encode());
+
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
@@ -111,7 +114,9 @@ library Bool {
   function set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
       storagePointer,
       1,
@@ -128,7 +133,9 @@ library Bool {
   function _set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
       storagePointer,
       1,
@@ -145,7 +152,9 @@ library Bool {
   function set(IStore _store, bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _keyHash = keccak256(abi.encode());
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -85,7 +85,7 @@ library Bool {
 
   /** Get value */
   function get(bytes32 _tableId) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
@@ -94,7 +94,7 @@ library Bool {
 
   /** Get value */
   function _get(bytes32 _tableId) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
@@ -103,7 +103,7 @@ library Bool {
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
@@ -114,7 +114,7 @@ library Bool {
   function set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreSwitch.storeStaticField(
@@ -133,7 +133,7 @@ library Bool {
   function _set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     StoreCore.storeStaticField(
@@ -152,7 +152,7 @@ library Bool {
   function set(IStore _store, bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes32 _keyHash = keccak256(abi.encode());
+    bytes32 _keyHash = keccak256(abi.encodePacked());
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -18,13 +18,14 @@ import { FieldLayout, FieldLayoutLib } from "@latticexyz/store/src/FieldLayout.s
 import { Schema, SchemaLib } from "@latticexyz/store/src/Schema.sol";
 import { PackedCounter, PackedCounterLib } from "@latticexyz/store/src/PackedCounter.sol";
 
+FieldLayout constant _fieldLayout = FieldLayout.wrap(
+  0x0001010001000000000000000000000000000000000000000000000000000000
+);
+
 library Bool {
   /** Get the table values' field layout */
   function getFieldLayout() internal pure returns (FieldLayout) {
-    uint256[] memory _fieldLayout = new uint256[](1);
-    _fieldLayout[0] = 1;
-
-    return FieldLayoutLib.encode(_fieldLayout, 0);
+    return _fieldLayout;
   }
 
   /** Get the table's key schema */

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -66,6 +66,18 @@ library Bool {
     );
   }
 
+  /** Register the table with its config */
+  function _register(bytes32 _tableId) internal {
+    StoreCore.registerTable(
+      _tableId,
+      getFieldLayout(),
+      getKeySchema(),
+      getValueSchema(),
+      getKeyNames(),
+      getFieldNames()
+    );
+  }
+
   /** Register the table with its config (using the specified store) */
   function register(IStore _store, bytes32 _tableId) internal {
     _store.registerTable(_tableId, getFieldLayout(), getKeySchema(), getValueSchema(), getKeyNames(), getFieldNames());
@@ -76,6 +88,14 @@ library Bool {
     bytes32 _keyHash = keccak256(abi.encode());
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
     bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
+  }
+
+  /** Get value */
+  function _get(bytes32 _tableId) internal view returns (bool value) {
+    bytes32 _keyHash = keccak256(abi.encode());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyHash);
+    bytes32 _blob = StoreCore.loadStaticField(storagePointer, 1, 0);
     return (_toBool(uint8(bytes1(_blob))));
   }
 
@@ -93,6 +113,23 @@ library Bool {
 
     uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
     StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      0,
+      abi.encodePacked((value)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
+  }
+
+  /** Set value */
+  function _set(bytes32 _tableId, bool value) internal {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreCore.storeStaticField(
       storagePointer,
       1,
       0,
@@ -129,6 +166,13 @@ library Bool {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
     StoreSwitch.deleteRecord(_tableId, _keyTuple, getFieldLayout());
+  }
+
+  /* Delete all data for given keys */
+  function _deleteRecord(bytes32 _tableId) internal {
+    bytes32[] memory _keyTuple = new bytes32[](0);
+
+    StoreCore.deleteRecord(_tableId, _keyTuple, getFieldLayout());
   }
 
   /* Delete all data for given keys (using the specified store) */

--- a/packages/world/test/tables/Bool.sol
+++ b/packages/world/test/tables/Bool.sol
@@ -9,7 +9,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 // Import store internals
 import { IStore } from "@latticexyz/store/src/IStore.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
-import { StoreCore } from "@latticexyz/store/src/StoreCore.sol";
+import { StoreCore, StoreCoreInternal } from "@latticexyz/store/src/StoreCore.sol";
 import { Bytes } from "@latticexyz/store/src/Bytes.sol";
 import { Memory } from "@latticexyz/store/src/Memory.sol";
 import { SliceLib } from "@latticexyz/store/src/Slice.sol";
@@ -74,30 +74,43 @@ library Bool {
   function get(bytes32 _tableId) internal view returns (bool value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = StoreSwitch.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = StoreSwitch.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Get value (using the specified store) */
   function get(IStore _store, bytes32 _tableId) internal view returns (bool value) {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    bytes memory _blob = _store.getField(_tableId, _keyTuple, 0, getFieldLayout());
-    return (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    bytes32 _blob = _store.loadStaticField(storagePointer, 1, 0);
+    return (_toBool(uint8(bytes1(_blob))));
   }
 
   /** Set value */
   function set(bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    StoreSwitch.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    StoreSwitch.storeStaticField(
+      storagePointer,
+      1,
+      0,
+      abi.encodePacked((value)),
+      _tableId,
+      _keyTuple,
+      0,
+      getFieldLayout()
+    );
   }
 
   /** Set value (using the specified store) */
   function set(IStore _store, bytes32 _tableId, bool value) internal {
     bytes32[] memory _keyTuple = new bytes32[](0);
 
-    _store.setField(_tableId, _keyTuple, 0, abi.encodePacked((value)), getFieldLayout());
+    uint256 storagePointer = StoreCoreInternal._getStaticDataLocation(_tableId, _keyTuple);
+    _store.storeStaticField(storagePointer, 1, 0, abi.encodePacked((value)), _tableId, _keyTuple, 0, getFieldLayout());
   }
 
   /** Tightly pack full data using this table's field layout */

--- a/templates/phaser/packages/contracts/foundry.toml
+++ b/templates/phaser/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/templates/react/packages/contracts/foundry.toml
+++ b/templates/react/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/templates/threejs/packages/contracts/foundry.toml
+++ b/templates/threejs/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true

--- a/templates/vanilla/packages/contracts/foundry.toml
+++ b/templates/vanilla/packages/contracts/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc = "0.8.21"
 ffi = false
 fuzz_runs = 256
 optimizer = true


### PR DESCRIPTION
Pasted from discord:

Feature request: bring real world mud2 read/write gas cost to parity with sload and sstore.

Almost all of the overhead that mud2 adds on top of sload and sstore comes from computing static constants onchain. 

For the current version of mud2, warm Table.get[StaticField] cost in the ballpark of 2000 + 500 * (# of fields in key schema) + 500 * (# of fields in value schema). This can probably be reduced by 90%+ to < 400 gas:
- Hardcoding the values for getValueSchema and getKeySchema reduces the gas down to a flat 1500.
- Hardcoding everything inside StoreCore.getField except for storage location reduces the gas down to 500.
- simplifying the storage location hash function can reduces the gas down to Storage.load which is 400.
- a custom Storage.loadField might reduce gas further, though not sure by how much.

The same logic is applicable to writes. 