### PR TITLE
fix(store): slice4 output should be bytes4 [M-03]

### DIFF
--- a/.changeset/blue-forks-move.md
+++ b/.changeset/blue-forks-move.md
@@ -2,4 +2,4 @@
 "@latticexyz/store": patch
 ---
 
-Changed the return type of the `slice4` function to `bytes4`.
+Changed the type of the output variable in the `slice4` function to `bytes4`.

--- a/.changeset/blue-forks-move.md
+++ b/.changeset/blue-forks-move.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": patch
+---
+
+Changed the return type of the `slice4` function to `bytes4`.

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -262,7 +262,7 @@ library Bytes {
    * @return The extracted bytes4 value from the specified position in the bytes32 value.
    */
   function slice4(bytes32 data, uint256 start) internal pure returns (bytes4) {
-    bytes2 output;
+    bytes4 output;
     assembly {
       output := shl(mul(8, start), data)
     }


### PR DESCRIPTION
Seems like Solidity was casting the `bytes2` `output` variable to the `bytes4` return type.