### PR TITLE
refactor(world): make coreModule variable immutable [n-08]

### DIFF
--- a/.changeset/little-cherries-rule.md
+++ b/.changeset/little-cherries-rule.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Made the `coreModule` variable in `WorldFactory` immutable.

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -57,13 +57,13 @@
     "file": "test/Factories.t.sol",
     "test": "testCreate2Factory",
     "name": "deploy contract via Create2",
-    "gasUsed": 4662733
+    "gasUsed": 4647528
   },
   {
     "file": "test/Factories.t.sol",
     "test": "testWorldFactory",
     "name": "deploy world via WorldFactory",
-    "gasUsed": 11933649
+    "gasUsed": 11933543
   },
   {
     "file": "test/World.t.sol",

--- a/packages/world/src/WorldFactory.sol
+++ b/packages/world/src/WorldFactory.sol
@@ -15,7 +15,7 @@ import { ROOT_NAMESPACE_ID } from "./constants.sol";
  */
 contract WorldFactory is IWorldFactory {
   /// @notice Address of the core module to be set in the World instances.
-  IModule public coreModule;
+  IModule public immutable coreModule;
 
   /// @notice Counter to keep track of the number of World instances deployed.
   uint256 public worldCount;


### PR DESCRIPTION
Makes the `coreModule` variable in `WorldFactory` [immutable](https://docs.soliditylang.org/en/latest/contracts.html#constant-and-immutable-state-variables) because it is only set once, in the constructor. This decreases gas cost:

> Compared to regular state variables, the gas costs of constant and immutable variables are much lower ... Immutable variables are evaluated once at construction time and their value is copied to all the places in the code where they are accessed. 