### PR TITLE
refactor(world-modules): simplify getUniqueEntity call

### DIFF
--- a/.changeset/breezy-garlics-decide.md
+++ b/.changeset/breezy-garlics-decide.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world-modules": patch
+---
+
+Removed `IUniqueEntitySystem` in favor of calling `getUniqueEntity` via `world.call` instead of the world function selector. This had a small gas improvement.

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -309,7 +309,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "get a unique entity nonce (non-root module)",
-    "gasUsed": 51027
+    "gasUsed": 50365
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
@@ -321,6 +321,6 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "get a unique entity nonce (root module)",
-    "gasUsed": 51027
+    "gasUsed": 50368
   }
 ]

--- a/packages/world-modules/src/interfaces/IUniqueEntitySystem.sol
+++ b/packages/world-modules/src/interfaces/IUniqueEntitySystem.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.8.21;
-
-// TODO allow overriding namespace per-system (or a separate config for modules?)
-interface IUniqueEntitySystem {
-  function uniqueEntity_system_getUniqueEntity() external returns (bytes32 uniqueEntity);
-}

--- a/packages/world-modules/src/modules/uniqueentity/getUniqueEntity.sol
+++ b/packages/world-modules/src/modules/uniqueentity/getUniqueEntity.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.21;
 
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 
-import { IUniqueEntitySystem } from "../../interfaces/IUniqueEntitySystem.sol";
 import { UniqueEntitySystem } from "./UniqueEntitySystem.sol";
 
 import { SystemSwitch } from "../../utils/SystemSwitch.sol";
@@ -23,5 +22,5 @@ function getUniqueEntity() returns (bytes32 uniqueEntity) {
  * Increment and get an entity nonce.
  */
 function getUniqueEntity(IBaseWorld world) returns (bytes32 uniqueEntity) {
-  return IUniqueEntitySystem(address(world)).uniqueEntity_system_getUniqueEntity();
+  return abi.decode(world.call(SYSTEM_ID, abi.encodeCall(UniqueEntitySystem.getUniqueEntity, ())), (bytes32));
 }


### PR DESCRIPTION
Spotted this while working on https://github.com/latticexyz/mud/pull/2160

Using `world.call` means we don't need to maintain this manual system interface and it's cheaper on gas.