### PR TITLE
feat(gas-report): add more logs to stdin piping

### DIFF
--- a/.changeset/nice-avocados-poke.md
+++ b/.changeset/nice-avocados-poke.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/gas-report": patch
+---
+
+Pass through `stdin` logs in `gas-report`. Since the script piping in logs to `gas-report` can be long-running, it is useful to see its logs to know if it's stalling.

--- a/packages/gas-report/package.json
+++ b/packages/gas-report/package.json
@@ -34,12 +34,14 @@
     "chalk": "^5.3.0",
     "dotenv": "^16.0.3",
     "execa": "^7.0.0",
+    "stream-to-array": "^2.3.0",
     "strip-ansi": "^7.1.0",
     "table": "^6.8.1",
     "yargs": "^17.7.1"
   },
   "devDependencies": {
     "@types/node": "^18.15.11",
+    "@types/stream-to-array": "^2.3.1",
     "@types/yargs": "^17.0.10",
     "ds-test": "https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#74cfb77e308dd188d2f58864aaf44963ae6b88b1",

--- a/packages/gas-report/ts/index.ts
+++ b/packages/gas-report/ts/index.ts
@@ -205,13 +205,16 @@ function saveGasReport(gasReport: GasReport, path: string) {
 
 function readStdIn(): Promise<string> {
   return new Promise((resolve) => {
+    console.log("Waiting for stdin...");
     let data = "";
 
     process.stdin.on("data", (chunk) => {
+      console.log(chunk.toString());
       data += chunk;
     });
 
     process.stdin.on("end", () => {
+      console.log("Done waiting for stdin");
       resolve(data);
     });
   });

--- a/packages/gas-report/ts/index.ts
+++ b/packages/gas-report/ts/index.ts
@@ -4,6 +4,7 @@ import { execa } from "execa";
 import chalk from "chalk";
 import { table, getBorderCharacters } from "table";
 import stripAnsi from "strip-ansi";
+import toArray from "stream-to-array";
 
 /**
  * Print the gas report to the console, save it to a file and compare it to a previous gas report if provided.
@@ -106,8 +107,11 @@ async function runGasReport(options: Options): Promise<GasReport> {
   let logs: string;
   try {
     if (options.stdin) {
-      // Read the logs from stdin
-      logs = await readStdIn();
+      // Read the logs from stdin and pipe them to stdout for visibility
+      console.log("Waiting for stdin...");
+      process.stdin.pipe(process.stdout);
+      logs = (await toArray(process.stdin)).map((chunk) => chunk.toString()).join("\n");
+      console.log("Done reading stdin");
     } else {
       // Run the default test command to capture the logs
       const child = execa("forge", ["test", "-vvv"], {
@@ -201,21 +205,4 @@ function printGasReport(gasReport: GasReport, compare?: string) {
 function saveGasReport(gasReport: GasReport, path: string) {
   console.log(chalk.bold(`Saving gas report to ${path}`));
   writeFileSync(path, `${JSON.stringify(gasReport, null, 2)}\n`);
-}
-
-function readStdIn(): Promise<string> {
-  return new Promise((resolve) => {
-    console.log("Waiting for stdin...");
-    let data = "";
-
-    process.stdin.on("data", (chunk) => {
-      console.log(chunk.toString());
-      data += chunk;
-    });
-
-    process.stdin.on("end", () => {
-      console.log("Done waiting for stdin");
-      resolve(data);
-    });
-  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
       execa:
         specifier: ^7.0.0
         version: 7.0.0
+      stream-to-array:
+        specifier: ^2.3.0
+        version: 2.3.0
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -469,6 +472,9 @@ importers:
       '@types/node':
         specifier: ^18.15.11
         version: 18.15.11
+      '@types/stream-to-array':
+        specifier: ^2.3.1
+        version: 2.3.1
       '@types/yargs':
         specifier: ^17.0.10
         version: 17.0.23
@@ -3380,6 +3386,12 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
+  /@types/stream-to-array@2.3.1:
+    resolution: {integrity: sha512-OqV/DIumEm5pT+m4LYGpDFRRLZ0VJRvrz58C8q8rjLGVgP5gRHxThG8eLZfhmK3GVAq9iq3eSvZ0vkZJ5ZH/Pg==}
+    dependencies:
+      '@types/node': 18.15.11
+    dev: true
+
   /@types/throttle-debounce@5.0.0:
     resolution: {integrity: sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==}
     dev: true
@@ -3868,7 +3880,6 @@ packages:
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
-    dev: true
 
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -10004,6 +10015,12 @@ packages:
   /std-env@3.3.2:
     resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
     dev: true
+
+  /stream-to-array@2.3.0:
+    resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
+    dependencies:
+      any-promise: 1.3.0
+    dev: false
 
   /stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}


### PR DESCRIPTION
- minor addition to pass through logs received via stdin (since the test command can be long running it's useful to know if the tests are still running or the gas reporter is already parsing)