### PR TITLE
test(world): add test to ensure all store/world tables are registered

### DIFF
--- a/packages/world/foundry.toml
+++ b/packages/world/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc = "0.8.21"
-ffi = false
+ffi = true
 fuzz_runs = 256
 optimizer = true
 optimizer_runs = 3000

--- a/packages/world/test/CoreModule.t.sol
+++ b/packages/world/test/CoreModule.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.21;
+
+import { Test } from "forge-std/Test.sol";
+
+import { StoreRead } from "@latticexyz/store/src/StoreRead.sol";
+import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
+import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
+import { Tables } from "@latticexyz/store/src/codegen/index.sol";
+
+import { WorldContextProviderLib } from "../src/WorldContext.sol";
+import { CoreModule } from "../src/modules/core/CoreModule.sol";
+
+contract WorldMock is StoreRead {
+  constructor() {
+    StoreSwitch.setStoreAddress(address(this));
+  }
+
+  function delegatecallFromWorld(address target, bytes memory callData) public {
+    WorldContextProviderLib.delegatecallWithContextOrRevert({
+      msgSender: msg.sender,
+      msgValue: 0,
+      target: target,
+      callData: callData
+    });
+  }
+}
+
+contract CoreModuleTest is Test {
+  CoreModule coreModule;
+  WorldMock worldMock;
+
+  function setUp() public {
+    coreModule = new CoreModule();
+    worldMock = new WorldMock();
+    StoreSwitch.setStoreAddress(address(worldMock));
+  }
+
+  function testInstallRoot() public {
+    // Prepare tableIds for registration validation
+    bytes32[] memory tableIds = getTableIdsFromStoreAndWorldConfigs();
+
+    // Invoke installRoot
+    worldMock.delegatecallFromWorld(address(coreModule), abi.encodeCall(CoreModule.installRoot, (new bytes(0))));
+
+    // Confirm that each tableId is registered
+    for (uint256 i; i < tableIds.length; i++) {
+      bytes32 tableId = tableIds[i];
+      assertFalse(
+        Tables.getFieldLayout(ResourceId.wrap(tableId)).isEmpty(),
+        string.concat("table should be registered: ", string(abi.encodePacked(tableId)))
+      );
+    }
+  }
+
+  function getTableIdsFromStoreAndWorldConfigs() private returns (bytes32[] memory) {
+    string[] memory ffiInputs = new string[](3);
+    ffiInputs[0] = "pnpm";
+    ffiInputs[1] = "tsx";
+    ffiInputs[2] = "ts/scripts/list-tables-from-store-and-world-configs.ts";
+
+    bytes memory ffiOutput = vm.ffi(ffiInputs);
+
+    // The JSONPath `$[*].id` selects the `id` of all elements in the root array
+    bytes memory encoded = vm.parseJson(string(ffiOutput), "$[*].id");
+    bytes32[] memory tableIds = abi.decode(encoded, (bytes32[]));
+
+    return tableIds;
+  }
+}

--- a/packages/world/ts/scripts/list-tables-from-store-and-world-configs.ts
+++ b/packages/world/ts/scripts/list-tables-from-store-and-world-configs.ts
@@ -1,0 +1,24 @@
+import { type Hex } from "viem";
+
+import { type ExpandMUDUserConfig } from "@latticexyz/store/register";
+import { type MUDCoreUserConfig } from "@latticexyz/config";
+
+import { resourceToHex } from "@latticexyz/common";
+
+import storeConfig from "@latticexyz/store/mud.config";
+import worldConfig from "../../mud.config";
+
+function configToTables<T extends MUDCoreUserConfig>(config: ExpandMUDUserConfig<T>): { name: string; id: Hex }[] {
+  return Object.entries(config.tables)
+    .filter(([_, table]) => !table.tableIdArgument) // Skip generic tables
+    .map(([name, table]) => ({
+      name: name,
+      id: resourceToHex({
+        type: table.offchainOnly ? "offchainTable" : "table",
+        namespace: config.namespace,
+        name: table.name,
+      }),
+    }));
+}
+
+console.log(JSON.stringify([...configToTables(storeConfig), ...configToTables(worldConfig)]));


