### PR TITLE
Revert "fix(cli): don't build twice on contract changes"

### DIFF
--- a/.changeset/chatty-news-join.md
+++ b/.changeset/chatty-news-join.md
@@ -1,5 +1,0 @@
----
-"@latticexyz/cli": patch
----
-
-Fixes an issue in development where contracts were built twice on contract changes.

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -140,6 +140,9 @@ const commandModule: CommandModule<Options, Options> = {
       // Run worldgen to generate interfaces based on the systems
       await worldgenHandler({ config, clean: true, srcDir: srcDirectory });
 
+      // Build the contracts
+      await forge(["build"]);
+
       // Generate TS-friendly ABI files
       // We rebuild into a separate dir to have a clean set of ABIs without test/script contracts
       await forge(["build", "--extra-output-files", "abi", "--out", "abi", "--skip", "test", "script", "MudTest.sol"]);


### PR DESCRIPTION
Reverts latticexyz/mud#1480

I believe this is the cause of
```
MUDError: Error reading file at out/System.sol/System.json
```
