### PR TITLE
fix(create-mud): workaround create-create-app templating

### DIFF
--- a/.changeset/purple-ghosts-hear.md
+++ b/.changeset/purple-ghosts-hear.md
@@ -1,0 +1,5 @@
+---
+"create-mud": patch
+---
+
+Fixed an issue when creating a new project from the `react` app, where React's expressions were overlapping with Handlebars expressions (used by our template command).

--- a/templates/react/packages/client/src/App.tsx
+++ b/templates/react/packages/client/src/App.tsx
@@ -1,5 +1,7 @@
 import { useMUD } from "./MUDContext";
 
+const styleUnset = { all: "unset" } as const;
+
 export const App = () => {
   const {
     network: { tables, useStore },
@@ -41,7 +43,7 @@ export const App = () => {
                 <button
                   type="button"
                   title="Delete task"
-                  style={{ all: "unset" }}
+                  style={styleUnset}
                   onClick={async (event) => {
                     event.preventDefault();
                     if (!window.confirm("Are you sure you want to delete this task?")) return;
@@ -87,7 +89,7 @@ export const App = () => {
                   }
                 }}
               >
-                <fieldset style={{ all: "unset" }}>
+                <fieldset style={styleUnset}>
                   <input type="text" name="description" />{" "}
                   <button type="submit" title="Add task">
                     Add


### PR DESCRIPTION
create-create-app treats things that look like `{{ something }}` as a handlebars statement, which doesn't play nicely with React apps

this fix works around that for now