### PR TITLE
docs(faucet): `npx faucet-server` typo

### DIFF
--- a/packages/faucet/README.md
+++ b/packages/faucet/README.md
@@ -8,7 +8,7 @@ Install and run with:
 
 ```sh
 npm install @latticexyz/faucet@next
-npm faucet-server
+npx faucet-server
 ```
 
 or execute the package bin directly:


### PR DESCRIPTION
Command to start faucet should be `npx faucet-server` instead. Optional fix if moving to pnpm on docs.