### PR TITLE
fix(cli): deploy failing to find user modules

### DIFF
--- a/packages/cli/src/utils/deploy.ts
+++ b/packages/cli/src/utils/deploy.ts
@@ -88,7 +88,7 @@ export async function deploy(
 
   // Filters any default modules from config
   const userModules = getUserModules(defaultModuleContracts, mudConfig.modules);
-  const userModuleContracts = Object.keys(userModules).map((name) => {
+  const userModuleContracts = userModules.map(({ name }) => {
     const { abi, bytecode } = getContractData(name, forgeOutDirectory);
     return {
       name,


### PR DESCRIPTION
When adding a custom user module to `mud.config.ts`, I am receiving the following error when deploying:

```
MUD dev-contracts watcher failed to deploy config or contracts changes

MUDError: Error reading file at out/0.sol/0.json
```

It appears the deploy script cannot find the compiled contract of my module, because it is using the array index (`0`) as the module name instead of the `name` field.