### PR TITLE
feat(cli,create-mud): use forge cache

### DIFF
--- a/.changeset/slimy-glasses-tickle.md
+++ b/.changeset/slimy-glasses-tickle.md
@@ -1,0 +1,8 @@
+---
+"@latticexyz/cli": patch
+"create-mud": patch
+---
+
+Sped up builds by using more of forge's cache.
+
+Previously we'd build only what we needed because we would check in ABIs and other build artifacts into git, but that meant that we'd get a lot of forge cache misses. Now that we no longer need these files visible, we can take advantage of forge's caching and greatly speed up builds, especially incremental ones.

--- a/e2e/packages/contracts/package.json
+++ b/e2e/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "mud tablegen && mud worldgen",
     "clean": "pnpm run clean:abi && pnpm run clean:mud",
     "clean:abi": "forge clean",

--- a/examples/minimal/packages/contracts/package.json
+++ b/examples/minimal/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge clean && forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "rimraf src/codegen && mud tablegen && mud worldgen",
     "deploy:local": "pnpm run build && mud deploy",
     "deploy:testnet": "pnpm run build && mud deploy --profile=lattice-testnet",

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -61,7 +61,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   if (!opts.skipBuild) {
     const outPath = path.join(srcDir, config.codegenDirectory);
     await tablegen(config, outPath, remappings);
-    await forge(["build", "--skip", "test", "script"], { profile });
+    await forge(["build"], { profile });
     await execa("mud", ["abi-ts"], { stdio: "inherit" });
   }
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -35,8 +35,8 @@
   },
   "scripts": {
     "build": "pnpm run build:tightcoder && pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts && pnpm run build:js",
-    "build:abi": "forge build --skip test script",
-    "build:abi-ts": "abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "abi-ts",
     "build:js": "tsup",
     "build:mud": "tsx ./ts/scripts/tablegen.ts && tsx ./ts/scripts/generate-test-tables.ts",
     "build:tightcoder": "tsx ./ts/scripts/generate-tightcoder.ts",

--- a/packages/world-modules/package.json
+++ b/packages/world-modules/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts && pnpm run build:js",
-    "build:abi": "forge build --skip test script",
-    "build:abi-ts": "abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "abi-ts",
     "build:js": "tsup",
     "build:mud": "tsx ./ts/scripts/tablegen.ts && tsx ./ts/scripts/worldgen.ts",
     "clean": "pnpm run clean:abi && pnpm run clean:js && pnpm run clean:mud",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -31,8 +31,8 @@
   },
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts && pnpm run build:js",
-    "build:abi": "forge build --skip test script",
-    "build:abi-ts": "abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "abi-ts",
     "build:js": "tsup",
     "build:mud": "tsx ./ts/scripts/tablegen.ts && tsx ./ts/scripts/worldgen.ts && tsx ./ts/scripts/generate-test-tables.ts",
     "clean": "pnpm run clean:abi && pnpm run clean:js && pnpm run clean:mud",

--- a/templates/phaser/packages/contracts/package.json
+++ b/templates/phaser/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge clean && forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "rimraf src/codegen && mud tablegen && mud worldgen",
     "deploy:local": "pnpm run build && mud deploy",
     "deploy:testnet": "pnpm run build && mud deploy --profile=lattice-testnet",

--- a/templates/react/packages/contracts/package.json
+++ b/templates/react/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge clean && forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "rimraf src/codegen && mud tablegen && mud worldgen",
     "deploy:local": "pnpm run build && mud deploy",
     "deploy:testnet": "pnpm run build && mud deploy --profile=lattice-testnet",

--- a/templates/threejs/packages/contracts/package.json
+++ b/templates/threejs/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge clean && forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "rimraf src/codegen && mud tablegen && mud worldgen",
     "deploy:local": "pnpm run build && mud deploy",
     "deploy:testnet": "pnpm run build && mud deploy --profile=lattice-testnet",

--- a/templates/vanilla/packages/contracts/package.json
+++ b/templates/vanilla/packages/contracts/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "pnpm run build:mud && pnpm run build:abi && pnpm run build:abi-ts",
-    "build:abi": "forge clean && forge build --skip test script",
-    "build:abi-ts": "mud abi-ts && prettier --write '**/*.abi.json.d.ts'",
+    "build:abi": "forge build",
+    "build:abi-ts": "mud abi-ts",
     "build:mud": "rimraf src/codegen && mud tablegen && mud worldgen",
     "deploy:local": "pnpm run build && mud deploy",
     "deploy:testnet": "pnpm run build && mud deploy --profile=lattice-testnet",


### PR DESCRIPTION
fixes #1773
fixes #1748

Now that forge artifacts are gitignored, we don't need to specifically target which artifacts to build or make them pretty, which greatly speeds up forge because it can use its full cache.
