### PR TITLE
fix(store,world): fix `tsc` errors in projects depending on `@latticexyz/store-sync`

### DIFF
--- a/.changeset/fair-baboons-compare.md
+++ b/.changeset/fair-baboons-compare.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Fixed an issue where `mud.config.ts` source file was not included in the package, causing TS errors downstream.

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -5,6 +5,7 @@
 !out/**/*.abi.json.d.ts
 !src/**
 !ts/**
+!mud.config.ts
 !package.json
 !README.md
 !dist/**

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -6,6 +6,7 @@
 !src/**
 !test/MudTest.t.sol
 !ts/**
+!mud.config.ts
 !package.json
 !README.md
 !dist/**


### PR DESCRIPTION
Projects created by `create-mud` are currently failing their `pnpm test` scripts due to TypeScript type checking errors. This pull request addresses this issue and also resolves #1958.

## Steps to Reproduce

```sh
# Create a new project
$ pnpm create mud@2.0.0-next.14 my-project --template vanilla
$ cd my-project

# Add missing dependencies to prevent other tsc errors
# I can address this issue in a separate PR
$ pnpm --filter contracts add --save-dev @types/prettier@2.7.2 @types/debug@4.1.7
$ pnpm --filter client add --save-dev @types/prettier@2.7.2 @types/debug@4.1.7 @types/react@18.2.22 @types/react-dom@18.2.7

# Test and see the errors
$ pnpm test # runs `pnpm -r run test` and fails, showing the log below
```
```
$ pnpm --filter client test
> client@0.0.0 test /Users/t/bench/my-project/packages/client
> tsc --noEmit

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/common.ts:6:25 - error TS2307: Cannot find module '@lattice
xyz/store/mud.config' or its corresponding type declarations.

6 import storeConfig from "@latticexyz/store/mud.config";
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/common.ts:7:25 - error TS2307: Cannot find module '@lattice
xyz/world/mud.config' or its corresponding type declarations.

7 import worldConfig from "@latticexyz/world/mud.config";
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/internalTableIds.ts:2:25 - error TS2307: Cannot find module
 '@latticexyz/store/mud.config' or its corresponding type declarations.

2 import storeConfig from "@latticexyz/store/mud.config";
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/internalTableIds.ts:3:25 - error TS2307: Cannot find module
 '@latticexyz/world/mud.config' or its corresponding type declarations.

3 import worldConfig from "@latticexyz/world/mud.config";
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/recs/recsStorage.ts:14:25 - error TS2307: Cannot find modul
e '@latticexyz/store/mud.config' or its corresponding type declarations.

14 import storeConfig from "@latticexyz/store/mud.config";
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_typescript
@5.1.6/node_modules/@latticexyz/store-sync/src/recs/recsStorage.ts:15:25 - error TS2307: Cannot find modul
e '@latticexyz/world/mud.config' or its corresponding type declarations.

15 import worldConfig from "@latticexyz/world/mud.config";
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 6 errors in 3 files.

Errors  Files
     2  ../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_ty
pescript@5.1.6/node_modules/@latticexyz/store-sync/src/common.ts:6
     2  ../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_ty
pescript@5.1.6/node_modules/@latticexyz/store-sync/src/internalTableIds.ts:2
     2  ../../node_modules/.pnpm/@latticexyz+store-sync@2.0.0-next.14_@types+react@18.2.22_react@18.2.0_ty
pescript@5.1.6/node_modules/@latticexyz/store-sync/src/recs/recsStorage.ts:14
/Users/t/bench/my-project/packages/client:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  client@0.0.0 test: `tsc --noEmit`
Exit status 2
```

## Cause

These errors occur because the published `store` and `world` packages don't contain the `/mud.config.ts` files. In the MUD repository's `/templates/vanilla/`, these errors don't occur, as it uses locally linked dependencies (like `"@latticexyz/store-sync": "link:../../../../packages/store-sync"`).

In the `package.json` files of both `store` and `world`, the `typesVersions` fields for TypeScript don't include `/mud.config`, so the `@latticexyz/<name>/mud.config` imports are resolved by their file paths.

## Fix

To resolve this, I've added `!mud.config.ts` to the `.npmignore` files of both `store` and `world` to include these files in the published packages.

To verify the fix of these errors, you can follow these steps after checking out this branch:

```sh
# Package
$ cd packages/store
$ pnpm pack
$ cd ../world
$ pnpm pack

# Go to the project where the error was reproduced
$ cd /path/to/my-project

# Replace the packages
$ pnpm --filter client add /path/to/mud/packages/store/latticexyz-store-2.0.0-next.14.tgz /path/to/mud/packages/world/latticexyz-world-2.0.0-next.14.tgz

# Re-run the tests that previously failed
$ pnpm --filter client test # passes without any errors
```

## Note

While this fix addresses the immediate issue for projects with `store-sync` dependencies, I'm considering whether the current packaging approach of using `typesVersions` is optimal. Currently, users are required to have `moduleResolution: node10` in their `tsconfig.json`, but I prefer using `node16` or `bundler` for my project. I believe this topic has already been discussed within the team. If there are any established ideas or directions regarding this issue, I'd be eager to learn and contribute.