### PR TITLE
docs(cli): add `mud test`

### DIFF
--- a/docs/pages/cli/test.mdx
+++ b/docs/pages/cli/test.mdx
@@ -1,3 +1,43 @@
 # mud test
 
-**Coming soon**
+This command runs the tests in a MUD project. This requires several steps:
+
+1. Start an [`anvil`](https://book.getfoundry.sh/reference/anvil/) instance.
+   {/* This could be either an empty blockchain, or one that can be forked for a [fork test](https://book.getfoundry.sh/forge/fork-testing). */}
+1. Deploy the `World` and all related `System`s using [`mud deploy`](./deploy).
+1. Run tests using [`forge test`](https://book.getfoundry.sh/forge/tests).
+
+## Command line options
+
+| Option                  | Meaning                                        | Type                            | Default value                                              |
+| ----------------------- | ---------------------------------------------- | ------------------------------- | ---------------------------------------------------------- | ---- |
+| `--version`             | Show version number                            | boolean                         | `false`                                                    |
+| `--configPath`          | Path to the config file                        | string                          | `mud.config.ts`                                            |
+| `--printConfig`         | Print the resolved config                      | boolean                         | `false`                                                    |
+| `--saveDeployment`      | Save the deployment info to a file             | boolean                         | `true`                                                     |
+| `--profile`             | The foundry profile to use                     | string                          | `local`                                                    |
+| `--srcDir`              | Source directory                               | string                          | Foundry `src` directory                                    |
+| `--skipBuild`           | Skip rebuilding the contracts before deploying | boolean                         | `false`                                                    |
+| `--alwaysRunPostDeploy` | Run `PostDeploy.s.sol` after each deploy       | boolean                         | `false` (run the script only when deploying a new `World`) |
+| `--port`                | Port for the testing `anvil` instance          | number                          | 4242                                                       |
+| `--help`                | Show help                                      | boolean                         | `false`                                                    |
+| {/\*                    | `--forgeOptions`                               | Options to pass to `forge test` | string                                                     | \*/} |
+
+(1) The hostname `localhost` may not work. If that is the case, use `127.0.0.1` instead.
+
+{/\*
+
+### Additional command-line options only applicable to fork tests
+
+| Option              | Meaning                                                                         | Type   | Default value               |
+| ------------------- | ------------------------------------------------------------------------------- | ------ | --------------------------- |
+| `--rpc`<sup>1</sup> | The RPC URL to use                                                              | string | RPC url from `foundry.toml` |
+| `--worldAddress`    | Address of an existing `World` contract, only meaningful when using a fork test | string | Empty, deploy new `World`   |
+
+\*/}
+
+## Examples
+
+```sh copy
+pnpm mud test
+```

--- a/docs/pages/cli/test.mdx
+++ b/docs/pages/cli/test.mdx
@@ -25,7 +25,9 @@ This command runs the tests in a MUD project. This requires several steps:
 
 (1) The hostname `localhost` may not work. If that is the case, use `127.0.0.1` instead.
 
-{/\*
+{
+
+/\*
 
 ### Additional command-line options only applicable to fork tests
 
@@ -34,7 +36,9 @@ This command runs the tests in a MUD project. This requires several steps:
 | `--rpc`<sup>1</sup> | The RPC URL to use                                                              | string | RPC url from `foundry.toml` |
 | `--worldAddress`    | Address of an existing `World` contract, only meaningful when using a fork test | string | Empty, deploy new `World`   |
 
-\*/}
+\*/
+
+}
 
 ## Examples
 

--- a/docs/pages/cli/test.mdx
+++ b/docs/pages/cli/test.mdx
@@ -1,11 +1,11 @@
 # mud test
 
-This command runs the tests in a MUD project. This requires several steps:
+This command runs the tests in a MUD project. Internally, it runs the following steps:
 
-1. Start an [`anvil`](https://book.getfoundry.sh/reference/anvil/) instance.
+1. Starts an [`anvil`](https://book.getfoundry.sh/reference/anvil/) instance.
    {/* This could be either an empty blockchain, or one that can be forked for a [fork test](https://book.getfoundry.sh/forge/fork-testing). */}
-1. Deploy the `World` and all related `System`s using [`mud deploy`](./deploy).
-1. Run tests using [`forge test`](https://book.getfoundry.sh/forge/tests).
+1. Deploys the `World` and all related `System`s using [`mud deploy`](./deploy).
+1. Runs tests using [`forge test`](https://book.getfoundry.sh/forge/tests) and passes the deployed world address to the tests via the `WORLD_ADDRESS` environment variable.
 
 ## Command line options
 

--- a/docs/pages/cli/test.mdx
+++ b/docs/pages/cli/test.mdx
@@ -27,3 +27,89 @@ This command runs the tests in a MUD project. Internally, it runs the following 
 ```sh copy
 pnpm mud test
 ```
+
+## Writing MUD tests
+
+MUD test contracts inherit from [`MudTest`](https://github.com/latticexyz/mud/blob/main/packages/world/test/MudTest.t.sol).
+This contract gets the `World` address from the `$WORLD_ADDRESS` environment variable and sets it as the `Store` address.
+
+<details>
+
+<summary>Line by line explanation of a test</summary>
+
+This is an explanation of [the test](https://github.com/latticexyz/mud/blob/main/templates/react/packages/contracts/test/TasksTest.t.sol) for the [React template](https://github.com/latticexyz/mud/tree/main/templates/react) contracts.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import "forge-std/Test.sol";
+import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
+```
+
+Import the general definitions required in all MUD tests.
+
+```solidity
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { Tasks, TasksData } from "../src/codegen/index.sol";
+```
+
+Import the definitions required for this test, the `World` we can access and the tables we'll use.
+
+```solidity
+contract TasksTest is MudTest {
+  function testWorldExists() public {
+```
+
+MUD tests are [Foundry tests](https://book.getfoundry.sh/forge/tests).
+Any public function that starts with `test` is a test that gets executed.
+
+```solidity
+    uint256 codeSize;
+    address addr = worldAddress;
+```
+
+The `World` address comes from the [`MudTest`](https://github.com/latticexyz/mud/blob/main/packages/world/test/MudTest.t.sol#L11).
+
+```solidity
+    assembly {
+      codeSize := extcodesize(addr)
+    }
+    assertTrue(codeSize > 0);
+  }
+```
+
+Use [`extcodesize`](https://www.evm.codes/#3b?fork=shanghai) to get the size of the `World` contract.
+If the deploy process failed, there wouldn't be any code there.
+
+```solidity
+  function testTasks() public {
+    // Expect task to exist that we created during PostDeploy script
+    TasksData memory task = Tasks.get("1");
+```
+
+Use the structure for a table entry's values that is created as part of code generation.
+
+```solidity
+    assertEq(task.description, "Walk the dog");
+    assertEq(task.completedAt, 0);
+```
+
+Verify the information that is prepopulated by [the `PostDeploy.s.sol` script](https://github.com/latticexyz/mud/blob/main/templates/react/packages/contracts/script/PostDeploy.s.sol).
+
+```solidity
+    // Expect the task to be completed after calling completeTask from our TasksSystem
+    IWorld(worldAddress).completeTask("1");
+```
+
+Call a `System` to modify the table data.
+
+```solidity
+    assertEq(Tasks.getCompletedAt("1"), block.timestamp);
+  }
+}
+```
+
+Verify that the call changed the data correctly.
+
+</details>

--- a/docs/pages/cli/test.mdx
+++ b/docs/pages/cli/test.mdx
@@ -9,36 +9,18 @@ This command runs the tests in a MUD project. This requires several steps:
 
 ## Command line options
 
-| Option                  | Meaning                                        | Type                            | Default value                                              |
-| ----------------------- | ---------------------------------------------- | ------------------------------- | ---------------------------------------------------------- | ---- |
-| `--version`             | Show version number                            | boolean                         | `false`                                                    |
-| `--configPath`          | Path to the config file                        | string                          | `mud.config.ts`                                            |
-| `--printConfig`         | Print the resolved config                      | boolean                         | `false`                                                    |
-| `--saveDeployment`      | Save the deployment info to a file             | boolean                         | `true`                                                     |
-| `--profile`             | The foundry profile to use                     | string                          | `local`                                                    |
-| `--srcDir`              | Source directory                               | string                          | Foundry `src` directory                                    |
-| `--skipBuild`           | Skip rebuilding the contracts before deploying | boolean                         | `false`                                                    |
-| `--alwaysRunPostDeploy` | Run `PostDeploy.s.sol` after each deploy       | boolean                         | `false` (run the script only when deploying a new `World`) |
-| `--port`                | Port for the testing `anvil` instance          | number                          | 4242                                                       |
-| `--help`                | Show help                                      | boolean                         | `false`                                                    |
-| {/\*                    | `--forgeOptions`                               | Options to pass to `forge test` | string                                                     | \*/} |
-
-(1) The hostname `localhost` may not work. If that is the case, use `127.0.0.1` instead.
-
-{
-
-/\*
-
-### Additional command-line options only applicable to fork tests
-
-| Option              | Meaning                                                                         | Type   | Default value               |
-| ------------------- | ------------------------------------------------------------------------------- | ------ | --------------------------- |
-| `--rpc`<sup>1</sup> | The RPC URL to use                                                              | string | RPC url from `foundry.toml` |
-| `--worldAddress`    | Address of an existing `World` contract, only meaningful when using a fork test | string | Empty, deploy new `World`   |
-
-\*/
-
-}
+| Option                  | Meaning                                        | Type    | Default value                                              |
+| ----------------------- | ---------------------------------------------- | ------- | ---------------------------------------------------------- |
+| `--version`             | Show version number                            | boolean | `false`                                                    |
+| `--configPath`          | Path to the config file                        | string  | `mud.config.ts`                                            |
+| `--printConfig`         | Print the resolved config                      | boolean | `false`                                                    |
+| `--saveDeployment`      | Save the deployment info to a file             | boolean | `true`                                                     |
+| `--profile`             | The foundry profile to use                     | string  | `local`                                                    |
+| `--srcDir`              | Source directory                               | string  | Foundry `src` directory                                    |
+| `--skipBuild`           | Skip rebuilding the contracts before deploying | boolean | `false`                                                    |
+| `--alwaysRunPostDeploy` | Run `PostDeploy.s.sol` after each deploy       | boolean | `false` (run the script only when deploying a new `World`) |
+| `--port`                | Port for the testing `anvil` instance          | number  | 4242                                                       |
+| `--help`                | Show help                                      | boolean | `false`                                                    |
 
 ## Examples
 


### PR DESCRIPTION
The parts that don't work (see #2002 and #2004) are in commit d78d95d68f9909971d00de689e1687bd860730ad. I tried to comment them out, but prettier "helped" by escaping the comments.