### PR TITLE
refactor(store-indexer): move sentry init

### DIFF
--- a/packages/store-indexer/bin/postgres-frontend.ts
+++ b/packages/store-indexer/bin/postgres-frontend.ts
@@ -27,7 +27,7 @@ const database = postgres(env.DATABASE_URL, { prepare: false });
 const server = new Koa();
 
 if (process.env.SENTRY_DSN) {
-  registerSentryMiddlewares(server);
+  registerSentryMiddlewares(server, process.env.SENTRY_DSN);
 }
 
 server.use(cors());

--- a/packages/store-indexer/bin/sqlite-indexer.ts
+++ b/packages/store-indexer/bin/sqlite-indexer.ts
@@ -97,7 +97,7 @@ server.use(cors());
 server.use(apiRoutes(database));
 
 if (env.SENTRY_DSN) {
-  registerSentryMiddlewares(server);
+  registerSentryMiddlewares(server, env.SENTRY_DSN);
 }
 
 const router = new Router();

--- a/packages/store-indexer/src/compress.ts
+++ b/packages/store-indexer/src/compress.ts
@@ -4,7 +4,7 @@ import accepts from "accepts";
 import { Zlib, createBrotliCompress, createDeflate, createGzip } from "node:zlib";
 import { includes } from "@latticexyz/common/utils";
 
-// Loosely based on https://github.com/holic/koa-compress/blob/master/lib/index.js
+// Loosely based on https://github.com/koajs/compress/blob/41d501bd5db02d810572cfe154088c5fa6fcb957/lib/index.js
 // with better handling of streams better with occasional flushing
 
 const encodings = {

--- a/packages/store-indexer/src/sentry.ts
+++ b/packages/store-indexer/src/sentry.ts
@@ -4,19 +4,6 @@ import { stripUrlQueryAndFragment } from "@sentry/utils";
 import { debug } from "./debug";
 import Koa from "koa";
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  integrations: [
-    // Automatically instrument Node.js libraries and frameworks
-    ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
-    new ProfilingIntegration(),
-  ],
-  // Performance Monitoring
-  tracesSampleRate: 1.0,
-  // Set sampling rate for profiling - this is relative to tracesSampleRate
-  profilesSampleRate: 1.0,
-});
-
 const requestHandler: Koa.Middleware = (ctx, next) => {
   return new Promise<void>((resolve, reject) => {
     Sentry.runWithAsyncContext(async () => {
@@ -96,7 +83,22 @@ const errorHandler: Koa.Middleware = async (ctx, next) => {
   }
 };
 
-export const registerSentryMiddlewares = (server: Koa): void => {
+export const registerSentryMiddlewares = (server: Koa, dsn: string): void => {
+  debug("Setting up Sentry");
+
+  Sentry.init({
+    dsn,
+    integrations: [
+      // Automatically instrument Node.js libraries and frameworks
+      ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+      new ProfilingIntegration(),
+    ],
+    // Performance Monitoring
+    tracesSampleRate: 1.0,
+    // Set sampling rate for profiling - this is relative to tracesSampleRate
+    profilesSampleRate: 1.0,
+  });
+
   debug("Registering Sentry middlewares");
 
   server.use(errorHandler);


### PR DESCRIPTION
moved `Sentry.init` to avoid initializing sentry on import 