### PR TITLE
build: remove bun from dockerfile for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,6 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
 RUN npm install pnpm --global && pnpm --version
 
-# bun
-ENV BUN_INSTALL="${HOME}/.bun"
-ENV PATH="${PATH}:${BUN_INSTALL}/bin"
-RUN npm install bun --global && bun --version
-
 FROM base AS mud
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
trying to run something like `bun --version` in the dockerfile causes it to spin forever 

prob related to me installing via pnpm but setting the `BUN_INSTALL` path to something different, but no time to debug right now