### PR TITLE
feat(store): add experimental config resolve helper

### DIFF
--- a/.changeset/dirty-cows-lie.md
+++ b/.changeset/dirty-cows-lie.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/store": minor
+---
+
+Added an experimental `resolveConfig` helper to refine the output type of `mudConfig` and simplify downstream consumption.
+Note that it's not recommended to use this helper externally yet, since the format is expected to change soon while we're refactoring the config parsing.

--- a/.changeset/dirty-cows-lie.md
+++ b/.changeset/dirty-cows-lie.md
@@ -1,6 +1,0 @@
----
-"@latticexyz/store": minor
----
-
-Added an experimental `resolveConfig` helper to refine the output type of `mudConfig` and simplify downstream consumption.
-Note that it's not recommended to use this helper externally yet, since the format is expected to change soon while we're refactoring the config parsing.

--- a/.changeset/three-scissors-smile.md
+++ b/.changeset/three-scissors-smile.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": minor
+---
+
+Added a `mapObject` helper to map the value of each property of an object to a new value.

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from "./identity";
 export * from "./isDefined";
 export * from "./isNotNull";
 export * from "./iteratorToArray";
+export * from "./mapObject";
 export * from "./uniqueBy";
 export * from "./wait";
 export * from "./waitForIdle";

--- a/packages/common/src/utils/mapObject.test.ts
+++ b/packages/common/src/utils/mapObject.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { mapObject } from "./mapObject";
+import { assertExhaustive } from "./assertExhaustive";
+
+describe("mapObject", () => {
+  it("should map the source to the target", () => {
+    const source = {
+      hello: "world",
+      foo: "bar",
+    } as const;
+
+    type Mapped<T extends Record<string, string>> = { [key in keyof T]: `mapped-${T[key]}` };
+
+    const target = mapObject<typeof source, Mapped<typeof source>>(source, (key) => {
+      if (key === "hello") return `mapped-${source[key]}`;
+      if (key === "foo") return `mapped-${source[key]}`;
+      assertExhaustive(key);
+    });
+
+    expect(target).toEqual({ hello: `mapped-world` });
+    expectTypeOf<typeof target>().toEqualTypeOf<Mapped<typeof source>>();
+  });
+});

--- a/packages/common/src/utils/mapObject.test.ts
+++ b/packages/common/src/utils/mapObject.test.ts
@@ -17,7 +17,7 @@ describe("mapObject", () => {
       assertExhaustive(key);
     });
 
-    expect(target).toEqual({ hello: `mapped-world` });
+    expect(target).toEqual({ hello: `mapped-world`, foo: `mapped-bar` });
     expectTypeOf<typeof target>().toEqualTypeOf<Mapped<typeof source>>();
   });
 });

