### PR TITLE
refactor(store,world): use hexadecimal as integer base [n-08]

### DIFF
--- a/.changeset/happy-ants-lay.md
+++ b/.changeset/happy-ants-lay.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Refactored various files to specify integers in a hex base instead of decimals.

--- a/packages/store/src/Slice.sol
+++ b/packages/store/src/Slice.sol
@@ -107,7 +107,7 @@ library SliceInstance {
     data = new bytes(_length);
     uint256 toPointer;
     assembly {
-      toPointer := add(data, 32)
+      toPointer := add(data, 0x20)
     }
     // Copy the slice contents to the array
     Memory.copy(fromPointer, toPointer, _length);

--- a/packages/store/src/Storage.sol
+++ b/packages/store/src/Storage.sol
@@ -160,7 +160,7 @@ library Storage {
     assembly {
       // Solidity's YulUtilFunctions::roundUpFunction
       function round_up_to_mul_of_32(value) -> _result {
-        _result := and(add(value, 31), not(31))
+        _result := and(add(value, 0x1F), not(0x1F))
       }
 
       // Allocate memory

--- a/packages/store/src/tightcoder/TightCoder.sol
+++ b/packages/store/src/tightcoder/TightCoder.sol
@@ -30,7 +30,7 @@ library TightCoder {
     assembly {
       // Solidity's YulUtilFunctions::roundUpFunction
       function round_up_to_mul_of_32(value) -> _result {
-        _result := and(add(value, 31), not(31))
+        _result := and(add(value, 0x1F), not(0x1F))
       }
 
       // Allocate memory
@@ -84,7 +84,7 @@ library TightCoder {
       // Allocate memory
       array := mload(0x40)
       let arrayPointer := add(array, 0x20)
-      mstore(0x40, add(arrayPointer, mul(arrayLength, 32)))
+      mstore(0x40, add(arrayPointer, mul(arrayLength, 0x20)))
       // Store length
       mstore(array, arrayLength)
 

--- a/packages/world/src/WorldContext.sol
+++ b/packages/world/src/WorldContext.sol
@@ -65,7 +65,7 @@ library WorldContextConsumerLib {
       // Load 32 bytes from calldata at position calldatasize() - context size,
       // then shift left 96 bits (to right-align the address)
       // 96 = 256 - 20 * 8
-      sender := shr(96, calldataload(sub(calldatasize(), CONTEXT_BYTES)))
+      sender := shr(0x60, calldataload(sub(calldatasize(), CONTEXT_BYTES)))
     }
     if (sender == address(0)) sender = msg.sender;
   }
@@ -78,7 +78,7 @@ library WorldContextConsumerLib {
   function _msgValue() internal pure returns (uint256 value) {
     assembly {
       // Load 32 bytes from calldata at position calldatasize() - 32 bytes,
-      value := calldataload(sub(calldatasize(), 32))
+      value := calldataload(sub(calldatasize(), 0x20))
     }
   }
 


### PR DESCRIPTION
Specify integers as hex (ie. 0x20) instead of decimal (ie. 32). This is purely for consistency and does not effect the compiled code.