### PR TITLE
fix(cli): deploy systems/modules before registering/installing them

### DIFF
--- a/.changeset/loud-mayflies-divide.md
+++ b/.changeset/loud-mayflies-divide.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Changed deploy order so that system/module contracts are fully deployed before registering/installing them on the world.

--- a/packages/cli/src/deploy/common.ts
+++ b/packages/cli/src/deploy/common.ts
@@ -38,25 +38,25 @@ export type WorldFunction = {
   readonly systemFunctionSelector: Hex;
 };
 
-export type System = {
+export type DeterministicContract = {
+  readonly address: Address;
+  readonly bytecode: Hex;
+  readonly abi: Abi;
+};
+
+export type System = DeterministicContract & {
   readonly namespace: string;
   readonly name: string;
   readonly systemId: Hex;
   readonly allowAll: boolean;
   readonly allowedAddresses: readonly Hex[];
-  readonly address: Address;
-  readonly bytecode: Hex;
-  readonly abi: Abi;
   readonly functions: readonly WorldFunction[];
 };
 
-export type Module = {
+export type Module = DeterministicContract & {
   readonly name: string;
   readonly installAsRoot: boolean;
   readonly installData: Hex; // TODO: figure out better naming for this
-  readonly address: Address;
-  readonly bytecode: Hex;
-  readonly abi: Abi;
 };
 
 export type ConfigInput = StoreConfig & WorldConfig;

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -2,14 +2,7 @@ import { Account, Address, Chain, Client, Transport } from "viem";
 import { ensureDeployer } from "./ensureDeployer";
 import { deployWorld } from "./deployWorld";
 import { ensureTables } from "./ensureTables";
-import {
-  Config,
-  ConfigInput,
-  DeterministicContract,
-  WorldDeploy,
-  supportedStoreVersions,
-  supportedWorldVersions,
-} from "./common";
+import { Config, ConfigInput, WorldDeploy, supportedStoreVersions, supportedWorldVersions } from "./common";
 import { ensureSystems } from "./ensureSystems";
 import { waitForTransactionReceipt } from "viem/actions";
 import { getWorldDeploy } from "./getWorldDeploy";

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -2,7 +2,14 @@ import { Account, Address, Chain, Client, Transport } from "viem";
 import { ensureDeployer } from "./ensureDeployer";
 import { deployWorld } from "./deployWorld";
 import { ensureTables } from "./ensureTables";
-import { Config, ConfigInput, WorldDeploy, supportedStoreVersions, supportedWorldVersions } from "./common";
+import {
+  Config,
+  ConfigInput,
+  DeterministicContract,
+  WorldDeploy,
+  supportedStoreVersions,
+  supportedWorldVersions,
+} from "./common";
 import { ensureSystems } from "./ensureSystems";
 import { waitForTransactionReceipt } from "viem/actions";
 import { getWorldDeploy } from "./getWorldDeploy";
@@ -11,6 +18,9 @@ import { ensureModules } from "./ensureModules";
 import { Table } from "./configToTables";
 import { assertNamespaceOwner } from "./assertNamespaceOwner";
 import { debug } from "./debug";
+import { resourceLabel } from "./resourceLabel";
+import { ensureContract } from "./ensureContract";
+import { uniqueBy } from "@latticexyz/common/utils";
 
 type DeployOptions<configInput extends ConfigInput> = {
   client: Client<Transport, Chain | undefined, Account>;
@@ -51,6 +61,27 @@ export async function deploy<configInput extends ConfigInput>({
     resourceIds: [...tables.map((table) => table.tableId), ...systems.map((system) => system.systemId)],
   });
 
+  // deploy all dependent contracts, because system registration, module install, etc. all expect these contracts to be callable.
+  const contractTxs = (
+    await Promise.all([
+      ...uniqueBy(systems, (system) => system.address).map((system) =>
+        ensureContract({ client, bytecode: system.bytecode, label: `${resourceLabel(system)} system` })
+      ),
+      ...uniqueBy(config.modules, (mod) => mod.address).map((mod) =>
+        ensureContract({ client, bytecode: mod.bytecode, label: `${mod.name} module` })
+      ),
+    ])
+  ).flat();
+
+  if (contractTxs.length) {
+    debug("waiting for contracts");
+    // wait for each tx separately/serially, because parallelizing results in RPC errors
+    for (const tx of contractTxs) {
+      await waitForTransactionReceipt(client, { hash: tx });
+      // TODO: throw if there was a revert?
+    }
+  }
+
   const tableTxs = await ensureTables({
     client,
     worldDeploy,
@@ -75,7 +106,7 @@ export async function deploy<configInput extends ConfigInput>({
   const txs = [...tableTxs, ...systemTxs, ...functionTxs, ...moduleTxs];
 
   // wait for each tx separately/serially, because parallelizing results in RPC errors
-  debug("waiting for transactions to confirm");
+  debug("waiting for all transactions to confirm");
   for (const tx of txs) {
     await waitForTransactionReceipt(client, { hash: tx });
     // TODO: throw if there was a revert?

--- a/packages/cli/src/deploy/ensureSystems.ts
+++ b/packages/cli/src/deploy/ensureSystems.ts
@@ -1,12 +1,11 @@
 import { Client, Transport, Chain, Account, Hex, getAddress } from "viem";
 import { writeContract } from "@latticexyz/common";
 import { System, WorldDeploy, worldAbi } from "./common";
-import { ensureContract } from "./ensureContract";
 import { debug } from "./debug";
 import { resourceLabel } from "./resourceLabel";
 import { getSystems } from "./getSystems";
 import { getResourceAccess } from "./getResourceAccess";
-import { uniqueBy, wait } from "@latticexyz/common/utils";
+import { wait } from "@latticexyz/common/utils";
 import pRetry from "p-retry";
 
 export async function ensureSystems({
@@ -53,7 +52,7 @@ export async function ensureSystems({
     debug("adding", accessToAdd.length, "access grants");
   }
 
-  const accessTxs = await Promise.all([
+  const accessTxs = [
     ...accessToRemove.map((access) =>
       pRetry(
         () =>
@@ -94,7 +93,7 @@ export async function ensureSystems({
         }
       )
     ),
-  ]);
+  ];
 
   const existingSystems = systems.filter((system) =>
     worldSystems.some(
@@ -127,37 +126,27 @@ export async function ensureSystems({
     debug("registering new systems", systemsToAdd.map(resourceLabel).join(", "));
   }
 
-  // kick off contract deployments first, otherwise registering systems can fail
-  const contractTxs = await Promise.all(
-    uniqueBy(missingSystems, (system) => system.address).map((system) =>
-      ensureContract({ client, bytecode: system.bytecode, label: `${resourceLabel(system)} system` })
+  const registerTxs = missingSystems.map((system) =>
+    pRetry(
+      () =>
+        writeContract(client, {
+          chain: client.chain ?? null,
+          address: worldDeploy.address,
+          abi: worldAbi,
+          // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
+          functionName: "registerSystem",
+          args: [system.systemId, system.address, system.allowAll],
+        }),
+      {
+        retries: 3,
+        onFailedAttempt: async (error) => {
+          const delay = error.attemptNumber * 500;
+          debug(`failed to register system ${resourceLabel(system)}, retrying in ${delay}ms...`);
+          await wait(delay);
+        },
+      }
     )
   );
 
-  // then start registering systems
-  const registerTxs = await Promise.all(
-    missingSystems.map((system) =>
-      pRetry(
-        () =>
-          writeContract(client, {
-            chain: client.chain ?? null,
-            address: worldDeploy.address,
-            abi: worldAbi,
-            // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
-            functionName: "registerSystem",
-            args: [system.systemId, system.address, system.allowAll],
-          }),
-        {
-          retries: 3,
-          onFailedAttempt: async (error) => {
-            const delay = error.attemptNumber * 500;
-            debug(`failed to register system ${resourceLabel(system)}, retrying in ${delay}ms...`);
-            await wait(delay);
-          },
-        }
-      )
-    )
-  );
-
-  return (await Promise.all([...accessTxs, ...contractTxs, ...registerTxs])).flat();
+  return await Promise.all([...accessTxs, ...registerTxs]);
 }


### PR DESCRIPTION
Using the `pending` block tag to simulate/estimate gas seems to give bad results if the a contract being called does not yet exist (i.e. is itself pending in the mempool). So we need to wait for contracts to be deployed before proceeding.