### PR TITLE
build: reduce CI concurrency when publishing to npm

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,7 +6,8 @@ on:
       # Target main branch
       - "main"
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Ensure only one workflow/job is publishing to npm at a time
+concurrency: publish-to-npm
 
 jobs:
   prerelease:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   prerelease:
-    name: Changests Prerelease
+    name: Changesets Prerelease
     if: github.repository == 'latticexyz/mud'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - v2
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: publish-to-npm
 
 jobs:
   version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - v2
 
+# Ensure only one workflow/job is publishing to npm at a time
 concurrency: publish-to-npm
 
 jobs:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
 
+# Ensure only one workflow/job is publishing to npm at a time
 concurrency: publish-to-npm
 
 jobs:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+concurrency: publish-to-npm
+
 jobs:
   release-snapshot:
     name: Publish snapshot release to npm


### PR DESCRIPTION
fixes #1764 
