### PR TITLE
build: allow use by TypeScript projects with `bundler`/`node16` config

### DIFF
--- a/.changeset/poor-beans-beg.md
+++ b/.changeset/poor-beans-beg.md
@@ -1,0 +1,23 @@
+---
+"@latticexyz/abi-ts": patch
+"@latticexyz/block-logs-stream": patch
+"@latticexyz/common": patch
+"@latticexyz/config": patch
+"@latticexyz/dev-tools": patch
+"@latticexyz/faucet": patch
+"@latticexyz/gas-report": patch
+"@latticexyz/noise": patch
+"@latticexyz/phaserx": patch
+"@latticexyz/protocol-parser": patch
+"@latticexyz/react": patch
+"@latticexyz/recs": patch
+"@latticexyz/schema-type": patch
+"@latticexyz/services": patch
+"@latticexyz/store-sync": patch
+"@latticexyz/store": patch
+"@latticexyz/utils": patch
+"@latticexyz/world-modules": patch
+"@latticexyz/world": patch
+---
+
+TS packages now generate their respective `.d.ts` type definition files for better compatibility when using MUD with `moduleResolution` set to `bundler` or `node16` and fixes issues around missing type declarations for dependent packages.

--- a/packages/abi-ts/tsup.config.ts
+++ b/packages/abi-ts/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts", "src/abi-ts.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/block-logs-stream/tsup.config.ts
+++ b/packages/block-logs-stream/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/common/src/codegen/modules.d.ts
+++ b/packages/common/src/codegen/modules.d.ts
@@ -1,1 +1,1 @@
-declare module "prettier-plugin-solidity";
+declare module "prettier-plugin-solidity" {}

--- a/packages/common/tsup.config.ts
+++ b/packages/common/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/library/index.ts", "src/register/index.ts", "src/node/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/dev-tools/src/router.tsx
+++ b/packages/dev-tools/src/router.tsx
@@ -9,7 +9,26 @@ import { ComponentData } from "./recs/ComponentData";
 import { TablesPage } from "./zustand/TablesPage";
 import { TableData } from "./zustand/TableData";
 
