### PR TITLE
feat(protoocl-parser): add valueSchemaToFieldLayoutHex

### DIFF
--- a/.changeset/silent-rice-argue.md
+++ b/.changeset/silent-rice-argue.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/protocol-parser": minor
+---
+
+Adds `valueSchemaToFieldLayoutHex` helper

--- a/packages/protocol-parser/src/fieldLayoutToHex.ts
+++ b/packages/protocol-parser/src/fieldLayoutToHex.ts
@@ -1,6 +1,7 @@
 import { Hex } from "viem";
 import { FieldLayout } from "./common";
 
+/** @deprecated use `valueSchemaToFieldLayoutHex` instead */
 export function fieldLayoutToHex(fieldLayout: FieldLayout): Hex {
   const staticDataLength = fieldLayout.staticFieldLengths.reduce((totalLength, length) => totalLength + length, 0);
   return `0x${[

--- a/packages/protocol-parser/src/valueSchemaToFieldLayoutHex.ts
+++ b/packages/protocol-parser/src/valueSchemaToFieldLayoutHex.ts
@@ -1,0 +1,21 @@
+import { Hex } from "viem";
+import { ValueSchema } from "./common";
+import { isDynamicAbiType, isStaticAbiType, staticAbiTypeToByteLength } from "@latticexyz/schema-type";
+
+// TODO: add tests once we have corresponding tests for FieldLayout.sol (bytes32 -> FieldLayout and vice versa)
+export function valueSchemaToFieldLayoutHex(valueSchema: ValueSchema): Hex {
+  const staticFields = Object.values(valueSchema).filter(isStaticAbiType);
+  const dynamicFields = Object.values(valueSchema).filter(isDynamicAbiType);
+
+  const staticFieldLengths = staticFields.map((fieldType) => staticAbiTypeToByteLength[fieldType]);
+  const staticDataLength = staticFieldLengths.reduce((dataLength, fieldLength) => dataLength + fieldLength, 0);
+
+  return `0x${[
+    staticDataLength.toString(16).padStart(4, "0"),
+    staticFields.length.toString(16).padStart(2, "0"),
+    dynamicFields.length.toString(16).padStart(2, "0"),
+    ...staticFieldLengths.map((fieldLength) => fieldLength.toString(16).padStart(2, "0")),
+  ]
+    .join("")
+    .padEnd(64, "0")}`;
+}


### PR DESCRIPTION
I lost track of where the comment was but I said I'd swap out `fieldLayoutToHex` with a thing that uses `ValueSchema`. This should help with https://github.com/latticexyz/mud/pull/1466 cc @y77cao 

Unfortunately we don't have Solidity tests that map a raw `bytes32` value to `FieldLayout` so I can copy that over to make sure the Solidity and TS line up in terms of behavior, padding, etc. So I skipped adding tests for now.
