### PR TITLE
docs: render release date in changelog

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -63,9 +63,10 @@ async function appendChangelog() {
 async function renderChangelog() {
   const changes = await getChanges(INCLUDE_CHANGESETS);
   const version = await getVersion();
+  const date = new Date();
 
   return `## Version ${version}
-
+Release date: ${date.toDateString()}
 ${await renderChangelogItems("Major changes", changes.major)}
 ${await renderChangelogItems("Minor changes", changes.minor)}
 ${await renderChangelogItems("Patch changes", changes.patch)}


### PR DESCRIPTION
Minor addition to render the current date as release date when rendering the changelog. (The changelog is append-only, and the changelog script runs when creating a new version, so `new Date()` corresponds to the release date.)