### PR TITLE
fix(faucet,store-indexer): fix invalid env message

### DIFF
--- a/.changeset/mean-islands-brake.md
+++ b/.changeset/mean-islands-brake.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/faucet": patch
+"@latticexyz/store-indexer": patch
+---
+
+Improves error message when parsing env variables

--- a/packages/faucet/bin/faucet-server.ts
+++ b/packages/faucet/bin/faucet-server.ts
@@ -1,28 +1,13 @@
 #!/usr/bin/env node
 import "dotenv/config";
-import { z } from "zod";
 import fastify from "fastify";
 import { fastifyTRPCPlugin } from "@trpc/server/adapters/fastify";
-import { http, parseEther, isHex, createClient } from "viem";
+import { http, createClient } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { AppRouter, createAppRouter } from "../src/createAppRouter";
+import { parseEnv } from "./parseEnv";
 
-const env = z
-  .object({
-    HOST: z.string().default("0.0.0.0"),
-    PORT: z.coerce.number().positive().default(3002),
-    RPC_HTTP_URL: z.string(),
-    FAUCET_PRIVATE_KEY: z.string().refine(isHex),
-    DRIP_AMOUNT_ETHER: z
-      .string()
-      .default("1")
-      .transform((ether) => parseEther(ether)),
-  })
-  .parse(process.env, {
-    errorMap: (issue) => ({
-      message: `Missing or invalid environment variable: ${issue.path.join(".")}`,
-    }),
-  });
+const env = parseEnv();
 
 const client = createClient({
   transport: http(env.RPC_HTTP_URL),

--- a/packages/faucet/bin/parseEnv.ts
+++ b/packages/faucet/bin/parseEnv.ts
@@ -1,24 +1,16 @@
+import { isHex, parseEther } from "viem";
 import { z, ZodError, ZodIntersection, ZodTypeAny } from "zod";
 
-const commonSchema = z.intersection(
-  z.object({
-    HOST: z.string().default("0.0.0.0"),
-    PORT: z.coerce.number().positive().default(3001),
-    START_BLOCK: z.coerce.bigint().nonnegative().default(0n),
-    MAX_BLOCK_RANGE: z.coerce.bigint().positive().default(1000n),
-    POLLING_INTERVAL: z.coerce.number().positive().default(1000),
-  }),
-  z.union([
-    z.object({
-      RPC_HTTP_URL: z.string(),
-      RPC_WS_URL: z.string().optional(),
-    }),
-    z.object({
-      RPC_HTTP_URL: z.string().optional(),
-      RPC_WS_URL: z.string(),
-    }),
-  ])
-);
+const commonSchema = z.object({
+  HOST: z.string().default("0.0.0.0"),
+  PORT: z.coerce.number().positive().default(3002),
+  RPC_HTTP_URL: z.string(),
+  FAUCET_PRIVATE_KEY: z.string().refine(isHex),
+  DRIP_AMOUNT_ETHER: z
+    .string()
+    .default("1")
+    .transform((ether) => parseEther(ether)),
+});
 
 export function parseEnv<TSchema extends ZodTypeAny | undefined = undefined>(
   schema?: TSchema


### PR DESCRIPTION
My refactor of env parsing with Zod in #1533 was incomplete and didn't realize the intersection errors got buried.

This replaces the env handling with a nicer error message format like:

```
Missing or invalid environment variables:

  RPC_HTTP_URL
  FAUCET_PRIVATE_KEY
```

<img width="473" alt="image" src="https://github.com/latticexyz/mud/assets/508855/11084fd4-4c83-4daf-8162-81fca454f686">
