### PR TITLE
fix(store-sync): use dynamic data in postgres decoded indexer

### DIFF
--- a/packages/store-sync/src/postgres-decoded/createStorageAdapter.ts
+++ b/packages/store-sync/src/postgres-decoded/createStorageAdapter.ts
@@ -96,7 +96,7 @@ export async function createStorageAdapter<TConfig extends StoreConfig = StoreCo
           const value = decodeValueArgs(table.valueSchema, {
             staticData: record.staticData ?? "0x",
             encodedLengths: record.encodedLengths ?? "0x",
-            dynamicData: record.encodedLengths ?? "0x",
+            dynamicData: record.dynamicData ?? "0x",
           });
 
           debug("upserting record", {


### PR DESCRIPTION
Fixes a small error in the storage adapter that used `encodedLengths` in place of `dynamicData`, causing incorrect data in the database.