### PR TITLE
docs(guides/hello-world): fix `add-table` to use correct name in devtools

### DIFF
--- a/docs/pages/guides/hello-world/add-table.mdx
+++ b/docs/pages/guides/hello-world/add-table.mdx
@@ -190,7 +190,7 @@ The directions here apply to the `vanilla` client template, if you use anything 
        publicClient: network.publicClient,
        walletClient: network.walletClient,
        latestBlock$: network.latestBlock$,
-       blockStorageOperations$: network.blockStorageOperations$,
+       storedBlockLogs$: network.storedBlockLogs$,
        worldAddress: network.worldContract.address,
        worldAbi: network.worldContract.abi,
        write$: network.write$,


### PR DESCRIPTION
It used the old name instead of `storedBlockLogs$`.