### PR TITLE
Revert "test: increase forge test verbosity in ci"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  FOUNDRY_VERBOSITY: 5
-
 jobs:
   test:
     name: Run tests


### PR DESCRIPTION
Reverts latticexyz/mud#2119

Turns out this is too noisy and makes it hard to even see test errors due to CI log truncation