### PR TITLE
refactor(store): slice library uses pointer consistently [n-08]

### DIFF
--- a/.changeset/little-starfishes-walk.md
+++ b/.changeset/little-starfishes-walk.md
@@ -1,5 +1,0 @@
----
-"@latticexyz/store": patch
----
-
-Refactored the `Slice` library to consistenly use `pointer(self)`.

--- a/.changeset/little-starfishes-walk.md
+++ b/.changeset/little-starfishes-walk.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": patch
+---
+
+Refactored the `Slice` library to consistenly use `pointer(self)`.

--- a/packages/store/src/Slice.sol
+++ b/packages/store/src/Slice.sol
@@ -120,7 +120,7 @@ library SliceInstance {
    * @return result The bytes32 representation of the provided Slice.
    */
   function toBytes32(Slice self) internal pure returns (bytes32 result) {
-    uint256 memoryPointer = self.pointer();
+    uint256 memoryPointer = pointer(self);
     /// @solidity memory-safe-assembly
     assembly {
       result := mload(memoryPointer)


### PR DESCRIPTION
The `Slice` library uses `self.pointer()` and `pointer(self)` which are interchangeable. With this PR it only uses `pointer(self)`, which I think is more "direct" than a method attached by the global `using` statement.