### PR TITLE
feat(cli): add batch call for function registering

### DIFF
--- a/packages/cli/src/utils/systems/getBatchCallCallData.ts
+++ b/packages/cli/src/utils/systems/getBatchCallCallData.ts
@@ -1,0 +1,13 @@
+import { CallData } from "../utils/types";
+
+export function getBatchCallCallData(input: { systemId: string; batchCallData: string[] }): CallData {
+  const { systemId, batchCallData } = input;
+  const extendedBatchCallData = [];
+  for (const calldata of batchCallData) {
+    extendedBatchCallData.push([systemId, calldata]);
+  }
+  return {
+    func: "batchCall",
+    args: [extendedBatchCallData],
+  };
+}


### PR DESCRIPTION
I plan to first implement batch calling for the function registration part in the deploy. If everything works well, I can then proceed to finish the remaining parts.

One tricky parameter is the BATCH_SIZE. It may vary based on the length of function names and the gas limit. I've chosen a conservative value for now, but I believe this can be made configurable in a certain place eventually.

fix #1645