### PR TITLE
chore: switch to hardhat solidity vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["JuanBlanco.solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-  "solidity.monoRepoSupport": true,
-  "solidity.compileUsingRemoteVersion": "v0.8.21+commit.d9974bed"
-}
+{}

--- a/e2e/packages/contracts/remappings.txt
+++ b/e2e/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/

--- a/examples/minimal/packages/contracts/remappings.txt
+++ b/examples/minimal/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/

--- a/templates/phaser/.vscode/extensions.json
+++ b/templates/phaser/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["JuanBlanco.solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity"]
 }

--- a/templates/phaser/.vscode/settings.json
+++ b/templates/phaser/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-  "solidity.monoRepoSupport": true,
-  "solidity.compileUsingRemoteVersion": "v0.8.21+commit.d9974bed"
-}
+{}

--- a/templates/phaser/packages/contracts/remappings.txt
+++ b/templates/phaser/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/

--- a/templates/react/.vscode/extensions.json
+++ b/templates/react/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["JuanBlanco.solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity"]
 }

--- a/templates/react/.vscode/settings.json
+++ b/templates/react/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-  "solidity.monoRepoSupport": true,
-  "solidity.compileUsingRemoteVersion": "v0.8.21+commit.d9974bed"
-}
+{}

--- a/templates/react/packages/contracts/remappings.txt
+++ b/templates/react/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/

--- a/templates/threejs/.vscode/extensions.json
+++ b/templates/threejs/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["JuanBlanco.solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity"]
 }

--- a/templates/threejs/.vscode/settings.json
+++ b/templates/threejs/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-  "solidity.monoRepoSupport": true,
-  "solidity.compileUsingRemoteVersion": "v0.8.21+commit.d9974bed"
-}
+{}

--- a/templates/threejs/packages/contracts/remappings.txt
+++ b/templates/threejs/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/

--- a/templates/vanilla/.vscode/extensions.json
+++ b/templates/vanilla/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["JuanBlanco.solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity"]
 }

--- a/templates/vanilla/.vscode/settings.json
+++ b/templates/vanilla/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-  "solidity.monoRepoSupport": true,
-  "solidity.compileUsingRemoteVersion": "v0.8.21+commit.d9974bed"
-}
+{}

--- a/templates/vanilla/packages/contracts/remappings.txt
+++ b/templates/vanilla/packages/contracts/remappings.txt
@@ -1,3 +1,3 @@
-ds-test/=./node_modules/ds-test/src/
-forge-std/=./node_modules/forge-std/src/
-@latticexyz/=./node_modules/@latticexyz/
+ds-test/=node_modules/ds-test/src/
+forge-std/=node_modules/forge-std/src/
+@latticexyz/=node_modules/@latticexyz/


### PR DESCRIPTION
- updates to hardhat solidity plugin for speed
- removes juanblanco-specific settings
- updates remappings because hardhat solidity didn't like the `./` path