### PR TITLE
fix(store-sync,store-indexer): make last updated block number not null

### DIFF
--- a/.changeset/beige-rockets-return.md
+++ b/.changeset/beige-rockets-return.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-indexer": patch
+---
+
+Records are now ordered by `lastUpdatedBlockNumber` at the Postgres SQL query level

--- a/.changeset/cyan-vans-pay.md
+++ b/.changeset/cyan-vans-pay.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": major
+---
+
+`lastUpdatedBlockNumber` columns in Postgres storage adapters are no longer nullable

--- a/packages/store-indexer/src/postgres/getLogs.ts
+++ b/packages/store-indexer/src/postgres/getLogs.ts
@@ -2,7 +2,7 @@ import { PgDatabase } from "drizzle-orm/pg-core";
 import { Hex } from "viem";
 import { StorageAdapterLog, SyncFilter } from "@latticexyz/store-sync";
 import { tables } from "@latticexyz/store-sync/postgres";
-import { and, eq, or } from "drizzle-orm";
+import { and, asc, eq, or } from "drizzle-orm";
 import { decodeDynamicField } from "@latticexyz/protocol-parser";
 import { bigIntMax } from "@latticexyz/common/utils";
 
@@ -53,7 +53,8 @@ export async function getLogs(
   const records = await database
     .select()
     .from(tables.recordsTable)
-    .where(or(...conditions));
+    .where(or(...conditions))
+    .orderBy(asc(tables.recordsTable.lastUpdatedBlockNumber));
 
   const blockNumber = records.reduce(
     (max, record) => bigIntMax(max, record.lastUpdatedBlockNumber ?? 0n),

--- a/packages/store-sync/src/postgres-decoded/buildTable.test.ts
+++ b/packages/store-sync/src/postgres-decoded/buildTable.test.ts
@@ -21,37 +21,44 @@ describe("buildTable", () => {
         name: column.name,
         dataType: column.dataType,
         sqlName: column.sqlName,
+        notNull: column.notNull,
       }))
     ).toMatchInlineSnapshot(`
       {
         "__keyBytes": {
           "dataType": "custom",
           "name": "__key_bytes",
+          "notNull": true,
           "sqlName": "bytea",
         },
         "__lastUpdatedBlockNumber": {
           "dataType": "custom",
           "name": "__last_updated_block_number",
+          "notNull": false,
           "sqlName": "numeric",
         },
         "addr": {
           "dataType": "custom",
           "name": "addr",
+          "notNull": true,
           "sqlName": "bytea",
         },
         "name": {
           "dataType": "string",
           "name": "name",
+          "notNull": true,
           "sqlName": undefined,
         },
         "x": {
           "dataType": "custom",
           "name": "x",
+          "notNull": true,
           "sqlName": "integer",
         },
         "y": {
           "dataType": "custom",
           "name": "y",
+          "notNull": true,
           "sqlName": "integer",
         },
       }

--- a/packages/store-sync/src/postgres/tables.ts
+++ b/packages/store-sync/src/postgres/tables.ts
@@ -9,7 +9,7 @@ const schemaName = transformSchemaName("mud");
  */
 const chainTable = pgSchema(schemaName).table("chain", {
   chainId: asNumber("chain_id", "bigint").notNull().primaryKey(),
-  lastUpdatedBlockNumber: asBigInt("last_updated_block_number", "numeric"),
+  lastUpdatedBlockNumber: asBigInt("last_updated_block_number", "numeric").notNull(),
 });
 
 const recordsTable = pgSchema(schemaName).table(
@@ -27,7 +27,7 @@ const recordsTable = pgSchema(schemaName).table(
     encodedLengths: asHex("encoded_lengths"),
     dynamicData: asHex("dynamic_data"),
     isDeleted: boolean("is_deleted"),
-    lastUpdatedBlockNumber: asBigInt("last_updated_block_number", "numeric"),
+    lastUpdatedBlockNumber: asBigInt("last_updated_block_number", "numeric").notNull(),
   },
   (table) => ({
     pk: primaryKey(table.address, table.tableId, table.keyBytes),


### PR DESCRIPTION
following up #1965 

not strictly a bug but just doing this for completeness so we don't have to sort inline