### PR TITLE
ci: switch to beefy runner for slow actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   main:
     name: Run end-to-end tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     services:
       postgres:
         image: postgres:12.1-alpine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     services:
       postgres:
         image: postgres:12.1-alpine

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "release:publish": "pnpm install && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
-    "test": "pnpm recursive run test",
-    "test:ci": "pnpm recursive run test:ci"
+    "test": "pnpm run --recursive test",
+    "test:ci": "pnpm recursive --recursive --parallel run test:ci"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
     "test": "pnpm run --recursive test",
-    "test:ci": "pnpm recursive --recursive --parallel run test:ci"
+    "test:ci": "pnpm run --recursive --parallel run test:ci"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "release:publish": "pnpm install && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
-    "test": "pnpm run --recursive test",
-    "test:ci": "pnpm run --recursive --parallel test:ci"
+    "test": "pnpm run --recursive --filter=!@latticexyz/services test",
+    "test:ci": "pnpm run --recursive --parallel --filter=!@latticexyz/services test:ci"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:version": "changeset version && pnpm install --lockfile-only && pnpx bun@0.7.3 scripts/changelog.ts",
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
     "test": "pnpm run --recursive test",
-    "test:ci": "pnpm run --recursive --parallel run test:ci"
+    "test:ci": "pnpm run --recursive --parallel test:ci"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",


### PR DESCRIPTION
too much time is being wasted on waiting for the `test` and `e2e` actions to complete

this PR speeds it up by
- running the tests on a beefier runner
- runnings tests in parallel
- excluding services package from tests