### PR TITLE
fix(common,config): remove chalk usage

### DIFF
--- a/.changeset/small-dots-poke.md
+++ b/.changeset/small-dots-poke.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/common": patch
+"@latticexyz/config": patch
+---
+
+Removed chalk usage from modules imported in client fix downstream client builds (vite in particular).

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@latticexyz/schema-type": "workspace:*",
     "@solidity-parser/parser": "^0.16.0",
-    "chalk": "^5.2.0",
     "debug": "^4.3.4",
     "execa": "^7.0.0",
     "p-queue": "^7.4.1",

--- a/packages/common/src/codegen/utils/format.ts
+++ b/packages/common/src/codegen/utils/format.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import prettier from "prettier";
 import prettierPluginSolidity from "prettier-plugin-solidity";
 
@@ -27,7 +26,7 @@ export async function formatSolidity(content: string, prettierConfigPath?: strin
     } else {
       message = error;
     }
-    console.log(chalk.yellow(`Error during output formatting: ${message}`));
+    console.log(`Error during output formatting: ${message}`);
     return content;
   }
 }

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -1,5 +1,4 @@
 import { execa, Options } from "execa";
-import chalk from "chalk";
 
 export interface ForgeConfig {
   // project
@@ -127,13 +126,13 @@ export async function anvil(args: string[]): Promise<string> {
 async function execLog(command: string, args: string[], options?: Options<string>): Promise<string> {
   const commandString = `${command} ${args.join(" ")}`;
   try {
-    console.log(chalk.gray(`running "${commandString}"`));
+    console.log(`running "${commandString}"`);
     const { stdout } = await execa(command, args, { stdout: "pipe", stderr: "pipe", ...options });
     return stdout;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     let errorMessage = error?.stderr || error?.message || "";
-    errorMessage += chalk.red(`\nError running "${commandString}"`);
+    errorMessage += `\nError running "${commandString}"`;
     throw new Error(errorMessage);
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@latticexyz/common": "workspace:*",
     "@latticexyz/schema-type": "workspace:*",
-    "chalk": "^5.2.0",
     "esbuild": "^0.17.15",
     "ethers": "^5.7.2",
     "find-up": "^6.3.0",

--- a/packages/config/src/library/errors.ts
+++ b/packages/config/src/library/errors.ts
@@ -1,4 +1,3 @@
-import chalk from "chalk";
 import { z, ZodError, ZodIssueCode } from "zod";
 import { fromZodError } from "zod-validation-error";
 
@@ -15,7 +14,7 @@ export class MUDContextNotCreatedError extends Error {
 // Wrapper with preset styles, only requires a `prefix`
 export function fromZodErrorCustom(error: ZodError, prefix: string) {
   return fromZodError(error, {
-    prefix: chalk.red(prefix),
+    prefix: prefix,
     prefixSeparator: "\n- ",
     issueSeparator: "\n- ",
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,9 +266,6 @@ importers:
       '@solidity-parser/parser':
         specifier: ^0.16.0
         version: 0.16.0
-      chalk:
-        specifier: ^5.2.0
-        version: 5.2.0
       debug:
         specifier: ^4.3.4
         version: 4.3.4(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,9 +312,6 @@ importers:
       '@latticexyz/schema-type':
         specifier: workspace:*
         version: link:../schema-type
-      chalk:
-        specifier: ^5.2.0
-        version: 5.2.0
       esbuild:
         specifier: ^0.17.15
         version: 0.17.15


### PR DESCRIPTION
When building a MUD v2 client project with vite (`pnpm run build`), the chalk dependency in `@latticexyz/config` and `@latticexyz/common` causes the following error:

```
error during build:
Error: [vite]: Rollup failed to resolve import "#ansi-styles" from "../../node_modules/.pnpm/chalk@5.3.0/node_modules/chalk/source/index.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at onRollupWarning (file:///vercel/path0/node_modules/.pnpm/vite@3.2.3_@types+node@18.17.14/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:45522:19)
    at onwarn (file:///vercel/path0/node_modules/.pnpm/vite@3.2.3_@types+node@18.17.14/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:45293:13)
    at Object.onwarn (file:///vercel/path0/node_modules/.pnpm/rollup@2.79.1/node_modules/rollup/dist/es/shared/rollup.js:23263:13)
    at ModuleLoader.handleResolveId (file:///vercel/path0/node_modules/.pnpm/rollup@2.79.1/node_modules/rollup/dist/es/shared/rollup.js:22158:26)
    at file:///vercel/path0/node_modules/.pnpm/rollup@2.79.1/node_modules/rollup/dist/es/shared/rollup.js:22119:26
 ELIFECYCLE  Command failed with exit code 1.
Error: Command "pnpm run build" exited with 1
```

which can be fixed by adding chalk to external dependencies in vite.config.ts:

```typescript
  build: {
    rollupOptions: {
      external: ["chalk"], // fix for chalk
        ...
      },
    },
    target: "ES2022",
  },
```

but this results in the following runtime error in the browser as shown in the screenshot. Note that this is a production build served by `serve dist`

```
Uncaught TypeError: Failed to resolve module specifier "chalk". Relative references must start with either "/", "./", or "../".
```

<img width="773" alt="image" src="https://github.com/primodiumxyz/primodium/assets/2308546/19c0d22c-28ad-4274-968c-7c5b764f1ba9">

Upon inspecting our bundle, `@latticexyz/config` which imports chalk appears in our browser bundle:

![image](https://github.com/latticexyz/mud/assets/2308546/f5c3157e-69c6-41b2-adb8-3393006f9c9a)

![image](https://github.com/latticexyz/mud/assets/2308546/17b1097f-729d-4b46-a922-4824995f6d9d)

This PR removes the dependency on `chalk` so that if it's imported by any submodules that shares a `pnpm.lock` with a browser client, `chalk` would not need to be externalized or imported. Our client also uses `getBurnerPrivateKey` and imports from `@latticexyz/common/chains` which directly requires `@latticexyz/common`.

[Discord thread](https://discord.com/channels/865335009915961364/1164269966284029993/1164269966284029993)