### PR TITLE
refactor(store,world,world-modules): do not explicitly initialise to zero [n-08]

### DIFF
--- a/.changeset/soft-panthers-develop.md
+++ b/.changeset/soft-panthers-develop.md
@@ -1,0 +1,7 @@
+---
+"@latticexyz/world-modules": patch
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Refactored various Solidity files to not explicitly initialise variables to zero.

--- a/packages/store/src/FieldLayout.sol
+++ b/packages/store/src/FieldLayout.sol
@@ -48,7 +48,7 @@ library FieldLayoutLib {
       revert FieldLayoutLib_TooManyDynamicFields(numDynamicFields, MAX_DYNAMIC_FIELDS);
 
     // Compute the total static length and store the field lengths in the encoded fieldLayout
-    for (uint256 i = 0; i < _staticFieldLengths.length; ) {
+    for (uint256 i; i < _staticFieldLengths.length; ) {
       uint256 staticByteLength = _staticFieldLengths[i];
       if (staticByteLength == 0) {
         revert FieldLayoutLib_StaticLengthIsZero();

--- a/packages/world-modules/src/modules/utils/ArrayLib.sol
+++ b/packages/world-modules/src/modules/utils/ArrayLib.sol
@@ -36,7 +36,7 @@ library ArrayLib {
 
   function filter(bytes32[] memory arr, bytes32 element) internal pure returns (bytes32[] memory) {
     bytes32[] memory filtered = new bytes32[](arr.length);
-    uint256 filteredIndex = 0;
+    uint256 filteredIndex;
     for (uint256 i; i < arr.length; i++) {
       if (arr[i] != element) {
         filtered[filteredIndex] = arr[i];

--- a/packages/world/src/modules/core/CoreModule.sol
+++ b/packages/world/src/modules/core/CoreModule.sol
@@ -142,7 +142,7 @@ contract CoreModule is Module {
       "registerNamespaceDelegation(bytes32,bytes32,bytes)"
     ];
 
-    for (uint256 i = 0; i < functionSignatures.length; i++) {
+    for (uint256 i; i < functionSignatures.length; i++) {
       // Use the CoreSystem's `registerRootFunctionSelector` to register the
       // root function selectors in the World.
       WorldContextProviderLib.delegatecallWithContextOrRevert({

--- a/packages/world/test/SystemHook.t.sol
+++ b/packages/world/test/SystemHook.t.sol
@@ -10,7 +10,7 @@ import { ISystemHook } from "../src/ISystemHook.sol";
 
 contract SystemHookTest is Test, GasReporter {
   function testFuzzEncode(address hookAddress, bool enableBeforeCallSystem, bool enableAfterCallSystem) public {
-    uint8 enabledHooksBitmap = 0;
+    uint8 enabledHooksBitmap;
     if (enableBeforeCallSystem) enabledHooksBitmap |= BEFORE_CALL_SYSTEM;
     if (enableAfterCallSystem) enabledHooksBitmap |= AFTER_CALL_SYSTEM;
 
@@ -21,7 +21,7 @@ contract SystemHookTest is Test, GasReporter {
   }
 
   function testFuzzIsEnabled(address hookAddress, bool enableBeforeCallSystem, bool enableAfterCallSystem) public {
-    uint8 enabledHooksBitmap = 0;
+    uint8 enabledHooksBitmap;
     if (enableBeforeCallSystem) enabledHooksBitmap |= BEFORE_CALL_SYSTEM;
     if (enableAfterCallSystem) enabledHooksBitmap |= AFTER_CALL_SYSTEM;
 
@@ -36,7 +36,7 @@ contract SystemHookTest is Test, GasReporter {
     bool enableBeforeCallSystem,
     bool enableAfterCallSystem
   ) public {
-    uint8 enabledHooksBitmap = 0;
+    uint8 enabledHooksBitmap;
     if (enableBeforeCallSystem) enabledHooksBitmap |= BEFORE_CALL_SYSTEM;
     if (enableAfterCallSystem) enabledHooksBitmap |= AFTER_CALL_SYSTEM;
 


### PR DESCRIPTION
Solidity variables are initialised to zero by default so we don't need to explicitly set them.