### PR TITLE
fix(common): workaround for zero base fee

### DIFF
--- a/.changeset/chilly-kangaroos-clap.md
+++ b/.changeset/chilly-kangaroos-clap.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Adds viem workaround for zero base fee used by MUD's anvil config

--- a/packages/common/src/chains/mudFoundry.ts
+++ b/packages/common/src/chains/mudFoundry.ts
@@ -4,6 +4,7 @@ import { MUDChain } from "./types";
 export const mudFoundry = {
   ...foundry,
   fees: {
-    defaultPriorityFee: 0n,
+    // This is intentionally defined as a function as a workaround for https://github.com/wagmi-dev/viem/pull/1280
+    defaultPriorityFee: () => 0n,
   },
 } as const satisfies MUDChain;


### PR DESCRIPTION
Workaround for regression after bumping viem version. See context in https://github.com/wagmi-dev/viem/pull/1280