### PR TITLE
docs: fix broken links in hello world guide + typo in emojimon guide

### DIFF
--- a/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
+++ b/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
@@ -33,7 +33,7 @@ Before continuing, try figuring out what components and systems would need to be
 
 Let's start by adding three new tables to `mud.config.ts`.
 
-- `Encounterable` can an entity can engage in an encounter
+- `Encounterable` can an entity engage in an encounter.
 - `EncounterTrigger` can an entity trigger an encounter when moved on by a player.
 - `Encounter` associate a player with an encounter.
 

--- a/docs/pages/guides/hello-world.mdx
+++ b/docs/pages/guides/hello-world.mdx
@@ -3,10 +3,10 @@
 On this page you learn how to modify a `World` before it is deployed to the blockchain.
 If you want to learn how to modify a `World` that is already deployed, [see the extending world page](./extending-world).
 
-The examples on this page use [the vanilla template](../template/typescript/vanilla).
-[See this page for installation instructions](../template/typescript/getting-started).
+The examples on this page use [the vanilla template](../templates/typescript/vanilla).
+[See this page for installation instructions](../templates/typescript/getting-started).
 Every example is written under the assumption that it is independent, and built on top of a new vanilla template.
 
 - [Add a table](hello-world/add-table).
 - [Add a system](hello-world/add-system).
-- [Deploy to a blockchain](hello-world/deploy).
+- [Deploy to a blockchain](../cli/deploy).


### PR DESCRIPTION
Quick link fixes I ran into while going through the guide.