### PR TITLE
feat(store): infer strong types from user types config (WIP)

### DIFF
--- a/packages/common/src/codegen/utils/loadUserTypesFile.ts
+++ b/packages/common/src/codegen/utils/loadUserTypesFile.ts
@@ -1,14 +1,21 @@
 import { readFileSync } from "fs";
 import path from "path";
 import { SolidityUserDefinedType, extractUserTypes } from "./extractUserTypes";
+import { SchemaAbiType } from "@latticexyz/schema-type";
+import { MUDError } from "../../errors";
+
+export type UserType = {
+  filePath: string;
+  internalType: SchemaAbiType;
+};
 
 export function loadAndExtractUserTypes(
-  userTypes: Record<string, string>,
+  userTypes: Record<string, UserType>,
   outputBaseDirectory: string,
   remappings: [string, string][]
 ): Record<string, SolidityUserDefinedType> {
   const userTypesPerFile: Record<string, string[]> = {};
-  for (const [userTypeName, unresolvedFilePath] of Object.entries(userTypes)) {
+  for (const [userTypeName, { filePath: unresolvedFilePath }] of Object.entries(userTypes)) {
     if (!(unresolvedFilePath in userTypesPerFile)) {
       userTypesPerFile[unresolvedFilePath] = [];
     }
@@ -17,7 +24,18 @@ export function loadAndExtractUserTypes(
   let extractedUserTypes: Record<string, SolidityUserDefinedType> = {};
   for (const [unresolvedFilePath, userTypeNames] of Object.entries(userTypesPerFile)) {
     const { filePath, data } = loadUserTypesFile(outputBaseDirectory, unresolvedFilePath, remappings);
-    extractedUserTypes = Object.assign(userTypes, extractUserTypes(data, userTypeNames, filePath));
+    const userTypesInFile = extractUserTypes(data, userTypeNames, filePath);
+
+    // Verify the actual user type matches the internalType specified in the config
+    for (const [userTypeName, userType] of Object.entries(userTypesInFile)) {
+      if (userType.internalTypeId !== userTypes[userTypeName].internalType) {
+        throw new MUDError(
+          `User type "${userTypeName}" has internal type "${userType.internalTypeId}" but config specifies "${userTypes[userTypeName].internalType}"`
+        );
+      }
+    }
+
+    extractedUserTypes = Object.assign(extractedUserTypes, userTypesInFile);
   }
   return extractedUserTypes;
 }

--- a/packages/store-sync/src/common.ts
+++ b/packages/store-sync/src/common.ts
@@ -1,5 +1,5 @@
 import { Address, Block, Hex, Log, PublicClient } from "viem";
-import { StoreConfig, StoreEventsAbiItem, StoreEventsAbi } from "@latticexyz/store";
+import { StoreConfig, StoreEventsAbiItem, StoreEventsAbi, resolveUserTypes } from "@latticexyz/store";
 import storeConfig from "@latticexyz/store/mud.config";
 import { Observable } from "rxjs";
 import { resourceIdToHex } from "@latticexyz/common";
@@ -76,7 +76,7 @@ export type StorageAdapterBlock = { blockNumber: BlockLogs["blockNumber"]; logs:
 export type StorageAdapter = (block: StorageAdapterBlock) => Promise<void>;
 
 // TODO: adjust when we get namespace support (https://github.com/latticexyz/mud/issues/994) and when table has namespace key (https://github.com/latticexyz/mud/issues/1201)
-export const schemasTable = storeConfig.tables.Tables;
+export const schemasTable = resolveUserTypes(storeConfig.tables.Tables, storeConfig);
 export const schemasTableId = resourceIdToHex({
   type: schemasTable.offchainOnly ? "offchainTable" : "table",
   namespace: storeConfig.namespace,

--- a/packages/store/ts/config/storeConfig.ts
+++ b/packages/store/ts/config/storeConfig.ts
@@ -288,6 +288,32 @@ export const zUserTypesConfig = z.object({
   userTypes: z.record(zUserTypeName, zUserTypeConfig).default(DEFAULTS.userTypes),
 });
 
+type SchemaWithResolvedUserTypes<
+  TUserTypesConfig extends UserTypesConfig<string>,
+  TSchemaConfig extends FullSchemaConfig
+> = {
+  [key in keyof TSchemaConfig]: TSchemaConfig[key] extends keyof TUserTypesConfig["userTypes"]
+    ? TUserTypesConfig["userTypes"][TSchemaConfig[key]] extends UserType
+      ? TUserTypesConfig["userTypes"][TSchemaConfig[key]]["internalType"]
+      : TSchemaConfig[key]
+    : TSchemaConfig[key];
+};
+
+type TableConfigWithResolvedUserTypes<
+  TUserTypesConfig extends UserTypesConfig<string>,
+  TTableConfig extends TableConfig
+> = Omit<TTableConfig, "valueSchema"> & {
+  valueSchema: SchemaWithResolvedUserTypes<TUserTypesConfig, ExpandSchemaConfig<TTableConfig["valueSchema"]>>;
+};
+
+export function resolveUserTypes<
+  TUserTypes extends StringForUnion,
+  TUserTypesConfig extends UserTypesConfig<TUserTypes>,
+  TTableConfig extends TableConfig
+>(table: TTableConfig, userTypes: TUserTypesConfig): TableConfigWithResolvedUserTypes<TUserTypesConfig, TTableConfig> {
+  return {} as any;
+}
+
 /************************************************************************
  *
  *    FINAL

--- a/packages/store/ts/config/storeConfig.ts
+++ b/packages/store/ts/config/storeConfig.ts
@@ -22,6 +22,7 @@ import {
   zName,
 } from "@latticexyz/config";
 import { DEFAULTS, PATH_DEFAULTS, TABLE_DEFAULTS } from "./defaults";
+import { UserType } from "@latticexyz/common/codegen";
 
 const zTableName = zObjectName;
 const zKeyName = zValueName;
@@ -241,7 +242,7 @@ export const zEnumsConfig = z.object({
  *
  ************************************************************************/
 
-export type UserTypesConfig<UserTypeNames extends StringForUnion> = never extends UserTypeNames
+export type UserTypesConfig<UserTypeNames extends StringForUnion = StringForUnion> = never extends UserTypeNames
   ? {
       /**
        * User types mapped to file paths from which to import them.
@@ -250,7 +251,7 @@ export type UserTypesConfig<UserTypeNames extends StringForUnion> = never extend
        *
        * (user types are inferred to be absent)
        */
-      userTypes?: Record<UserTypeNames, string>;
+      userTypes?: Record<UserTypeNames, UserType>;
     }
   : StringForUnion extends UserTypeNames
   ? {
@@ -261,7 +262,7 @@ export type UserTypesConfig<UserTypeNames extends StringForUnion> = never extend
        *
        * (user types aren't inferred - use `mudConfig` or `storeConfig` helper, and `as const` for variables)
        */
-      userTypes?: Record<UserTypeNames, string>;
+      userTypes?: Record<UserTypeNames, UserType>;
     }
   : {
       /**
@@ -271,15 +272,20 @@ export type UserTypesConfig<UserTypeNames extends StringForUnion> = never extend
        *
        * User types defined here can be used as types in table schemas/keys
        */
-      userTypes: Record<UserTypeNames, string>;
+      userTypes: Record<UserTypeNames, UserType>;
     };
 
 export type FullUserTypesConfig<UserTypeNames extends StringForUnion> = {
   userTypes: Record<UserTypeNames, string>;
 };
 
+const zUserTypeConfig = z.object({
+  filePath: z.string(),
+  internalType: z.string(),
+});
+
 export const zUserTypesConfig = z.object({
-  userTypes: z.record(zUserTypeName, z.string()).default(DEFAULTS.userTypes),
+  userTypes: z.record(zUserTypeName, zUserTypeConfig).default(DEFAULTS.userTypes),
 });
 
 /************************************************************************


### PR DESCRIPTION
- not yet working, since `mudConfig` doesn't pass strong types for `userTypes`, so we can't infer the type for user types as values in `valueSchema` or `keySchema`

- punting on this for now because we might do a bigger config parsing overhaul soon

- cc #1561 