### PR TITLE
build: call docker workflow after each release step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,7 @@
 name: Docker
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      # only target a single package tag to avoid running this task for every package on a version release
-      # in the metadata step, we parse out the specific version used in the tag (e.g. `2.0.0-next.5` and `next`)
-      - "@latticexyz/common@*"
+  workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -37,6 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
+          # If this doesn't tag properly within the context of `workflow_call`, try `context: git`
           images: ${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+
       - name: Check for pre.json file existence
         id: check_files
         uses: andstor/file-existence-action@v2.0.0
@@ -47,10 +47,13 @@ jobs:
         run: npx changeset pre enter next
 
       - name: Create next version PR or publish 🚀
-        uses: changesets/action@v1 
+        uses: changesets/action@v1
         with:
           version: pnpm release:version
           publish: pnpm release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  docker:
+    uses: ./.github/workflows/docker.yml
+    needs: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: "Setup"
         uses: ./.github/actions/setup
-        
+
       - name: Clean
         shell: bash
         run: pnpm turbo run clean --force --concurrency 10
@@ -60,3 +60,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  docker:
+    uses: ./.github/workflows/docker.yml
+    needs: version

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,3 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docker:
+    uses: ./.github/workflows/docker.yml
+    needs: release-snapshot


### PR DESCRIPTION
attempts to fix docker image tagging by running the docker image step after release so that next tags are present 