### PR TITLE
chore: add dist-tag-rm script to remove tags from npm

### DIFF
--- a/.github/workflows/remove-npm-tag.yml
+++ b/.github/workflows/remove-npm-tag.yml
@@ -1,0 +1,24 @@
+name: Remove npm tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  remove-npm-tag:
+    name: Remove an npm dist tag for the current branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set deployment token
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Remove npm dist tag
+        run: pnpm dist-tag-rm
+        env: TAG=${{ github.ref_name }}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "turbo run build",
     "clean": "turbo run clean",
     "dev": "turbo run dev --concurrency 100",
+    "dist-tag-rm": "pnpm recursive exec -- sh -c 'npm dist-tag rm $(cat package.json | jq -r \".name\") $TAG || true'",
     "foundryup": "curl -L https://foundry.paradigm.xyz | bash && bash ~/.foundry/bin/foundryup",
     "gas-report": "pnpm recursive run gas-report",
     "lint": "pnpm prettier:check && eslint . --ext .ts --ext .tsx",


### PR DESCRIPTION
adding a small pnpm script util to remove dist tags from npm.
Usage `TAG=<tag> pnpm dist-tag-rm`

Used this to clean up the npm tags for `canary`, `indexing` and `snapshot-test`