### PR TITLE
feat(cli): remove forge clean from deploy

### DIFF
--- a/.changeset/silent-carrots-glow.md
+++ b/.changeset/silent-carrots-glow.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": minor
+---
+
+CLI `deploy`, `test`, `dev-contracts` no longer run `forge clean` before each deploy. We previously cleaned to ensure no outdated artifacts were checked into git (ABIs, typechain types, etc.). Now that all artifacts are gitignored, we can let forge use its cache again.

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -76,7 +76,6 @@ const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof
         const deploy = await runDeploy({
           configPath,
           rpc,
-          clean: true,
           skipBuild: false,
           printConfig: false,
           profile: undefined,

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { InferredOptionTypes, Options } from "yargs";
 import { deploy } from "./deploy/deploy";
 import { createWalletClient, http, Hex } from "viem";
@@ -19,11 +19,6 @@ import { tablegen } from "@latticexyz/store/codegen";
 
 export const deployOptions = {
   configPath: { type: "string", desc: "Path to the config file" },
-  clean: {
-    type: "boolean",
-    desc: "Remove the build forge artifacts and cache directories before building",
-    default: false,
-  },
   printConfig: { type: "boolean", desc: "Print the resolved config" },
   profile: { type: "string", desc: "The foundry profile to use" },
   saveDeployment: { type: "boolean", desc: "Save the deployment info to a file", default: true },
@@ -57,10 +52,6 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
       chalk.whiteBright(`\n Deploying MUD contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`)
     )
   );
-
-  if (opts.clean) {
-    await forge(["clean"], { profile });
-  }
 
   // Run forge build
   if (!opts.skipBuild) {


### PR DESCRIPTION
closes #1750

I think we were cleaning before when we had artifacts checked into git and we didn't want to leave around old artifacts, and when we were using typechain to generate types. I don't think this is as concerning anymore now that these are all in a gitignored directory and abi-ts is simple+fast.

I considered replacing `forge clean` with just `rm -rf out` but removing build files creates weird race conditions in Sky Strife deploy + start up, where a process has a chance of starting up while a redeploy is happening and then immediately fails because it can't find e.g. `out/IWorld.sol/IWorld.abi.json`.

If folks want a one-time, pre-deploy clean, they can add that to their script e.g. `forge clean && mud deploy`