### PR TITLE
fix(common): always import relative sol files from ./

### DIFF
--- a/.changeset/fresh-scissors-unite.md
+++ b/.changeset/fresh-scissors-unite.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Minor fix to resolving user types: `solc` doesn't like relative imports without `./`, but is fine with relative imports from `./../`, so we always append `./` to the relative path.

--- a/packages/common/src/codegen/utils/loadUserTypesFile.ts
+++ b/packages/common/src/codegen/utils/loadUserTypesFile.ts
@@ -31,8 +31,9 @@ function loadUserTypesFile(
   data: string;
 } {
   if (unresolvedFilePath.at(0) === ".") {
+    const relativePath = path.relative(outputBaseDirectory, unresolvedFilePath);
     return {
-      filePath: path.relative(outputBaseDirectory, unresolvedFilePath),
+      filePath: "./" + relativePath, // solc doesn't like relative paths without "./"
       data: readFileSync(unresolvedFilePath, "utf8"),
     };
   } else {


### PR DESCRIPTION
- solc doesn't like relative imports without `./`
- solc is fine with `./../`