### PR TITLE
docs: sort files from dir before concatenating

### DIFF
--- a/scripts/render-api-docs.ts
+++ b/scripts/render-api-docs.ts
@@ -140,6 +140,7 @@ async function renderDocs() {
           .map((input) => {
             const docsPath = getDocsPath(input.source);
             const docsFiles = readdirSync(docsPath);
+            docsFiles.sort();
             return docsFiles
               .filter(input.filterFiles ?? identity)
               .map((fileName) => readFileSync(path.join(docsPath, fileName), { encoding: "utf8" }));


### PR DESCRIPTION
builds are occasionally failing due to non-deterministic ordering of files returned by `readdirSync`

https://github.com/latticexyz/mud/actions/runs/6731637925/job/18297224008?pr=1843
