### PR TITLE
refactor(world): world context gets world from consumer lib [n-08]

### DIFF
--- a/.changeset/three-llamas-sin.md
+++ b/.changeset/three-llamas-sin.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Refactored `WorldContext` to get the world address from `WorldContextConsumerLib` instead of `StoreSwitch`.

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -75,13 +75,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1413360
+    "gasUsed": 1413395
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1413360
+    "gasUsed": 1413395
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -93,13 +93,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1413360
+    "gasUsed": 1413395
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1413360
+    "gasUsed": 1413395
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -117,7 +117,7 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1413360
+    "gasUsed": 1413395
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -135,7 +135,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 668171
+    "gasUsed": 668206
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -153,7 +153,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 668171
+    "gasUsed": 668206
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -165,7 +165,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 668171
+    "gasUsed": 668206
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -183,7 +183,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 668171
+    "gasUsed": 668206
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -303,7 +303,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 694879
+    "gasUsed": 694914
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
@@ -315,7 +315,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 663830
+    "gasUsed": 663865
   },
   {
     "file": "test/UniqueEntityModule.t.sol",

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -45,13 +45,13 @@
     "file": "test/BatchCall.t.sol",
     "test": "testBatchCallFromReturnData",
     "name": "call systems with batchCallFrom",
-    "gasUsed": 46444
+    "gasUsed": 46479
   },
   {
     "file": "test/BatchCall.t.sol",
     "test": "testBatchCallReturnData",
     "name": "call systems with batchCall",
-    "gasUsed": 45206
+    "gasUsed": 45241
   },
   {
     "file": "test/World.t.sol",

--- a/packages/world/src/WorldContext.sol
+++ b/packages/world/src/WorldContext.sol
@@ -40,7 +40,7 @@ abstract contract WorldContextConsumer is IWorldContextConsumer {
    * @return The address of the World contract that routed the call to this WorldContextConsumer.
    */
   function _world() public view returns (address) {
-    return StoreSwitch.getStoreAddress();
+    return WorldContextConsumerLib._world();
   }
 
   /**


### PR DESCRIPTION
`WorldContext._world()` currently fetches the world address with `StoreSwitch`. 

For consistency with `_msgSender` and `_msgValue`, it should use`WorldContextConsumerLib` which calls `StoreSwitch` under the hood.