### PR TITLE
feat(cli): add `--alwaysPostDeploy` flag to deploys

### DIFF
--- a/.changeset/metal-pots-notice.md
+++ b/.changeset/metal-pots-notice.md
@@ -2,6 +2,6 @@
 "@latticexyz/cli": minor
 ---
 
-Added a `--alwaysPostDeploy` flag to deploys (`deploy`, `test`, `dev-contracts` commands) to always run `PostDeploy.s.sol` script after each deploy. By default, `PostDeploy.s.sol` is only run once after a new world is deployed.
+Added a `--alwaysRunPostDeploy` flag to deploys (`deploy`, `test`, `dev-contracts` commands) to always run `PostDeploy.s.sol` script after each deploy. By default, `PostDeploy.s.sol` is only run once after a new world is deployed.
 
 This is helpful if you want to continue a deploy that may not have finished (due to an error or otherwise) or to run deploys with an idempotent `PostDeploy.s.sol` script.

--- a/.changeset/metal-pots-notice.md
+++ b/.changeset/metal-pots-notice.md
@@ -1,0 +1,7 @@
+---
+"@latticexyz/cli": minor
+---
+
+Added a `--alwaysPostDeploy` flag to deploys (`deploy`, `test`, `dev-contracts` commands) to always run `PostDeploy.s.sol` script after each deploy. By default, `PostDeploy.s.sol` is only run once after a new world is deployed.
+
+This is helpful if you want to continue a deploy that may not have finished (due to an error or otherwise) or to run deploys with an idempotent `PostDeploy.s.sol` script.

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -15,7 +15,7 @@ import { Address } from "viem";
 const devOptions = {
   rpc: deployOptions.rpc,
   configPath: deployOptions.configPath,
-  alwaysPostDeploy: deployOptions.alwaysPostDeploy,
+  alwaysRunPostDeploy: deployOptions.alwaysRunPostDeploy,
 };
 
 const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof devOptions>> = {

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -15,6 +15,7 @@ import { Address } from "viem";
 const devOptions = {
   rpc: deployOptions.rpc,
   configPath: deployOptions.configPath,
+  alwaysPostDeploy: deployOptions.alwaysPostDeploy,
 };
 
 const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof devOptions>> = {
@@ -74,6 +75,7 @@ const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof
         }
         // TODO: handle errors
         const deploy = await runDeploy({
+          ...opts,
           configPath,
           rpc,
           skipBuild: false,

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -26,6 +26,10 @@ export const deployOptions = {
   worldAddress: { type: "string", desc: "Deploy to an existing World at the given address" },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
   skipBuild: { type: "boolean", desc: "Skip rebuilding the contracts before deploying" },
+  alwaysPostDeploy: {
+    type: "boolean",
+    desc: "Always run PostDeploy.s.sol after each deploy (including during upgrades). By default, PostDeploy.s.sol is only run once after a new world is deployed.",
+  },
 } as const satisfies Record<string, Options>;
 
 export type DeployOptions = InferredOptionTypes<typeof deployOptions>;
@@ -84,7 +88,7 @@ in your contracts directory to use the default anvil private key.`
     client,
     config: resolvedConfig,
   });
-  if (opts.worldAddress == null) {
+  if (opts.worldAddress == null || opts.alwaysPostDeploy) {
     await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile);
   }
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -26,7 +26,7 @@ export const deployOptions = {
   worldAddress: { type: "string", desc: "Deploy to an existing World at the given address" },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
   skipBuild: { type: "boolean", desc: "Skip rebuilding the contracts before deploying" },
-  alwaysPostDeploy: {
+  alwaysRunPostDeploy: {
     type: "boolean",
     desc: "Always run PostDeploy.s.sol after each deploy (including during upgrades). By default, PostDeploy.s.sol is only run once after a new world is deployed.",
   },
@@ -88,7 +88,7 @@ in your contracts directory to use the default anvil private key.`
     client,
     config: resolvedConfig,
   });
-  if (opts.worldAddress == null || opts.alwaysPostDeploy) {
+  if (opts.worldAddress == null || opts.alwaysRunPostDeploy) {
     await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile);
   }
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));


### PR DESCRIPTION
Helpful if you want to re-run a `mud deploy` with a world that may not have finished deploying. A small workaround until we can do proper failure retries.

