### PR TITLE
feat: add user defined salt in WorldFactory.deployWorld()

### DIFF
--- a/packages/world/src/IWorldFactory.sol
+++ b/packages/world/src/IWorldFactory.sol
@@ -25,5 +25,5 @@ interface IWorldFactory {
    * @dev The deployment of the World contract will result in the `WorldDeployed` event being emitted.
    * @return worldAddress The address of the newly deployed World contract.
    */
-  function deployWorld() external returns (address worldAddress);
+  function deployWorld(bytes memory _salt) external returns (address worldAddress);
 }

--- a/packages/world/src/WorldFactory.sol
+++ b/packages/world/src/WorldFactory.sol
@@ -8,7 +8,9 @@ import { IBaseWorld } from "./codegen/interfaces/IBaseWorld.sol";
 import { IModule } from "./IModule.sol";
 import { ROOT_NAMESPACE_ID } from "./constants.sol";
 
-/**
+import { Test, console } from "forge-std/Test.sol";
+
+/*
  * @title WorldFactory
  * @notice A factory contract to deploy new World instances.
  * @dev This contract allows users to deploy a new World, install the CoreModule, and transfer the ownership.
@@ -25,15 +27,18 @@ contract WorldFactory is IWorldFactory {
     coreModule = _coreModule;
   }
 
-  /**
+  /*
    * @notice Deploys a new World instance, installs the CoreModule and transfers ownership to the caller.
    * @dev Uses the Create2 for deterministic deployment.
+   * @param _salt User defined salt for deterministic world addresses across chains
    * @return worldAddress The address of the newly deployed World contract.
    */
-  function deployWorld() public returns (address worldAddress) {
+  function deployWorld(bytes memory _salt) public returns (address worldAddress) {
     // Deploy a new World and increase the WorldCount
     bytes memory bytecode = type(World).creationCode;
-    uint256 salt = uint256(keccak256(abi.encode(msg.sender, worldCounts[msg.sender]++)));
+    uint256 salt = uint256(keccak256(abi.encode(msg.sender, _salt)));
+    worldCounts[msg.sender]++;
+
     worldAddress = Create2.deploy(bytecode, salt);
     IBaseWorld world = IBaseWorld(worldAddress);
 


### PR DESCRIPTION
This PR adds user-defined salt functionality to the `WorldFactory.deployWorld()` function.

Resolves #2214

The modified `WorldFactory.deployWorld()` function allows the world creator to pass in an arbitrary salt value. This makes it easier for developers to have deterministic addresses across chains. 

The edited function still increments worldCounts when creating a new world, but the worldCount nonce is not used to create a unique salt. 

The salt value still uses msg.sender as a parameter to generate a salt. If msg.sender calls deployWorld() a second time with the same bytes _salt value, the transaction will revert.

solidity
    function deployWorld(bytes memory _salt) public returns (address worldAddress) {
        // Deploy a new World and increase the WorldCount
        bytes memory bytecode = type(World).creationCode;
        uint256 salt = uint256(keccak256(abi.encode(msg.sender, _salt)));
        worldCounts[msg.sender]++;
        
        worldAddress = Create2.deploy(bytecode, salt);
        IBaseWorld world = IBaseWorld(worldAddress);

        // Initialize the World and transfer ownership to the caller
        world.initialize(coreModule);
        world.transferOwnership(ROOT_NAMESPACE_ID, msg.sender);

        emit WorldDeployed(worldAddress);
    }

This PR also updates the Factories.t.sol test. 

In the test, the calculated address matches the deployed address via Create2.

Additionally the test expects revert when attempting to deploy a second world with the same _salt value. 

Please let me know if I need to edit the PR.