### PR TITLE
chore(world): add gas reports for deploying world via WorldFactory

### DIFF
--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -55,8 +55,14 @@
   },
   {
     "file": "test/Factories.t.sol",
+    "test": "testCreate2Factory",
+    "name": "deploy contract via Create2",
+    "gasUsed": 4663033
+  },
+  {
+    "file": "test/Factories.t.sol",
     "test": "testWorldFactory",
-    "name": "deploy world",
+    "name": "deploy world via WorldFactory",
     "gasUsed": 11933749
   },
   {

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -54,6 +54,12 @@
     "gasUsed": 45206
   },
   {
+    "file": "test/Factories.t.sol",
+    "test": "testWorldFactory",
+    "name": "deploy world",
+    "gasUsed": 11933749
+  },
+  {
     "file": "test/World.t.sol",
     "test": "testCall",
     "name": "call a system via the World",

--- a/packages/world/test/Factories.t.sol
+++ b/packages/world/test/Factories.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.21;
 import { Test, console } from "forge-std/Test.sol";
 
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
+import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
 import { WORLD_VERSION } from "../src/version.sol";
 import { World } from "../src/World.sol";
 import { ResourceId } from "../src/WorldResourceId.sol";
@@ -16,7 +17,7 @@ import { InstalledModules } from "../src/codegen/tables/InstalledModules.sol";
 import { NamespaceOwner } from "../src/codegen/tables/NamespaceOwner.sol";
 import { ROOT_NAMESPACE_ID } from "../src/constants.sol";
 
-contract FactoriesTest is Test {
+contract FactoriesTest is Test, GasReporter {
   event ContractDeployed(address addr, uint256 salt);
   event WorldDeployed(address indexed newContract);
   event HelloWorld(bytes32 indexed version);
@@ -67,7 +68,9 @@ contract FactoriesTest is Test {
     // Check for WorldDeployed event from Factory
     vm.expectEmit(true, false, false, false);
     emit WorldDeployed(calculatedAddress);
+    startGasReport("deploy world via WorldFactory");
     worldFactory.deployWorld();
+    endGasReport();
 
     // Set the store address manually
     StoreSwitch.setStoreAddress(calculatedAddress);

--- a/packages/world/test/Factories.t.sol
+++ b/packages/world/test/Factories.t.sol
@@ -45,7 +45,9 @@ contract FactoriesTest is Test, GasReporter {
     // Confirm event for deployment
     vm.expectEmit(true, false, false, false);
     emit ContractDeployed(calculatedAddress, uint256(0));
+    startGasReport("deploy contract via Create2");
     create2Factory.deployContract(combinedBytes, uint256(0));
+    endGasReport();
 
     // Confirm worldFactory was deployed correctly
     IWorldFactory worldFactory = IWorldFactory(calculatedAddress);


### PR DESCRIPTION
We don't currently have gas tests for `WorldFactory`. Adding this also covers more code like the `Create2` library.