### PR TITLE
feat(cli): add the batch registration feature to systems, accesses, functions and tables

### DIFF
--- a/packages/cli/src/deploy/ensureFunctions.ts
+++ b/packages/cli/src/deploy/ensureFunctions.ts
@@ -56,13 +56,13 @@ export async function ensureFunctions({
         encodedFunctionData = encodeFunctionData({
           abi: worldAbi,
           functionName: "registerRootFunctionSelector",
-          args: [systemId, func.systemFunctionSignature, func.systemFunctionSelector],
+          args: [systemId as Hex, func.systemFunctionSignature, func.systemFunctionSelector],
         });
       } else {
         encodedFunctionData = encodeFunctionData({
           abi: worldAbi,
           functionName: "registerFunctionSelector",
-          args: [systemId, func.systemFunctionSignature],
+          args: [systemId as Hex, func.systemFunctionSignature],
         });
       }
       return encodedFunctionData;

--- a/packages/cli/src/utils/getBatchCallData.ts
+++ b/packages/cli/src/utils/getBatchCallData.ts
@@ -1,0 +1,16 @@
+import { resourceToHex } from "@latticexyz/common";
+import { Hex } from "viem";
+
+// Used to identify the core system in `batchCall`
+const coreSystemId = resourceToHex({ type: "system", namespace: "", name: "core" });
+
+export function getBatchCallData(encodedFunctionDataList: Hex[]): { systemId: Hex; callData: Hex }[] {
+  const encodedFunctionDataListExtended = encodedFunctionDataList.map((encodedFunctionData) => {
+    const encodedFunctionDataTmp: { systemId: Hex; callData: Hex } = {
+      systemId: coreSystemId,
+      callData: encodedFunctionData,
+    };
+    return encodedFunctionDataTmp;
+  });
+  return encodedFunctionDataListExtended;
+}


### PR DESCRIPTION
Fixes issue #1645.

There are some parts that can be further examined.

One is the `batchCall` functiin, which is not easy to invoke correctly in Typescript. To address this, I added a helper function `getBatchCallData` to alleviate this issue.

The other part is the granularity of batching. For systems and access controls, I batched the system and its corresponding access changes together. This approach ensures atomicity of the system and its access control changes, resulting in the invocation of a number of system transactions.

For function registrations, I batched the functions per system, as it seems that a system can naturally divide the functions.

For table registrations, I used a static slicing approach. The number of packed registrations for now is 10, which is a conservative figure designed to adapt to most chain environments. This number could be added to advanced configurations in the future.

PS: I have temporarily set aside the part related to modules, as there is currently no filter available for installedModules.