### PR TITLE
refactor(world,world-modules): rename module args to encodedArgs

### DIFF
--- a/.changeset/seven-pears-walk.md
+++ b/.changeset/seven-pears-walk.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/world-modules": patch
+"@latticexyz/world": patch
+---
+
+Renamed the Module `args` parameter to `encodedArgs` to better reflect that it is ABI-encoded arguments.

--- a/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
+++ b/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
@@ -25,12 +25,12 @@ contract ERC20Module is Module {
 
   address immutable registrationLibrary = address(new ERC20ModuleRegistrationLibrary());
 
-  function install(bytes memory args) public {
+  function install(bytes memory encodedArgs) public {
     // Require the module to not be installed with these args yet
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     // Extract args
-    (bytes14 namespace, ERC20MetadataData memory metadata) = abi.decode(args, (bytes14, ERC20MetadataData));
+    (bytes14 namespace, ERC20MetadataData memory metadata) = abi.decode(encodedArgs, (bytes14, ERC20MetadataData));
 
     // Require the namespace to not be the module's namespace
     if (namespace == MODULE_NAMESPACE) {

--- a/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
+++ b/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
@@ -29,7 +29,7 @@ contract ERC20Module is Module {
     // Require the module to not be installed with these args yet
     requireNotInstalled(__self, encodedArgs);
 
-    // Extract args
+    // Decode args
     (bytes14 namespace, ERC20MetadataData memory metadata) = abi.decode(encodedArgs, (bytes14, ERC20MetadataData));
 
     // Require the namespace to not be the module's namespace

--- a/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
@@ -33,7 +33,7 @@ contract ERC721Module is Module {
     // Require the module to not be installed with these args yet
     requireNotInstalled(__self, encodedArgs);
 
-    // Extract args
+    // Decode args
     (bytes14 namespace, ERC721MetadataData memory metadata) = abi.decode(encodedArgs, (bytes14, ERC721MetadataData));
 
     // Require the namespace to not be the module's namespace

--- a/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
@@ -29,12 +29,12 @@ contract ERC721Module is Module {
 
   address immutable registrationLibrary = address(new ERC721ModuleRegistrationLibrary());
 
-  function install(bytes memory args) public {
+  function install(bytes memory encodedArgs) public {
     // Require the module to not be installed with these args yet
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     // Extract args
-    (bytes14 namespace, ERC721MetadataData memory metadata) = abi.decode(args, (bytes14, ERC721MetadataData));
+    (bytes14 namespace, ERC721MetadataData memory metadata) = abi.decode(encodedArgs, (bytes14, ERC721MetadataData));
 
     // Require the namespace to not be the module's namespace
     if (namespace == MODULE_NAMESPACE) {

--- a/packages/world-modules/src/modules/keysintable/KeysInTableModule.sol
+++ b/packages/world-modules/src/modules/keysintable/KeysInTableModule.sol
@@ -33,13 +33,13 @@ contract KeysInTableModule is Module {
   // from the source table id (passed as argument to the hook methods)
   KeysInTableHook private immutable hook = new KeysInTableHook();
 
-  function installRoot(bytes memory args) public override {
+  function installRoot(bytes memory encodedArgs) public override {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     // Extract source table id from args
-    ResourceId sourceTableId = ResourceId.wrap(abi.decode(args, (bytes32)));
+    ResourceId sourceTableId = ResourceId.wrap(abi.decode(encodedArgs, (bytes32)));
 
     IBaseWorld world = IBaseWorld(_world());
 

--- a/packages/world-modules/src/modules/keyswithvalue/KeysWithValueModule.sol
+++ b/packages/world-modules/src/modules/keyswithvalue/KeysWithValueModule.sol
@@ -35,13 +35,13 @@ contract KeysWithValueModule is Module {
   // from the source table id (passed as argument to the hook methods)
   KeysWithValueHook private immutable hook = new KeysWithValueHook();
 
-  function installRoot(bytes memory args) public {
+  function installRoot(bytes memory encodedArgs) public {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     // Extract source table id from args
-    ResourceId sourceTableId = ResourceId.wrap(abi.decode(args, (bytes32)));
+    ResourceId sourceTableId = ResourceId.wrap(abi.decode(encodedArgs, (bytes32)));
     ResourceId targetTableId = getTargetTableId(MODULE_NAMESPACE, sourceTableId);
 
     IBaseWorld world = IBaseWorld(_world());

--- a/packages/world-modules/src/modules/uniqueentity/UniqueEntityModule.sol
+++ b/packages/world-modules/src/modules/uniqueentity/UniqueEntityModule.sol
@@ -22,10 +22,10 @@ contract UniqueEntityModule is Module {
   // known tables, we can deploy it once and register it in multiple Worlds.
   UniqueEntitySystem private immutable uniqueEntitySystem = new UniqueEntitySystem();
 
-  function installRoot(bytes memory args) public {
+  function installRoot(bytes memory encodedArgs) public {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     IBaseWorld world = IBaseWorld(_world());
 
@@ -51,10 +51,10 @@ contract UniqueEntityModule is Module {
     if (!success) revertWithBytes(data);
   }
 
-  function install(bytes memory args) public {
+  function install(bytes memory encodedArgs) public {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
-    requireNotInstalled(__self, args);
+    requireNotInstalled(__self, encodedArgs);
 
     IBaseWorld world = IBaseWorld(_world());
 

--- a/packages/world/src/IModule.sol
+++ b/packages/world/src/IModule.sol
@@ -20,7 +20,7 @@ interface IModule is IERC165 {
    * @notice Installs the module as a root module.
    * @dev This function is invoked by the World contract during `installRootModule` process.
    * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
-   * @param encodedArgs Arguments that may be needed during the installation process.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
    */
   function installRoot(bytes memory encodedArgs) external;
 

--- a/packages/world/src/IModule.sol
+++ b/packages/world/src/IModule.sol
@@ -20,16 +20,16 @@ interface IModule is IERC165 {
    * @notice Installs the module as a root module.
    * @dev This function is invoked by the World contract during `installRootModule` process.
    * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
-   * @param args Arguments that may be needed during the installation process.
+   * @param encodedArgs Arguments that may be needed during the installation process.
    */
-  function installRoot(bytes memory args) external;
+  function installRoot(bytes memory encodedArgs) external;
 
   /**
    * @notice Installs the module.
    * @dev This function is invoked by the World contract during `installModule` process.
    * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
    * Logic might differ from `installRoot`, for example, this might accept namespace parameters.
-   * @param args Arguments that may be needed during the installation process.
+   * @param encodedArgs Arguments that may be needed during the installation process.
    */
-  function install(bytes memory args) external;
+  function install(bytes memory encodedArgs) external;
 }

--- a/packages/world/src/IModule.sol
+++ b/packages/world/src/IModule.sol
@@ -29,7 +29,7 @@ interface IModule is IERC165 {
    * @dev This function is invoked by the World contract during `installModule` process.
    * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
    * Logic might differ from `installRoot`, for example, this might accept namespace parameters.
-   * @param encodedArgs Arguments that may be needed during the installation process.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
    */
   function install(bytes memory encodedArgs) external;
 }

--- a/packages/world/src/IWorldKernel.sol
+++ b/packages/world/src/IWorldKernel.sol
@@ -14,7 +14,7 @@ interface IWorldModuleInstallation {
    * @notice Install the given root module in the World.
    * @dev Requires the caller to own the root namespace. The module is delegatecalled and installed in the root namespace.
    * @param module The module to be installed.
-   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
+   * @param encodedArgs The ABI encoded arguments for the module installation.
    */
   function installRootModule(IModule module, bytes memory encodedArgs) external;
 }

--- a/packages/world/src/IWorldKernel.sol
+++ b/packages/world/src/IWorldKernel.sol
@@ -14,7 +14,7 @@ interface IWorldModuleInstallation {
    * @notice Install the given root module in the World.
    * @dev Requires the caller to own the root namespace. The module is delegatecalled and installed in the root namespace.
    * @param module The module to be installed.
-   * @param encodedArgs The arguments provided for the module installation.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
    */
   function installRootModule(IModule module, bytes memory encodedArgs) external;
 }

--- a/packages/world/src/IWorldKernel.sol
+++ b/packages/world/src/IWorldKernel.sol
@@ -14,9 +14,9 @@ interface IWorldModuleInstallation {
    * @notice Install the given root module in the World.
    * @dev Requires the caller to own the root namespace. The module is delegatecalled and installed in the root namespace.
    * @param module The module to be installed.
-   * @param args The arguments provided for the module installation.
+   * @param encodedArgs The arguments provided for the module installation.
    */
-  function installRootModule(IModule module, bytes memory args) external;
+  function installRootModule(IModule module, bytes memory encodedArgs) external;
 }
 
 /**

--- a/packages/world/src/Module.sol
+++ b/packages/world/src/Module.sol
@@ -32,7 +32,7 @@ abstract contract Module is IModule, WorldContextConsumer {
   /**
    * @dev Check if a module with the given name and arguments is installed.
    * @param moduleAddress The address of the module.
-   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
+   * @param encodedArgs The ABI encoded arguments for the module installation.
    * @return true if the module is installed, false otherwise.
    */
   function isInstalled(address moduleAddress, bytes memory encodedArgs) internal view returns (bool) {
@@ -42,7 +42,7 @@ abstract contract Module is IModule, WorldContextConsumer {
   /**
    * @dev Revert if the module with the given name and arguments is already installed.
    * @param moduleAddress The address of the module.
-   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
+   * @param encodedArgs The ABI encoded arguments for the module installation.
    */
   function requireNotInstalled(address moduleAddress, bytes memory encodedArgs) internal view {
     if (isInstalled(moduleAddress, encodedArgs)) {

--- a/packages/world/src/Module.sol
+++ b/packages/world/src/Module.sol
@@ -32,20 +32,20 @@ abstract contract Module is IModule, WorldContextConsumer {
   /**
    * @dev Check if a module with the given name and arguments is installed.
    * @param moduleAddress The address of the module.
-   * @param args The arguments for the module installation.
+   * @param encodedArgs The arguments for the module installation.
    * @return true if the module is installed, false otherwise.
    */
-  function isInstalled(address moduleAddress, bytes memory args) internal view returns (bool) {
-    return InstalledModules.get(moduleAddress, keccak256(args));
+  function isInstalled(address moduleAddress, bytes memory encodedArgs) internal view returns (bool) {
+    return InstalledModules.get(moduleAddress, keccak256(encodedArgs));
   }
 
   /**
    * @dev Revert if the module with the given name and arguments is already installed.
    * @param moduleAddress The address of the module.
-   * @param args The arguments for the module installation.
+   * @param encodedArgs The arguments for the module installation.
    */
-  function requireNotInstalled(address moduleAddress, bytes memory args) internal view {
-    if (isInstalled(moduleAddress, args)) {
+  function requireNotInstalled(address moduleAddress, bytes memory encodedArgs) internal view {
+    if (isInstalled(moduleAddress, encodedArgs)) {
       revert Module_AlreadyInstalled();
     }
   }

--- a/packages/world/src/Module.sol
+++ b/packages/world/src/Module.sol
@@ -32,7 +32,7 @@ abstract contract Module is IModule, WorldContextConsumer {
   /**
    * @dev Check if a module with the given name and arguments is installed.
    * @param moduleAddress The address of the module.
-   * @param encodedArgs The arguments for the module installation.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
    * @return true if the module is installed, false otherwise.
    */
   function isInstalled(address moduleAddress, bytes memory encodedArgs) internal view returns (bool) {
@@ -42,7 +42,7 @@ abstract contract Module is IModule, WorldContextConsumer {
   /**
    * @dev Revert if the module with the given name and arguments is already installed.
    * @param moduleAddress The address of the module.
-   * @param encodedArgs The arguments for the module installation.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
    */
   function requireNotInstalled(address moduleAddress, bytes memory encodedArgs) internal view {
     if (isInstalled(moduleAddress, encodedArgs)) {

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -84,20 +84,20 @@ contract World is StoreData, IWorldKernel {
   /**
    * @notice Installs a given root module in the World.
    * @param module The module to be installed.
-   * @param args Arguments for module installation.
+   * @param encodedArgs Arguments for module installation.
    * @dev The caller must own the root namespace.
    */
-  function installRootModule(IModule module, bytes memory args) public prohibitDirectCallback {
+  function installRootModule(IModule module, bytes memory encodedArgs) public prohibitDirectCallback {
     AccessControl.requireOwner(ROOT_NAMESPACE_ID, msg.sender);
-    _installRootModule(module, args);
+    _installRootModule(module, encodedArgs);
   }
 
   /**
    * @dev Internal function to install a root module.
    * @param module The module to be installed.
-   * @param args Arguments for module installation.
+   * @param encodedArgs Arguments for module installation.
    */
-  function _installRootModule(IModule module, bytes memory args) internal {
+  function _installRootModule(IModule module, bytes memory encodedArgs) internal {
     // Require the provided address to implement the IModule interface
     requireInterface(address(module), type(IModule).interfaceId);
 
@@ -105,11 +105,11 @@ contract World is StoreData, IWorldKernel {
       msgSender: msg.sender,
       msgValue: 0,
       target: address(module),
-      callData: abi.encodeCall(IModule.installRoot, (args))
+      callData: abi.encodeCall(IModule.installRoot, (encodedArgs))
     });
 
     // Register the module in the InstalledModules table
-    InstalledModules._set(address(module), keccak256(args), true);
+    InstalledModules._set(address(module), keccak256(encodedArgs), true);
   }
 
   /************************************************************************

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -84,7 +84,7 @@ contract World is StoreData, IWorldKernel {
   /**
    * @notice Installs a given root module in the World.
    * @param module The module to be installed.
-   * @param encodedArgs Arguments for module installation.
+   * @param encodedArgs The ABI encoded arguments for module installation.
    * @dev The caller must own the root namespace.
    */
   function installRootModule(IModule module, bytes memory encodedArgs) public prohibitDirectCallback {
@@ -95,7 +95,7 @@ contract World is StoreData, IWorldKernel {
   /**
    * @dev Internal function to install a root module.
    * @param module The module to be installed.
-   * @param encodedArgs Arguments for module installation.
+   * @param encodedArgs The ABI encoded arguments for module installation.
    */
   function _installRootModule(IModule module, bytes memory encodedArgs) internal {
     // Require the provided address to implement the IModule interface

--- a/packages/world/src/codegen/interfaces/IModuleInstallationSystem.sol
+++ b/packages/world/src/codegen/interfaces/IModuleInstallationSystem.sol
@@ -10,5 +10,5 @@ import { IModule } from "./../../IModule.sol";
  * @dev This interface is automatically generated from the corresponding system contract. Do not edit manually.
  */
 interface IModuleInstallationSystem {
-  function installModule(IModule module, bytes memory args) external;
+  function installModule(IModule module, bytes memory encodedArgs) external;
 }

--- a/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
+++ b/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
@@ -19,7 +19,7 @@ contract ModuleInstallationSystem is System, LimitedCallContext {
    * @dev Validates the given module against the IModule interface and delegates the installation process.
    * The module is then registered in the InstalledModules table.
    * @param module The module to be installed.
-   * @param encodedArgs Arguments for the module installation.
+   * @param encodedArgs The ABI encoded arguments for module installation.
    */
   function installModule(IModule module, bytes memory encodedArgs) public onlyDelegatecall {
     // Require the provided address to implement the IModule interface

--- a/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
+++ b/packages/world/src/modules/core/implementations/ModuleInstallationSystem.sol
@@ -19,9 +19,9 @@ contract ModuleInstallationSystem is System, LimitedCallContext {
    * @dev Validates the given module against the IModule interface and delegates the installation process.
    * The module is then registered in the InstalledModules table.
    * @param module The module to be installed.
-   * @param args Arguments for the module installation.
+   * @param encodedArgs Arguments for the module installation.
    */
-  function installModule(IModule module, bytes memory args) public onlyDelegatecall {
+  function installModule(IModule module, bytes memory encodedArgs) public onlyDelegatecall {
     // Require the provided address to implement the IModule interface
     requireInterface(address(module), type(IModule).interfaceId);
 
@@ -29,10 +29,10 @@ contract ModuleInstallationSystem is System, LimitedCallContext {
       msgSender: _msgSender(),
       msgValue: 0,
       target: address(module),
-      callData: abi.encodeCall(IModule.install, (args))
+      callData: abi.encodeCall(IModule.install, (encodedArgs))
     });
 
     // Register the module in the InstalledModules table
-    InstalledModules._set(address(module), keccak256(args), true);
+    InstalledModules._set(address(module), keccak256(encodedArgs), true);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/latticexyz/mud/issues/1757

This name better reflects that the `bytes` argument is encoded module arguments, not the actual typed arguments.