### PR TITLE
fix(create-mud): include `.gitignore` files in created projects

### DIFF
--- a/packages/create-mud/scripts/copy-templates.sh
+++ b/packages/create-mud/scripts/copy-templates.sh
@@ -22,3 +22,12 @@ if grep -r -E 'link:' ./dist/templates; then
   echo "Linked dependencies found in dist/templates"
   exit 1
 fi
+
+# Since npm-packlist does not include ".gitignore" files in the packaging process,
+# these files are renamed to "gitignore".
+# create-create-app automatically renames them back to ".gitignore" upon execution.
+find ./dist/templates/* -name ".gitignore" -type f | while read -r file; do
+  newfile="$(dirname "$file")/gitignore"
+  echo "Renaming $file to $newfile"
+  mv "$file" "$newfile"
+done

--- a/templates/.npmignore
+++ b/templates/.npmignore
@@ -1,2 +1,0 @@
-# make sure our npm package includes the template's gitignore
-!.gitignore


### PR DESCRIPTION
This Pull Request resolves #1865, where projects created by `create-mud` are missing `.gitignore` files, specifically in versions `2.0.0-next.13` and `2.0.0-next.14`.

The cause is an update in [`npm-packlist`](https://github.com/npm/npm-packlist), used during the npm package publishing process to list target package files. The MUD's release command `changeset publish` relies on `npm-packlist` through [`pnpm publish`](https://github.com/changesets/changesets/blob/%40changesets/cli%402.26.2/packages/cli/src/commands/publish/npm-utils.ts#L187).

The previous version of `npm-packlist` included `.gitignore` files by respecting the `.npmignore` file, but the latest version doesn't. This change is not documented in its [changelog](https://github.com/npm/npm-packlist/blob/v8.0.0/CHANGELOG.md), but based on [this issue's comment](https://github.com/npm/npm/issues/7252#issuecomment-253339460), it seems better not to expect `.gitignore` files to be included.

This PR addresses this issue by utilizing `create-create-app`'s feature for handling `.gitignore`. During the build process of `create-mud`, `.gitignore` files are renamed to `gitignore`, ensuring their inclusion in the package. When the `create-mud` cli is executed, `create-create-app` automatically renames those `gitignore` files back to `.gitignore` for project creation.

To test the fix, you can run `pnpm build && dist/cli.js test-project`.

Reference: #336

**Testing the `npm-packlist` behavior:**

To observe the behavior change in `npm-packlist`, we can use `pnpm pack` or `npm pack` without the changes from this PR.

```sh
$ cd packages/create-mud
$ pnpm build # copy template files to dist/

# with earlier version of pnpm (npm-packlist v5)
$ npm install -g pnpm@8.9.2 
$ pnpm pack
$ tar -xzf create-mud-2.0.0-next.14.tgz # extract to package/
$ ls -A package/dist/templates/vanilla # .gitignore included
.eslintrc           .gitignore          mprocs.yaml         packages
.gitattributes      .vscode             package.json        pnpm-workspace.yaml
$ rm -r create-mud-2.0.0-next.14.tgz package

# with more recent version of pnpm (npm-packlist v8)
$ npm install -g pnpm@8.10.2
$ pnpm pack
$ tar -xzf create-mud-2.0.0-next.14.tgz
$ ls -A package/dist/templates/vanilla # .gitignore not included
.eslintrc           .vscode             package.json        pnpm-workspace.yaml
.gitattributes      mprocs.yaml         packages
$ rm -r create-mud-2.0.0-next.14.tgz package
```