### PR TITLE
test(world-modules): improve `SystemSwitch` test coverage

### DIFF
--- a/packages/world-modules/test/SystemSwitch.t.sol
+++ b/packages/world-modules/test/SystemSwitch.t.sol
@@ -13,7 +13,7 @@ import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.
 import { World } from "@latticexyz/world/src/World.sol";
 import { createCoreModule } from "@latticexyz/world/test/createCoreModule.sol";
 import { ResourceId, WorldResourceIdLib, WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
-import { RESOURCE_SYSTEM, RESOURCE_TABLE } from "@latticexyz/world/src/worldResourceTypes.sol";
+import { RESOURCE_SYSTEM } from "@latticexyz/world/src/worldResourceTypes.sol";
 import { ROOT_NAMESPACE } from "@latticexyz/world/src/constants.sol";
 import { SystemSwitch } from "../src/utils/SystemSwitch.sol";
 

--- a/packages/world-modules/test/SystemSwitch.t.sol
+++ b/packages/world-modules/test/SystemSwitch.t.sol
@@ -171,19 +171,19 @@ contract SystemSwitchTest is Test, GasReporter {
     assertEq(abi.decode(returnData, (address)), caller);
   }
 
-  function testNonCallRootFromRootWorld() public {
+  function testCallNonRootFromRootWorld() public {
     vm.prank(caller);
     bytes memory returnData = _executeFromRootSystemA(systemBId, abi.encodeCall(EchoSystem.world, ()));
     assertEq(abi.decode(returnData, (address)), address(world));
   }
 
-  function testNonCallRootFromRootEcho() public {
+  function testCallNonRootFromRootEcho() public {
     vm.prank(caller);
     bytes memory returnData = _executeFromRootSystemA(systemBId, abi.encodeCall(EchoSystem.echo, ("hello")));
     assertEq(abi.decode(returnData, (string)), "hello");
   }
 
-  function testNonCallRootFromRootWorldSelector() public {
+  function testCallNonRootFromRootWorldSelector() public {
     bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
       systemBId,
       "echo(string)",
@@ -204,19 +204,19 @@ contract SystemSwitchTest is Test, GasReporter {
     assertEq(abi.decode(returnData, (address)), address(systemA));
   }
 
-  function testNonCallRootFromNonRootWorld() public {
+  function testCallNonRootFromNonRootWorld() public {
     vm.prank(caller);
     bytes memory returnData = _executeFromSystemA(systemBId, abi.encodeCall(EchoSystem.world, ()));
     assertEq(abi.decode(returnData, (address)), address(world));
   }
 
-  function testNonCallRootFromNonRootEcho() public {
+  function testCallNonRootFromNonRootEcho() public {
     vm.prank(caller);
     bytes memory returnData = _executeFromSystemA(systemBId, abi.encodeCall(EchoSystem.echo, ("hello")));
     assertEq(abi.decode(returnData, (string)), "hello");
   }
 
-  function testNonCallRootFromNonRootWorldSelector() public {
+  function testCallNonRootFromNonRootWorldSelector() public {
     bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
       systemBId,
       "echo(string)",

--- a/packages/world-modules/test/SystemSwitch.t.sol
+++ b/packages/world-modules/test/SystemSwitch.t.sol
@@ -13,13 +13,21 @@ import { RESOURCE_SYSTEM } from "@latticexyz/world/src/worldResourceTypes.sol";
 import { ROOT_NAMESPACE } from "@latticexyz/world/src/constants.sol";
 import { SystemSwitch } from "../src/utils/SystemSwitch.sol";
 
+uint256 constant INDEX = 7;
+
 contract EchoSystem is System {
+  uint256 public _index = INDEX;
+
   function msgSender() public view returns (address) {
     return _msgSender();
   }
 
   function world() public view returns (address) {
     return _world();
+  }
+
+  function index() public view returns (uint256) {
+    return _index;
   }
 
   function echo(string memory message) public view returns (string memory) {
@@ -194,6 +202,12 @@ contract SystemSwitchTest is Test, GasReporter {
     vm.prank(caller);
     bytes memory returnData = _executeFromRootSystemA(callData);
     assertEq(abi.decode(returnData, (string)), "hello");
+  }
+
+  function testCallNonRootFromRootIndex() public {
+    vm.prank(caller);
+    bytes memory returnData = _executeFromRootSystemA(systemBId, abi.encodeCall(EchoSystem.index, ()));
+    assertEq(abi.decode(returnData, (uint256)), INDEX);
   }
 
   // - NON ROOT FROM NON ROOT ---------------------------------------------------------------------------- //

--- a/packages/world-modules/test/SystemSwitch.t.sol
+++ b/packages/world-modules/test/SystemSwitch.t.sol
@@ -30,7 +30,7 @@ contract EchoSystem is System {
     return _index;
   }
 
-  function echo(string memory message) public view returns (string memory) {
+  function echo(string memory message) public pure returns (string memory) {
     return message;
   }
 
@@ -138,6 +138,13 @@ contract SystemSwitchTest is Test, GasReporter {
     assertEq(abi.decode(returnData, (string)), "hello");
   }
 
+  function testCallRootFromRootIndex() public {
+    vm.prank(caller);
+    bytes memory returnData = _executeFromRootSystemA(rootSystemBId, abi.encodeCall(EchoSystem.index, ()));
+    // `index` should be zero because that variable does not exist on the world
+    assertEq(abi.decode(returnData, (uint256)), 0);
+  }
+
   // - ROOT FROM NON ROOT ---------------------------------------------------------------------------- //
 
   function testCallRootFromNonRootMsgSender() public {
@@ -169,6 +176,13 @@ contract SystemSwitchTest is Test, GasReporter {
     vm.prank(caller);
     bytes memory returnData = _executeFromSystemA(callData);
     assertEq(abi.decode(returnData, (string)), "hello");
+  }
+
+  function testCallRootFromNonRootIndex() public {
+    vm.prank(caller);
+    bytes memory returnData = _executeFromSystemA(rootSystemBId, abi.encodeCall(EchoSystem.index, ()));
+    // `index` should be zero because that variable does not exist on the world
+    assertEq(abi.decode(returnData, (uint256)), 0);
   }
 
   // - NON ROOT FROM ROOT ---------------------------------------------------------------------------- //
@@ -241,5 +255,11 @@ contract SystemSwitchTest is Test, GasReporter {
     vm.prank(caller);
     bytes memory returnData = _executeFromSystemA(callData);
     assertEq(abi.decode(returnData, (string)), "hello");
+  }
+
+  function testCallNonRootFromNonRootIndex() public {
+    vm.prank(caller);
+    bytes memory returnData = _executeFromSystemA(systemBId, abi.encodeCall(EchoSystem.index, ()));
+    assertEq(abi.decode(returnData, (uint256)), INDEX);
   }
 }


### PR DESCRIPTION
As noted in https://github.com/latticexyz/mud/issues/2089, `SystemSwitch` the world incorrectly uses `delegatecall` when calling non-root systems from the root.

This was not picked up in the test suite, because it either checks the `WorldContext`, or calls a pure `echo` function (which doesn't rely on storage so returns the same result if using `call` or `delegatecall`).

This PR adds a test which calls a function to read the systems storage. It fails because the function is `delegatecalled` and the output is not what we expect.