-export const router = createMemoryRouter(
+/*
+This workaround is necessary to pass `tsc --declaration`. Without it, the following error occurs:
+
+```
+error TS2742: The inferred type of 'router' cannot be named without a reference to '.pnpm/@remix-run+router@1.6.0/node_modules/@remix-run/router'.
+This is likely not portable. A type annotation is necessary.
+```
+
+This `tsc --declaration` issue arises under the following combined conditions:
+
+1. pnpm is the package manager.
+2. The source uses a function from the dependency package (this time, react-router-dom's createMemoryRouter) and relies on type inference for its return type.
+3. The inferred return type originates from a package that is not a direct dependency of the source (this time, @remix-run/router's Router).
+4. The dependency package containing the function (react-router-dom) does not re-export the function's return type (Router).
+
+See https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189
+*/
+type Router = ReturnType<typeof createMemoryRouter>;
+
+export const router: Router = createMemoryRouter(
   createRoutesFromElements(
     <Route path="/" element={<RootPage />} errorElement={<RouteError />}>
       <Route index element={<SummaryPage />} />

--- a/packages/dev-tools/tsup.config.ts
+++ b/packages/dev-tools/tsup.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/faucet/tsup.config.ts
+++ b/packages/faucet/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts", "bin/faucet-server.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/gas-report/tsup.config.ts
+++ b/packages/gas-report/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["ts/index.ts", "ts/gas-report.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/noise/tsup.config.ts
+++ b/packages/noise/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["ts/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/phaserx/tsup.config.ts
+++ b/packages/phaserx/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/protocol-parser/tsup.config.ts
+++ b/packages/protocol-parser/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/recs/tsup.config.ts
+++ b/packages/recs/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts", "src/deprecated/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/schema-type/tsup.config.ts
+++ b/packages/schema-type/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: "dist/typescript",
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/services/tsup.config.ts
+++ b/packages/services/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
 });

--- a/packages/store-sync/tsup.config.ts
+++ b/packages/store-sync/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   ],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/store/tsup.config.ts
+++ b/packages/store/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["mud.config.ts", "ts/index.ts", "ts/codegen/index.ts", "ts/config/index.ts", "ts/register/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/world-modules/tsup.config.ts
+++ b/packages/world-modules/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["mud.config.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,

--- a/packages/world/tsup.config.ts
+++ b/packages/world/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ["mud.config.ts", "ts/index.ts", "ts/register/index.ts", "ts/node/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: false,
+  dts: true,
   sourcemap: true,
   clean: true,
   minify: true,


### PR DESCRIPTION
- Step 1 of the improvements from https://github.com/latticexyz/mud/issues/2051

This pull request enables MUD users with `moduleResolution` set to `bundler` or `node16` in their `tsconfig.json` to pass `tsc` by generating `.d.ts` files during the build. After this change, users with `bundler`/`node16` config can use MUD packages without being affected by MUD's internal TypeScript setup, as they won't need to use the `.ts` files of MUD packages.

## Problem

Currently, `moduleResolution: node10` is the only supported option for using MUD packages, which is [not ideal for most users](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html). For example, here is the config I'd like to use:

```diff
diff --git a/templates/vanilla/packages/client/tsconfig.json b/templates/vanilla/packages/client/tsconfig.json
index d8bb624b..d740aed8 100644
--- a/templates/vanilla/packages/client/tsconfig.json
+++ b/templates/vanilla/packages/client/tsconfig.json
@@ -1,18 +1,17 @@
 {
   "compilerOptions": {
     "types": ["vite/client"],
-    "target": "ESNext",
+    "target": "esnext",
     "useDefineForClassFields": true,
-    "module": "ESNext",
+    "module": "esnext",
     "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "noEmit": true,
-    "skipLibCheck": true,
-    "jsx": "react-jsx"
+    "skipLibCheck": true
   },
   "include": ["src"]
 }
diff --git a/templates/vanilla/packages/contracts/tsconfig.json b/templates/vanilla/packages/contracts/tsconfig.json
index 270db8fd..da0a1f48 100644
--- a/templates/vanilla/packages/contracts/tsconfig.json
+++ b/templates/vanilla/packages/contracts/tsconfig.json
@@ -1,13 +1,13 @@
 // Visit https://aka.ms/tsconfig.json for all config options
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
+    "target": "esnext",
+    "module": "esnext",
     "strict": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   }
 }
```

However, this configuration results in the following error (similar errors also occur in `client/`):

```
$ cd templates/vanilla/packages/contracts
$ pnpm tsc --noEmit

mud.config.ts:1:27 - error TS7016: Could not find a declaration file for module '@latticexyz/world/register'. '/Users/t/ghq/github.com/tash-2s/mud/packages/world/dist/ts/register/index.js' implicitly has an 'any' type.
  There are types at '/Users/t/ghq/github.com/tash-2s/mud/templates/vanilla/packages/contracts/node_modules/@latticexyz/world/ts/register/index.ts', but this result could not be resolved when respecting package.json "exports". The '@latticexyz/world' library may need to update its package.json or typings.

1 import { mudConfig } from "@latticexyz/world/register";
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in mud.config.ts:1
```

This error occurs because, under the `moduleResolution: bundler` setting, tsc refers to the `package.json` `exports` field of the MUD package to find the `.js` file but fails to find the corresponding `.d.ts` file.

This issue can also be confirmed using the [`@arethetypeswrong/cli`](https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/%40arethetypeswrong/cli%400.13.5/packages/cli) tool:

```
$ cd packages/common && attw --entrypoints . --pack .
...
┌───────────────────┬──────────────────────┐
│                   │ "@latticexyz/common" │
├───────────────────┼──────────────────────┤
│ node10            │ 🟢                   │
├───────────────────┼──────────────────────┤
│ node16 (from CJS) │ ❌ No types          │
├───────────────────┼──────────────────────┤
│ node16 (from ESM) │ ❌ No types          │
├───────────────────┼──────────────────────┤
│ bundler           │ ❌ No types          │
└───────────────────┴──────────────────────┘
```

## Solution

To resolve this, this PR enables the generation of `.d.ts` files during the build. MUD packages use tsup for TypeScript builds, and simply [setting `dts: true`](https://tsup.egoist.dev/#generate-declaration-file) in `tsup.config.ts` suffices.

`.ts` files cannot replace `.d.ts` files in libraries. Using `.ts` files as type declarations forces users to align their `tsconfig.json` with that of the libraries.

The targeted packages are under `./packages/`, except for:

- **Empty packages:** ecs-browser, network, solecs, std-client, std-contracts, store-cache
- **Packages with no exports:** create-mud
- **Packages with exports but empty files:** cli, store-indexer
- **Packages not imported from TypeScript:** solhint-config-mud, solhint-plugin-mud

With this change, the previously mentioned errors are resolved, and the project works without issues. In projects configured with `bundler` or `node16`, tsc no longer asks for the installation of libraries like `@types/prettier` and `@types/react-dom`. Additionally, `tsc --noEmit` time decreased from 13 seconds to 4 seconds under `templates/vanilla/packages/client` on my mac, as tsc does not need to process MUD's `.ts` files.

`@arethetypeswrong/cli` outputs results like this for the packages:

```
┌───────────────────┬──────────────────────────────┐
│                   │ "@latticexyz/common"         │
├───────────────────┼──────────────────────────────┤
│ node10            │ 🟢                           │
├───────────────────┼──────────────────────────────┤
│ node16 (from CJS) │ ⚠️ ESM (dynamic import only) │
├───────────────────┼──────────────────────────────┤
│ node16 (from ESM) │ 🟢 (ESM)                     │
├───────────────────┼──────────────────────────────┤
│ bundler           │ 🟢                           │
└───────────────────┴──────────────────────────────┘
```

(MUD packages are pure ESM and are not expected to be used from CJS.)

This change does not impact existing users with `node10`, as their tsc does not refer to the `exports` fields in MUD packages, and the built `.js` files within MUD packages, used by their bundlers, remain unchanged.

The downside is an increase in build time. However, it is not significant, as tsup generates `.js` and `.d.ts` files in parallel. Here is a comparison on my mac between the main branch and this branch using a build command that disables all cache: `git clean -d -f -x -q && pnpm install && time pnpm build --force`.

Main branch (dts disabled):

```
 Tasks:    24 successful, 24 total
Cached:    0 cached, 24 total
  Time:    1m7.039s 

pnpm build --force  82.02s user 6.78s system 131% cpu 1:07.78 total
```

This branch (dts enabled):

```
 Tasks:    24 successful, 24 total
Cached:    0 cached, 24 total
  Time:    1m38.516s 

pnpm build --force  212.04s user 13.61s system 227% cpu 1:39.27 total
```