### PR TITLE
build: try git context in docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          # If this doesn't tag properly within the context of `workflow_call`, try `context: git`
+          context: git
           images: ${{ matrix.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
my last ditch effort to fix docker tagging for next releases

hopefully this lets the docker metadata action find the tag
