### PR TITLE
chore(store-sync): delete console log

### DIFF
--- a/packages/store-sync/src/zustand/createStorageAdapter.ts
+++ b/packages/store-sync/src/zustand/createStorageAdapter.ts
@@ -30,7 +30,6 @@ export function createStorageAdapter<tables extends Tables>({
       if (!table) {
         const { namespace, name } = hexToResource(log.args.tableId);
         debug(`skipping update for unknown table: ${namespace}:${name} (${log.args.tableId}) at ${log.address}`);
-        console.log(store.getState().tables, log.args.tableId);
         continue;
       }
 


### PR DESCRIPTION
This log was found to be [slowing down](https://github.com/latticexyz/mud/pull/2178#issuecomment-1907918017) the Zustand storage adapter, and is not needed because the preceding `debug` call logs the same information.