### PR TITLE
fix(cli): change import order so .env file is loaded first

### DIFF
--- a/.changeset/rich-rockets-jog.md
+++ b/.changeset/rich-rockets-jog.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Changed `mud` CLI import order so that environment variables from the `.env` file are loaded before other imports.

--- a/packages/cli/src/mud.ts
+++ b/packages/cli/src/mud.ts
@@ -1,39 +1,45 @@
 #!/usr/bin/env node
 
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import { commands } from "./commands";
-import { logError } from "./utils/errors";
-
 // Load .env file into process.env
 import * as dotenv from "dotenv";
-import chalk from "chalk";
 dotenv.config();
 
-yargs(hideBin(process.argv))
-  // Explicit name to display in help (by default it's the entry file, which may not be "mud" for e.g. ts-node)
-  .scriptName("mud")
-  // Use the commands directory to scaffold
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- command array overload isn't typed, see https://github.com/yargs/yargs/blob/main/docs/advanced.md#esm-hierarchy
-  .command(commands as any)
-  // Enable strict mode.
-  .strict()
-  // Custom error handler
-  .fail((msg, err) => {
-    console.error(chalk.red(msg));
-    if (msg.includes("Missing required argument")) {
-      console.log(
-        chalk.yellow(`Run 'pnpm mud ${process.argv[2]} --help' for a list of available and required arguments.`)
-      );
-    }
-    console.log("");
-    // Even though `.fail` type says we should get an `Error`, this can sometimes be undefined
-    if (err != null) {
-      logError(err);
-      console.log("");
-    }
+async function run() {
+  // Import everything else async so they can pick up env vars in .env
+  const { default: yargs } = await import("yargs");
+  const { default: chalk } = await import("chalk");
+  const { hideBin } = await import("yargs/helpers");
+  const { logError } = await import("./utils/errors");
+  const { commands } = await import("./commands");
 
-    process.exit(1);
-  })
-  // Useful aliases.
-  .alias({ h: "help" }).argv;
+  yargs(hideBin(process.argv))
+    // Explicit name to display in help (by default it's the entry file, which may not be "mud" for e.g. ts-node)
+    .scriptName("mud")
+    // Use the commands directory to scaffold
+    // command array overload isn't typed, see https://github.com/yargs/yargs/blob/main/docs/advanced.md#esm-hierarchy
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .command(commands as any)
+    // Enable strict mode.
+    .strict()
+    // Custom error handler
+    .fail((msg, err) => {
+      console.error(chalk.red(msg));
+      if (msg.includes("Missing required argument")) {
+        console.log(
+          chalk.yellow(`Run 'pnpm mud ${process.argv[2]} --help' for a list of available and required arguments.`)
+        );
+      }
+      console.log("");
+      // Even though `.fail` type says we should get an `Error`, this can sometimes be undefined
+      if (err != null) {
+        logError(err);
+        console.log("");
+      }
+
+      process.exit(1);
+    })
+    // Useful aliases.
+    .alias({ h: "help" }).argv;
+}
+
+run();


### PR DESCRIPTION
The env vars defined in `.env` weren't getting picked up by CLI because the `.env` file isn't loaded by the time the other imports (specifically commands) are loaded.

This changes the CLI import ordering to make sure `.env` is loaded before everything else is imported.