--- a/packages/common/src/utils/mapObject.test.ts
+++ b/packages/common/src/utils/mapObject.test.ts
@@ -11,9 +11,9 @@ describe("mapObject", () => {
 
     type Mapped<T extends Record<string, string>> = { [key in keyof T]: `mapped-${T[key]}` };
 
-    const target = mapObject<typeof source, Mapped<typeof source>>(source, (key) => {
-      if (key === "hello") return `mapped-${source[key]}`;
-      if (key === "foo") return `mapped-${source[key]}`;
+    const target = mapObject<typeof source, Mapped<typeof source>>(source, (value, key) => {
+      if (key === "hello") return `mapped-${value}`;
+      if (key === "foo") return `mapped-${value}`;
       assertExhaustive(key);
     });
 

--- a/packages/common/src/utils/mapObject.ts
+++ b/packages/common/src/utils/mapObject.ts
@@ -5,9 +5,7 @@ export function mapObject<
   Source extends Record<string | number | symbol, unknown>,
   Target extends { [key in keyof Source]: unknown }
 >(source: Source, valueMap: (key: keyof Source, value: Source[typeof key]) => Target[typeof key]): Target {
-  const target: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(source)) {
-    target[key] = valueMap(key, value as Source[keyof Source]);
-  }
-  return target as Target;
+  return Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [key, valueMap(key, value as Source[keyof Source])])
+  ) as Target;
 }

--- a/packages/common/src/utils/mapObject.ts
+++ b/packages/common/src/utils/mapObject.ts
@@ -4,8 +4,8 @@
 export function mapObject<
   Source extends Record<string | number | symbol, unknown>,
   Target extends { [key in keyof Source]: unknown }
->(source: Source, valueMap: (key: keyof Source, value: Source[typeof key]) => Target[typeof key]): Target {
+>(source: Source, valueMap: (value: Source[typeof key], key: keyof Source) => Target[typeof key]): Target {
   return Object.fromEntries(
-    Object.entries(source).map(([key, value]) => [key, valueMap(key, value as Source[keyof Source])])
+    Object.entries(source).map(([key, value]) => [key, valueMap(value as Source[keyof Source], key)])
   ) as Target;
 }

--- a/packages/common/src/utils/mapObject.ts
+++ b/packages/common/src/utils/mapObject.ts
@@ -1,10 +1,10 @@
 /**
  * Map each key of a source object via a given valueMap function
  */
-export function mapObject<Source extends Record<string, unknown>, Target extends { [key in keyof Source]: unknown }>(
-  source: Source,
-  valueMap: (key: keyof Source, value: Source[typeof key]) => Target[typeof key]
-): Target {
+export function mapObject<
+  Source extends Record<string | number | symbol, unknown>,
+  Target extends { [key in keyof Source]: unknown }
+>(source: Source, valueMap: (key: keyof Source, value: Source[typeof key]) => Target[typeof key]): Target {
   const target: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(source)) {
     target[key] = valueMap(key, value as Source[keyof Source]);

--- a/packages/common/src/utils/mapObject.ts
+++ b/packages/common/src/utils/mapObject.ts
@@ -1,0 +1,13 @@
+/**
+ * Map each key of a source object via a given valueMap function
+ */
+export function mapObject<Source extends Record<string, unknown>, Target extends { [key in keyof Source]: unknown }>(
+  source: Source,
+  valueMap: (key: keyof Source, value: Source[typeof key]) => Target[typeof key]
+): Target {
+  const target: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    target[key] = valueMap(key, value as Source[keyof Source]);
+  }
+  return target as Target;
+}

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -2,7 +2,7 @@ import { mudConfig } from "./ts/register";
 
 export default mudConfig({
   storeImportPath: "../../",
-  namespace: "store",
+  namespace: "store" as const,
   userTypes: {
     ResourceId: { filePath: "./src/ResourceId.sol", internalType: "bytes32" },
     FieldLayout: { filePath: "./src/FieldLayout.sol", internalType: "bytes32" },

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -8,9 +8,6 @@ export default mudConfig({
     FieldLayout: { filePath: "./src/FieldLayout.sol", internalType: "bytes32" },
     Schema: { filePath: "./src/Schema.sol", internalType: "bytes32" },
   },
-  enums: {
-    Enum1: ["hello", "world"],
-  },
   tables: {
     StoreHooks: {
       keySchema: {

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -1,7 +1,6 @@
-import { resolveConfig } from "./ts/config/experimental/resolveConfig";
 import { mudConfig } from "./ts/register";
 
-const config = mudConfig({
+export default mudConfig({
   storeImportPath: "../../",
   namespace: "store",
   userTypes: {
@@ -51,33 +50,5 @@ const config = mudConfig({
       },
       tableIdArgument: true,
     },
-    Shorthand: {
-      keySchema: {
-        key: "ResourceId",
-      },
-      valueSchema: "Enum1",
-    },
   },
 });
-
-export default config;
-
-const resolvedConfig = resolveConfig(config);
-
-resolvedConfig.tables.Shorthand.keySchema.key;
-//                                        ^?
-
-resolvedConfig.tables.Shorthand.valueSchema.value;
-//                                          ^?
-
-resolvedConfig.resolved.tables.Shorthand.keySchema.key.type;
-//                                                     ^?
-
-resolvedConfig.resolved.tables.Shorthand.keySchema.key.internalType;
-//                                                     ^?
-
-resolvedConfig.resolved.tables.Shorthand.valueSchema.value.type;
-//                                                         ^?
-
-resolvedConfig.resolved.tables.Shorthand.valueSchema.value.internalType;
-//                                                         ^?

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -1,7 +1,6 @@
-import { resolveConfig } from "./ts/config/experimental/resolveConfig";
 import { mudConfig } from "./ts/register";
 
-const config = mudConfig({
+export default mudConfig({
   storeImportPath: "../../",
   namespace: "store",
   userTypes: {
@@ -56,25 +55,3 @@ const config = mudConfig({
     },
   },
 });
-
-export default config;
-
-const resolvedConfig = resolveConfig(config);
-
-resolvedConfig.tables.Shorthand.keySchema.key;
-//                                        ^?
-
-resolvedConfig.tables.Shorthand.valueSchema.value;
-//                                          ^?
-
-resolvedConfig.resolved.tables.Shorthand.keySchema.key.type;
-//                                                     ^?
-
-resolvedConfig.resolved.tables.Shorthand.keySchema.key.internalType;
-//                                                     ^?
-
-resolvedConfig.resolved.tables.Shorthand.valueSchema.value.type;
-//                                                         ^?
-
-resolvedConfig.resolved.tables.Shorthand.valueSchema.value.internalType;
-//                                                         ^?

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -1,12 +1,16 @@
+import { resolveConfig } from "./ts/config/experimental/resolveConfig";
 import { mudConfig } from "./ts/register";
 
-export default mudConfig({
+const config = mudConfig({
   storeImportPath: "../../",
   namespace: "store",
   userTypes: {
     ResourceId: { filePath: "./src/ResourceId.sol", internalType: "bytes32" },
     FieldLayout: { filePath: "./src/FieldLayout.sol", internalType: "bytes32" },
     Schema: { filePath: "./src/Schema.sol", internalType: "bytes32" },
+  },
+  enums: {
+    Enum1: ["hello", "world"],
   },
   tables: {
     StoreHooks: {
@@ -51,7 +55,29 @@ export default mudConfig({
       keySchema: {
         key: "ResourceId",
       },
-      valueSchema: "ResourceId",
+      valueSchema: "Enum1",
     },
   },
 });
+
+export default config;
+
+const resolvedConfig = resolveConfig(config);
+
+resolvedConfig.tables.Shorthand.keySchema.key;
+//                                        ^?
+
+resolvedConfig.tables.Shorthand.valueSchema.value;
+//                                          ^?
+
+resolvedConfig.resolved.tables.Shorthand.keySchema.key.type;
+//                                                     ^?
+
+resolvedConfig.resolved.tables.Shorthand.keySchema.key.internalType;
+//                                                     ^?
+
+resolvedConfig.resolved.tables.Shorthand.valueSchema.value.type;
+//                                                         ^?
+
+resolvedConfig.resolved.tables.Shorthand.valueSchema.value.internalType;
+//                                                         ^?

--- a/packages/store/mud.config.ts
+++ b/packages/store/mud.config.ts
@@ -1,6 +1,7 @@
+import { resolveConfig } from "./ts/config/experimental/resolveConfig";
 import { mudConfig } from "./ts/register";
 
-export default mudConfig({
+const config = mudConfig({
   storeImportPath: "../../",
   namespace: "store",
   userTypes: {
@@ -47,5 +48,33 @@ export default mudConfig({
       },
       tableIdArgument: true,
     },
+    Shorthand: {
+      keySchema: {
+        key: "ResourceId",
+      },
+      valueSchema: "ResourceId",
+    },
   },
 });
+
+export default config;
+
+const resolvedConfig = resolveConfig(config);
+
+resolvedConfig.tables.Shorthand.keySchema.key;
+//                                        ^?
+
+resolvedConfig.tables.Shorthand.valueSchema.value;
+//                                          ^?
+
+resolvedConfig.resolved.tables.Shorthand.keySchema.key.type;
+//                                                     ^?
+
+resolvedConfig.resolved.tables.Shorthand.keySchema.key.internalType;
+//                                                     ^?
+
+resolvedConfig.resolved.tables.Shorthand.valueSchema.value.type;
+//                                                         ^?
+
+resolvedConfig.resolved.tables.Shorthand.valueSchema.value.internalType;
+//                                                         ^?

--- a/packages/store/ts/config/experimental/resolveConfig.test-d.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test-d.ts
@@ -4,6 +4,10 @@ import { resolveConfig } from "./resolveConfig";
 
 const config = resolveConfig(
   mudConfig({
+    // Seems like we need `as const` here to keep the strong type.
+    // Note it resolves to the strong `""` type if no namespace is provided.
+    // TODO: require the entire input config to be `const`
+    namespace: "the-namespace" as const,
     userTypes: {
       ResourceId: {
         internalType: "bytes32",
@@ -25,6 +29,12 @@ const config = resolveConfig(
 );
 
 describe("resolveConfig", () => {
+  expectTypeOf<typeof config._resolved.tables.Shorthand.namespace>().toEqualTypeOf<"the-namespace">();
+
+  expectTypeOf<typeof config._resolved.tables.Shorthand.name>().toEqualTypeOf<"Shorthand">();
+
+  expectTypeOf<typeof config._resolved.tables.Shorthand.tableId>().toEqualTypeOf<`0x${string}`>();
+
   expectTypeOf<typeof config._resolved.tables.Shorthand.keySchema>().toEqualTypeOf<{
     key: {
       internalType: "ResourceId";

--- a/packages/store/ts/config/experimental/resolveConfig.test-d.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test-d.ts
@@ -29,20 +29,20 @@ const config = resolveConfig(
 );
 
 describe("resolveConfig", () => {
-  expectTypeOf<typeof config._resolved.tables.Shorthand.namespace>().toEqualTypeOf<"the-namespace">();
+  expectTypeOf<typeof config.tables.Shorthand.namespace>().toEqualTypeOf<"the-namespace">();
 
-  expectTypeOf<typeof config._resolved.tables.Shorthand.name>().toEqualTypeOf<"Shorthand">();
+  expectTypeOf<typeof config.tables.Shorthand.name>().toEqualTypeOf<"Shorthand">();
 
-  expectTypeOf<typeof config._resolved.tables.Shorthand.tableId>().toEqualTypeOf<`0x${string}`>();
+  expectTypeOf<typeof config.tables.Shorthand.tableId>().toEqualTypeOf<`0x${string}`>();
 
-  expectTypeOf<typeof config._resolved.tables.Shorthand.keySchema>().toEqualTypeOf<{
+  expectTypeOf<typeof config.tables.Shorthand.keySchema>().toEqualTypeOf<{
     key: {
       internalType: "ResourceId";
       type: "bytes32";
     };
   }>();
 
-  expectTypeOf<typeof config._resolved.tables.Shorthand.valueSchema>().toEqualTypeOf<{
+  expectTypeOf<typeof config.tables.Shorthand.valueSchema>().toEqualTypeOf<{
     value: {
       internalType: "ResourceType";
       type: "uint8";

--- a/packages/store/ts/config/experimental/resolveConfig.test-d.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test-d.ts
@@ -1,0 +1,41 @@
+import { describe, expectTypeOf } from "vitest";
+import { mudConfig } from "../../register/mudConfig";
+import { resolveConfig } from "./resolveConfig";
+
+const config = resolveConfig(
+  mudConfig({
+    userTypes: {
+      ResourceId: {
+        internalType: "bytes32",
+        filePath: "",
+      },
+    },
+    enums: {
+      ResourceType: ["namespace", "system", "table"],
+    },
+    tables: {
+      Shorthand: {
+        keySchema: {
+          key: "ResourceId",
+        },
+        valueSchema: "ResourceType",
+      },
+    },
+  })
+);
+
+describe("resolveConfig", () => {
+  expectTypeOf<typeof config._resolved.tables.Shorthand.keySchema>().toEqualTypeOf<{
+    key: {
+      internalType: "ResourceId";
+      type: "bytes32";
+    };
+  }>();
+
+  expectTypeOf<typeof config._resolved.tables.Shorthand.valueSchema>().toEqualTypeOf<{
+    value: {
+      internalType: "ResourceType";
+      type: "uint8";
+    };
+  }>();
+});

--- a/packages/store/ts/config/experimental/resolveConfig.test.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { mudConfig } from "../../register/mudConfig";
 import { resolveConfig } from "./resolveConfig";
 import { MUDCoreContext } from "@latticexyz/config";
+import { resourceToHex } from "@latticexyz/common";
 MUDCoreContext.createContext();
 
 const config = resolveConfig(
   mudConfig({
+    namespace: "the-namespace",
     userTypes: {
       ResourceId: {
         internalType: "bytes32",
@@ -28,9 +30,18 @@ const config = resolveConfig(
 
 describe("resolveConfig", () => {
   it("should resolve userTypes and enums", () => {
+    expect(config._resolved.tables.Shorthand.namespace).toEqual("the-namespace");
+
+    expect(config._resolved.tables.Shorthand.name).toEqual("Shorthand");
+
+    expect(config._resolved.tables.Shorthand.tableId).toEqual(
+      resourceToHex({ type: "table", namespace: "the-namespace", name: "Shorthand" })
+    );
+
     expect(config._resolved.tables.Shorthand.keySchema).toEqual({
       key: { internalType: "ResourceId", type: "bytes32" },
     });
+
     expect(config._resolved.tables.Shorthand.valueSchema).toEqual({
       value: { internalType: "ResourceType", type: "uint8" },
     });

--- a/packages/store/ts/config/experimental/resolveConfig.test.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test.ts
@@ -30,19 +30,19 @@ const config = resolveConfig(
 
 describe("resolveConfig", () => {
   it("should resolve userTypes and enums", () => {
-    expect(config._resolved.tables.Shorthand.namespace).toEqual("the-namespace");
+    expect(config.tables.Shorthand.namespace).toEqual("the-namespace");
 
-    expect(config._resolved.tables.Shorthand.name).toEqual("Shorthand");
+    expect(config.tables.Shorthand.name).toEqual("Shorthand");
 
-    expect(config._resolved.tables.Shorthand.tableId).toEqual(
+    expect(config.tables.Shorthand.tableId).toEqual(
       resourceToHex({ type: "table", namespace: "the-namespace", name: "Shorthand" })
     );
 
-    expect(config._resolved.tables.Shorthand.keySchema).toEqual({
+    expect(config.tables.Shorthand.keySchema).toEqual({
       key: { internalType: "ResourceId", type: "bytes32" },
     });
 
-    expect(config._resolved.tables.Shorthand.valueSchema).toEqual({
+    expect(config.tables.Shorthand.valueSchema).toEqual({
       value: { internalType: "ResourceType", type: "uint8" },
     });
   });

--- a/packages/store/ts/config/experimental/resolveConfig.test.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { mudConfig } from "../../register/mudConfig";
+import { resolveConfig } from "./resolveConfig";
+import { MUDCoreContext } from "@latticexyz/config";
+MUDCoreContext.createContext();
+
+const config = resolveConfig(
+  mudConfig({
+    userTypes: {
+      ResourceId: {
+        internalType: "bytes32",
+        filePath: "",
+      },
+    },
+    enums: {
+      ResourceType: ["namespace", "system", "table"],
+    },
+    tables: {
+      Shorthand: {
+        keySchema: {
+          key: "ResourceId",
+        },
+        valueSchema: "ResourceType",
+      },
+    },
+  })
+);
+
+describe("resolveConfig", () => {
+  it("should resolve userTypes and enums", () => {
+    expect(config._resolved.tables.Shorthand.keySchema).toEqual({
+      key: { internalType: "ResourceId", type: "bytes32" },
+    });
+    expect(config._resolved.tables.Shorthand.valueSchema).toEqual({
+      value: { internalType: "ResourceType", type: "uint8" },
+    });
+  });
+});

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -3,7 +3,8 @@ import { StoreConfig, TableConfig, UserTypesConfig } from "../storeConfig";
 import { UserType } from "@latticexyz/common/codegen";
 
 export type ResolvedStoreConfig<TStoreConfig extends StoreConfig> = TStoreConfig & {
-  resolved: {
+  /** @deprecated Note: this property is experimental and expected to change */
+  _resolved: {
     tables: {
       [key in keyof TStoreConfig["tables"]]: ResolvedTableConfig<
         TStoreConfig["tables"][key],
@@ -19,9 +20,21 @@ export type ResolvedTableConfig<
   TUserTypes extends UserTypesConfig,
   TEnumNames extends StringForUnion
 > = Omit<TTableConfig, "keySchema" | "valueSchema"> & {
-  keySchema: ResolvedSchema<TTableConfig["keySchema"], TUserTypes, TEnumNames>;
-  valueSchema: ResolvedSchema<TTableConfig["valueSchema"], TUserTypes, TEnumNames>;
+  keySchema: ResolvedKeySchema<TTableConfig["keySchema"], TUserTypes, TEnumNames>;
+  valueSchema: ResolvedValueSchema<TTableConfig["valueSchema"], TUserTypes, TEnumNames>;
 };
+
+export type ResolvedKeySchema<
+  TKeySchema extends TableConfig["keySchema"],
+  TUserTypes extends UserTypesConfig,
+  TEnumNames extends StringForUnion
+> = ResolvedSchema<TKeySchema, TUserTypes, TEnumNames>;
+
+export type ResolvedValueSchema<
+  TValueSchema extends TableConfig["valueSchema"],
+  TUserTypes extends UserTypesConfig,
+  TEnumNames extends StringForUnion
+> = ResolvedSchema<TValueSchema, TUserTypes, TEnumNames>;
 
 export type ResolvedSchema<
   TSchema extends TableConfig["keySchema"] | TableConfig["valueSchema"],
@@ -47,5 +60,80 @@ export type ResolvedSchema<
 export function resolveConfig<TStoreConfig extends StoreConfig>(
   config: TStoreConfig
 ): ResolvedStoreConfig<TStoreConfig> {
-  return config as ResolvedStoreConfig<TStoreConfig>;
+  const resolvedTables: Record<string, ReturnType<typeof resolveTable>> = {};
+
+  for (const key of Object.keys(config.tables)) {
+    resolvedTables[key] = resolveTable(config.tables[key], config.userTypes, Object.keys(config.enums)) as ReturnType<
+      typeof resolveTable
+    >;
+  }
+
+  return {
+    ...config,
+    _resolved: {
+      tables: resolvedTables as ResolvedStoreConfig<TStoreConfig>["_resolved"]["tables"],
+    },
+  };
+}
+
+function resolveTable<
+  TTableConfig extends TableConfig,
+  TUserTypes extends UserTypesConfig,
+  TEnums extends StringForUnion[]
+>(
+  tableConfig: TTableConfig,
+  userTypes: TUserTypes,
+  enums: TEnums
+): ResolvedTableConfig<TTableConfig, TUserTypes, TEnums[number]> {
+  return {
+    ...tableConfig,
+    keySchema: resolveKeySchema(tableConfig.keySchema ?? { key: "bytes32" }, userTypes, enums),
+    valueSchema: resolveValueSchema(tableConfig.valueSchema, userTypes, enums),
+  } as ResolvedTableConfig<TTableConfig, TUserTypes, TEnums[number]>;
+}
+
+function resolveKeySchema<
+  TKeySchema extends TableConfig["keySchema"],
+  TUserTypes extends UserTypesConfig,
+  TEnums extends StringForUnion[]
+>(
+  keySchema: TKeySchema,
+  userTypes: TUserTypes,
+  enums: TEnums
+): ResolvedKeySchema<TKeySchema extends undefined ? { key: "bytes32" } : TKeySchema, TUserTypes, TEnums[number]> {
+  const schema = (keySchema ?? { key: "bytes32" }) as TKeySchema extends undefined ? { key: "bytes32" } : TKeySchema;
+  return resolveSchema(schema, userTypes, enums);
+}
+
+function resolveValueSchema<
+  TValueSchema extends TableConfig["valueSchema"],
+  TUserTypes extends UserTypesConfig,
+  TEnums extends StringForUnion[]
+>(
+  schema: TValueSchema,
+  userTypes: TUserTypes,
+  enums: TEnums
+): ResolvedValueSchema<TValueSchema, TUserTypes, TEnums[number]> {
+  return resolveSchema(schema, userTypes, enums);
+}
+
+function resolveSchema<
+  TSchema extends NonNullable<TableConfig["keySchema"]> | TableConfig["valueSchema"],
+  TUserTypes extends UserTypesConfig,
+  TEnums extends StringForUnion[]
+>(schema: TSchema, { userTypes }: TUserTypes, enums: TEnums): ResolvedSchema<TSchema, TUserTypes, TEnums[number]> {
+  const resolvedSchema: Record<string, { internalType: string; type: string }> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    resolvedSchema[key] = {
+      // This mirrors the logic in the `ResolvedSchema` type
+      type:
+        userTypes && key in userTypes
+          ? userTypes[key].internalType
+          : enums.includes(value)
+          ? ("uint8" as const)
+          : value,
+      internalType: value,
+    };
+  }
+  return resolvedSchema as ResolvedValueSchema<TSchema, TUserTypes, TEnums[number]>;
 }

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -63,6 +63,11 @@ export type ResolvedSchema<
   };
 };
 
+
+/**
+ * @internal Internal only
+ * @deprecated Internal only
+ */
 export function resolveConfig<TStoreConfig extends StoreConfig>(
   config: TStoreConfig
 ): ResolvedStoreConfig<TStoreConfig> {

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -63,7 +63,6 @@ export type ResolvedSchema<
   };
 };
 
-
 /**
  * @internal Internal only
  * @deprecated Internal only

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -1,0 +1,45 @@
+import { StoreConfig, TableConfig, UserTypesConfig } from "../storeConfig";
+import { UserType } from "@latticexyz/common/codegen";
+
+export type ResolvedStoreConfig<TStoreConfig extends StoreConfig> = TStoreConfig & {
+  resolved: {
+    tables: {
+      [key in keyof TStoreConfig["tables"]]: ResolvedTableConfig<
+        TStoreConfig["tables"][key],
+        TStoreConfig["userTypes"]
+      >;
+    };
+  };
+};
+
+export type ResolvedTableConfig<TTableConfig extends TableConfig, TUserTypes extends UserTypesConfig> = Omit<
+  TTableConfig,
+  "keySchema" | "valueSchema"
+> & {
+  keySchema: ResolvedSchema<TTableConfig["keySchema"], TUserTypes>;
+  valueSchema: ResolvedSchema<TTableConfig["valueSchema"], TUserTypes>;
+};
+
+export type ResolvedSchema<
+  TSchema extends TableConfig["keySchema"] | TableConfig["valueSchema"],
+  TUserTypes extends UserTypesConfig
+> = {
+  [key in keyof TSchema]: {
+    type: TSchema[key] extends keyof TUserTypes
+      ? TUserTypes[TSchema[key]] extends UserType
+        ? // Note: we mistakenly named the plain ABI type "internalType",
+          // while in Solidity ABIs the plain ABI type is called "type" and
+          // and the custom type "internalType". We're planning to
+          // change our version and align with Solidity ABIs going forward.
+          TUserTypes[TSchema[key]]["internalType"]
+        : never
+      : TSchema[key];
+    internalType: TSchema[key];
+  };
+};
+
+export function resolveConfig<TStoreConfig extends StoreConfig>(
+  config: TStoreConfig
+): ResolvedStoreConfig<TStoreConfig> {
+  return config as ResolvedStoreConfig<TStoreConfig>;
+}

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -153,7 +153,7 @@ function resolveSchema<
   TUserTypes extends UserTypesConfig["userTypes"],
   TEnums extends StringForUnion[]
 >(schema: TSchema, userTypes: TUserTypes, enums: TEnums): ResolvedSchema<TSchema, TUserTypes, TEnums[number]> {
-  return mapObject<TSchema, ResolvedSchema<TSchema, TUserTypes, TEnums[number]>>(schema, (key, value) => {
+  return mapObject<TSchema, ResolvedSchema<TSchema, TUserTypes, TEnums[number]>>(schema, (value, key) => {
     const isUserType = userTypes && value in userTypes;
     const isEnum = enums.includes(value);
     return {

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -86,12 +86,12 @@ function resolveTable<
   userTypes: TUserTypes,
   enums: TEnums
 ): ResolvedTableConfig<typeof tableConfig, TUserTypes, TEnums[number]> {
-  const { keySchema: _, valueSchema: __, ...rest } = tableConfig;
+  const { keySchema, valueSchema, ...rest } = tableConfig;
 
   return {
     ...rest,
-    keySchema: resolveKeySchema(tableConfig.keySchema, userTypes, enums),
-    valueSchema: resolveValueSchema(tableConfig.valueSchema, userTypes, enums) as ResolvedSchema<
+    keySchema: resolveKeySchema(keySchema, userTypes, enums),
+    valueSchema: resolveValueSchema(valueSchema, userTypes, enums) as ResolvedSchema<
       Exclude<TTableConfig["valueSchema"], string>,
       TUserTypes,
       TEnums[number]

--- a/packages/store/ts/config/experimental/resolveConfig.ts
+++ b/packages/store/ts/config/experimental/resolveConfig.ts
@@ -4,18 +4,15 @@ import { UserType } from "@latticexyz/common/codegen";
 import { mapObject } from "@latticexyz/common/utils";
 import { resourceToHex } from "@latticexyz/common";
 
-export type ResolvedStoreConfig<TStoreConfig extends StoreConfig> = TStoreConfig & {
-  /** @deprecated Note: this property is experimental and expected to change */
-  _resolved: {
-    tables: {
-      [TableKey in keyof TStoreConfig["tables"] & string]: ResolvedTableConfig<
-        TStoreConfig["tables"][TableKey],
-        TStoreConfig["userTypes"],
-        keyof TStoreConfig["enums"] & string,
-        TStoreConfig["namespace"],
-        TableKey
-      >;
-    };
+export type ResolvedStoreConfig<TStoreConfig extends StoreConfig> = {
+  tables: {
+    [TableKey in keyof TStoreConfig["tables"] & string]: ResolvedTableConfig<
+      TStoreConfig["tables"][TableKey],
+      TStoreConfig["userTypes"],
+      keyof TStoreConfig["enums"] & string,
+      TStoreConfig["namespace"],
+      TableKey
+    >;
   };
 };
 
@@ -82,10 +79,7 @@ export function resolveConfig<TStoreConfig extends StoreConfig>(
   }
 
   return {
-    ...config,
-    _resolved: {
-      tables: resolvedTables as ResolvedStoreConfig<TStoreConfig>["_resolved"]["tables"],
-    },
+    tables: resolvedTables as ResolvedStoreConfig<TStoreConfig>["tables"],
   };
 }
 

--- a/packages/world/mud.config.ts
+++ b/packages/world/mud.config.ts
@@ -4,7 +4,7 @@ export default mudConfig({
   worldImportPath: "../../",
   worldgenDirectory: "interfaces",
   worldInterfaceName: "IBaseWorld",
-  namespace: "world", // NOTE: this namespace is only used for tables, the core system is deployed in the root namespace.
+  namespace: "world" as const, // NOTE: this namespace is only used for tables, the core system is deployed in the root namespace.
   userTypes: {
     ResourceId: { filePath: "@latticexyz/store/src/ResourceId.sol", internalType: "bytes32" },
   },


### PR DESCRIPTION
- Aims to solve one of the main pain points of our current config parser, which breaks on user types in some cases
- Note that this is just a temporary solution, we're still planning to refactor our config parsing from ground up in the medium term (see #1668 for context)

![CleanShot 2023-10-25 at 19 55 22](https://github.com/latticexyz/mud/assets/89248902/b0948787-7ecc-4faa-a400-9bc80705f037)