### PR DESCRIPTION
Closes #1842.

This pull request introduces a test confirming that `CoreModule` registers all necessary store and world tables. With this test, we can detect missing table registration.

Currently, all tables are registered, allowing this test to pass. To demonstrate the test's functionality, you can revert commit #1841 (`e5a962b`), which resolved a registration oversight. This action will result in a test failure:

```
$ git revert e5a962b
$ cd packages/world
$ forge test --match-path test/CoreModule.t.sol
[⠒] Compiling...
No files changed, compilation skipped

Running 1 test for test/CoreModule.t.sol:CoreModuleTest
[FAIL. Reason: assertion failed] testInstallRoot() (gas: 7153086)
Logs:
  Error: table should be registered: otworldFunctionSignatur
  Error: Assertion Failed

Test result: FAILED. 0 passed; 1 failed; 0 skipped; finished in 485.23ms
 
Ran 1 test suites: 0 tests passed, 1 failed, 0 skipped (1 total tests)

Failing tests:
Encountered 1 failing test in test/CoreModule.t.sol:CoreModuleTest
[FAIL. Reason: assertion failed] testInstallRoot() (gas: 7153086)

Encountered a total of 1 failing tests, 0 tests succeeded
```

For implementing this test, I've created a `CoreModule.t.sol` file and added a unit test for `CoreModule.installRoot`. I could have added this test in `World.t.sol`, but opted for a `CoreModule.t.sol` file to maintain a minimal test scope.

The test checks for the existence of each table. The list of necessary tables are made by a TypeScript script that references store and world configs, and the script is executed via [the `ffi` cheatcode](https://book.getfoundry.sh/forge/differential-ffi-testing#primer-the-ffi-cheatcode) in the Solidity test code.

An alternative approach would be to conduct the test against a deployed world in a TypeScript test. However, this was avoided as it extends beyond mere table registration.

<details>

<summary>Output of the TypeScript script:</summary>

All store and world tables are listed except `Hooks`.

```
$ cd packages/world
$ pnpm tsx ts/scripts/list-tables-from-store-and-world-configs.ts | jq .
[
  {
    "name": "StoreHooks",
    "id": "0x746273746f726500000000000000000053746f7265486f6f6b73000000000000"
  },
  {
    "name": "Tables",
    "id": "0x746273746f72650000000000000000005461626c657300000000000000000000"
  },
  {
    "name": "ResourceIds",
    "id": "0x746273746f72650000000000000000005265736f757263654964730000000000"
  },
  {
    "name": "NamespaceOwner",
    "id": "0x7462776f726c640000000000000000004e616d6573706163654f776e65720000"
  },
  {
    "name": "ResourceAccess",
    "id": "0x7462776f726c640000000000000000005265736f757263654163636573730000"
  },
  {
    "name": "InstalledModules",
    "id": "0x7462776f726c64000000000000000000496e7374616c6c65644d6f64756c6573"
  },
  {
    "name": "UserDelegationControl",
    "id": "0x7462776f726c640000000000000000005573657244656c65676174696f6e436f"
  },
  {
    "name": "NamespaceDelegationControl",
    "id": "0x7462776f726c640000000000000000004e616d65737061636544656c65676174"
  },
  {
    "name": "Balances",
    "id": "0x7462776f726c6400000000000000000042616c616e6365730000000000000000"
  },
  {
    "name": "Systems",
    "id": "0x7462776f726c6400000000000000000053797374656d73000000000000000000"
  },
  {
    "name": "SystemRegistry",
    "id": "0x7462776f726c6400000000000000000053797374656d52656769737472790000"
  },
  {
    "name": "SystemHooks",
    "id": "0x7462776f726c6400000000000000000053797374656d486f6f6b730000000000"
  },
  {
    "name": "FunctionSelectors",
    "id": "0x7462776f726c6400000000000000000046756e6374696f6e53656c6563746f72"
  },
  {
    "name": "FunctionSignatures",
    "id": "0x6f74776f726c6400000000000000000046756e6374696f6e5369676e61747572"
  }
]
```

</details>