### PR TITLE
build: pin react/react-dom types versions

### DIFF
--- a/examples/minimal/packages/client-phaser/package.json
+++ b/examples/minimal/packages/client-phaser/package.json
@@ -40,8 +40,8 @@
     "zustand": "^4.3.8"
   },
   "devDependencies": {
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",

--- a/examples/minimal/packages/client-react/package.json
+++ b/examples/minimal/packages/client-react/package.json
@@ -35,8 +35,8 @@
     "viem": "1.6.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@vitejs/plugin-react": "^3.1.0",
     "eslint-plugin-react": "7.31.11",
     "eslint-plugin-react-hooks": "4.6.0",

--- a/examples/minimal/pnpm-lock.yaml
+++ b/examples/minimal/pnpm-lock.yaml
@@ -112,11 +112,11 @@ importers:
         version: 4.3.8(react@18.2.0)
     devDependencies:
       '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.6
+        specifier: 18.2.22
+        version: 18.2.22
       '@types/react-dom':
-        specifier: ^18.2.4
-        version: 18.2.4
+        specifier: 18.2.7
+        version: 18.2.7
       '@types/styled-components':
         specifier: ^5.1.26
         version: 5.1.26
@@ -209,11 +209,11 @@ importers:
         version: 1.6.0(typescript@5.1.6)
     devDependencies:
       '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.6
+        specifier: 18.2.22
+        version: 18.2.22
       '@types/react-dom':
-        specifier: ^18.2.4
-        version: 18.2.4
+        specifier: 18.2.7
+        version: 18.2.7
       '@vitejs/plugin-react':
         specifier: ^3.1.0
         version: 3.1.0(vite@4.2.1)
@@ -1072,7 +1072,7 @@ packages:
   /@types/hoist-non-react-statics@3.3.1:
     resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
     dependencies:
-      '@types/react': 18.2.6
+      '@types/react': 18.2.22
       hoist-non-react-statics: 3.3.2
     dev: true
 
@@ -1091,14 +1091,14 @@ packages:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react-dom@18.2.4:
-    resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
+  /@types/react-dom@18.2.7:
+    resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
     dependencies:
-      '@types/react': 18.2.6
+      '@types/react': 18.2.22
     dev: true
 
-  /@types/react@18.2.6:
-    resolution: {integrity: sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==}
+  /@types/react@18.2.22:
+    resolution: {integrity: sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
@@ -1117,7 +1117,7 @@ packages:
     resolution: {integrity: sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.2.6
+      '@types/react': 18.2.22
       csstype: 3.1.2
     dev: true
 

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -41,8 +41,8 @@
     "zustand": "^4.3.7"
   },
   "devDependencies": {
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@types/ws": "^8.5.4",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.23",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^8.0.1",
-    "@types/react": "^18.2.6",
+    "@types/react": "18.2.22",
     "@vitejs/plugin-react": "^4.0.0",
     "eslint-plugin-react": "7.31.11",
     "eslint-plugin-react-hooks": "4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,11 +379,11 @@ importers:
         version: 4.3.7(react@18.2.0)
     devDependencies:
       '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.6
+        specifier: 18.2.22
+        version: 18.2.22
       '@types/react-dom':
-        specifier: ^18.2.4
-        version: 18.2.4
+        specifier: 18.2.7
+        version: 18.2.7
       '@types/ws':
         specifier: ^8.5.4
         version: 8.5.4
@@ -600,10 +600,10 @@ importers:
     devDependencies:
       '@testing-library/react-hooks':
         specifier: ^8.0.1
-        version: 8.0.1(@types/react@18.2.6)(react-test-renderer@18.2.0)(react@18.2.0)
+        version: 8.0.1(@types/react@18.2.22)(react-test-renderer@18.2.0)(react@18.2.0)
       '@types/react':
-        specifier: ^18.2.6
-        version: 18.2.6
+        specifier: 18.2.22
+        version: 18.2.22
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.0.0(vite@4.3.6)
@@ -3029,7 +3029,7 @@ packages:
       antlr4ts: 0.5.0-alpha.4
     dev: false
 
-  /@testing-library/react-hooks@8.0.1(@types/react@18.2.6)(react-test-renderer@18.2.0)(react@18.2.0):
+  /@testing-library/react-hooks@8.0.1(@types/react@18.2.22)(react-test-renderer@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -3046,7 +3046,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@types/react': 18.2.6
+      '@types/react': 18.2.22
       react: 18.2.0
       react-error-boundary: 3.1.4(react@18.2.0)
       react-test-renderer: 18.2.0(react@18.2.0)
@@ -3282,14 +3282,14 @@ packages:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react-dom@18.2.4:
-    resolution: {integrity: sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==}
+  /@types/react-dom@18.2.7:
+    resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
     dependencies:
-      '@types/react': 18.2.6
+      '@types/react': 18.2.22
     dev: true
 
-  /@types/react@18.2.6:
-    resolution: {integrity: sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==}
+  /@types/react@18.2.22:
+    resolution: {integrity: sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3

--- a/templates/phaser/packages/client/package.json
+++ b/templates/phaser/packages/client/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.194",
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^3.1.0",
     "eslint-plugin-react": "7.31.11",

--- a/templates/react/packages/client/package.json
+++ b/templates/react/packages/client/package.json
@@ -27,8 +27,8 @@
     "viem": "1.6.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@vitejs/plugin-react": "^3.1.0",
     "eslint-plugin-react": "7.31.11",
     "eslint-plugin-react-hooks": "4.6.0",

--- a/templates/threejs/packages/client/package.json
+++ b/templates/threejs/packages/client/package.json
@@ -28,8 +28,8 @@
     "viem": "1.6.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "18.2.22",
+    "@types/react-dom": "18.2.7",
     "@vitejs/plugin-react": "^3.1.0",
     "eslint-plugin-react": "7.31.11",
     "eslint-plugin-react-hooks": "4.6.0",


### PR DESCRIPTION
something about a recent package push to `@types/react` caused CI to fall over and seemed to only resolve it by pinning these versions so they all align
