### PR TITLE
feat(cli): Add rpc concurrency option to cli

### DIFF
--- a/packages/cli/src/deploy/concurrencyLock.ts
+++ b/packages/cli/src/deploy/concurrencyLock.ts
@@ -1,0 +1,61 @@
+export class ConcurrencyLock {
+  private readonly concurrency: number;
+  private readonly interval: number;
+
+  private running = 0;
+  private waitingResolves: Array<() => void> = [];
+  private lastRunAt: Date | null = null;
+
+  constructor({ concurrency, interval }: { concurrency?: number; interval?: number }) {
+    this.concurrency = concurrency ?? 1000;
+    this.interval = interval ?? 0;
+  }
+
+  async run<T>(func: () => PromiseLike<T> | T): Promise<T> {
+    await this.get(new Date());
+    const result = await func();
+    await this.release(new Date());
+
+    return result;
+  }
+
+  private async get(calledAt: Date) {
+    await new Promise<void>((resolve) => {
+      if (this.running >= this.concurrency) {
+        this.waitingResolves.push(resolve);
+        return;
+      }
+
+      this.running += 1;
+      this.schedule(resolve, calledAt);
+    });
+  }
+
+  private async release(calledAt: Date) {
+    if (this.running === 0) {
+      console.warn("ConcurrencyLock#release was called but has no runnings");
+      return;
+    }
+
+    if (this.waitingResolves.length === 0) {
+      this.running -= 1;
+      return;
+    }
+
+    const popped = this.waitingResolves.shift();
+    if (!popped) {
+      return;
+    }
+    this.schedule(popped, calledAt);
+  }
+
+  private schedule(func: () => void, calledAt: Date) {
+    const willRunAt = !this.lastRunAt
+      ? calledAt
+      : new Date(Math.max(calledAt.getTime(), this.lastRunAt.getTime() + this.interval));
+
+    this.lastRunAt = willRunAt;
+
+    setTimeout(func, willRunAt.getTime() - calledAt.getTime());
+  }
+}

--- a/packages/cli/src/deploy/deployWorld.ts
+++ b/packages/cli/src/deploy/deployWorld.ts
@@ -6,9 +6,13 @@ import { writeContract } from "@latticexyz/common";
 import { debug } from "./debug";
 import { logsToWorldDeploy } from "./logsToWorldDeploy";
 import { WorldDeploy } from "./common";
+import { ConcurrencyLock } from "./concurrencyLock";
 
-export async function deployWorld(client: Client<Transport, Chain | undefined, Account>): Promise<WorldDeploy> {
-  await ensureWorldFactory(client);
+export async function deployWorld(
+  client: Client<Transport, Chain | undefined, Account>,
+  lock: ConcurrencyLock
+): Promise<WorldDeploy> {
+  await ensureWorldFactory(client, lock);
 
   debug("deploying world");
   const tx = await writeContract(client, {

--- a/packages/cli/src/deploy/ensureContractsDeployed.ts
+++ b/packages/cli/src/deploy/ensureContractsDeployed.ts
@@ -2,15 +2,20 @@ import { Client, Transport, Chain, Account, Hex } from "viem";
 import { waitForTransactionReceipt } from "viem/actions";
 import { debug } from "./debug";
 import { Contract, ensureContract } from "./ensureContract";
+import { ConcurrencyLock } from "./concurrencyLock";
 
 export async function ensureContractsDeployed({
   client,
   contracts,
+  lock,
 }: {
   readonly client: Client<Transport, Chain | undefined, Account>;
   readonly contracts: readonly Contract[];
+  readonly lock: ConcurrencyLock;
 }): Promise<readonly Hex[]> {
-  const txs = (await Promise.all(contracts.map((contract) => ensureContract({ client, ...contract })))).flat();
+  const txs = (
+    await Promise.all(contracts.map((contract) => lock.run(async () => ensureContract({ client, ...contract }))))
+  ).flat();
 
   if (txs.length) {
     debug("waiting for contracts");

--- a/packages/cli/src/deploy/ensureFunctions.ts
+++ b/packages/cli/src/deploy/ensureFunctions.ts
@@ -5,17 +5,20 @@ import { debug } from "./debug";
 import { getFunctions } from "./getFunctions";
 import pRetry from "p-retry";
 import { wait } from "@latticexyz/common/utils";
+import { ConcurrencyLock } from "./concurrencyLock";
 
 export async function ensureFunctions({
   client,
   worldDeploy,
   functions,
+  lock,
 }: {
   readonly client: Client<Transport, Chain | undefined, Account>;
   readonly worldDeploy: WorldDeploy;
   readonly functions: readonly WorldFunction[];
+  readonly lock: ConcurrencyLock;
 }): Promise<readonly Hex[]> {
-  const worldFunctions = await getFunctions({ client, worldDeploy });
+  const worldFunctions = await getFunctions({ client, worldDeploy, lock });
   const worldSelectorToFunction = Object.fromEntries(worldFunctions.map((func) => [func.selector, func]));
 
   const toSkip = functions.filter((func) => worldSelectorToFunction[func.selector]);

--- a/packages/cli/src/deploy/ensureModules.ts
+++ b/packages/cli/src/deploy/ensureModules.ts
@@ -5,15 +5,18 @@ import { debug } from "./debug";
 import { isDefined, uniqueBy, wait } from "@latticexyz/common/utils";
 import pRetry from "p-retry";
 import { ensureContractsDeployed } from "./ensureContractsDeployed";
+import { ConcurrencyLock } from "./concurrencyLock";
 
 export async function ensureModules({
   client,
   worldDeploy,
   modules,
+  lock,
 }: {
   readonly client: Client<Transport, Chain | undefined, Account>;
   readonly worldDeploy: WorldDeploy;
   readonly modules: readonly Module[];
+  readonly lock: ConcurrencyLock;
 }): Promise<readonly Hex[]> {
   if (!modules.length) return [];
 
@@ -24,48 +27,51 @@ export async function ensureModules({
       deployedBytecodeSize: mod.deployedBytecodeSize,
       label: `${mod.name} module`,
     })),
+    lock,
   });
 
   debug("installing modules:", modules.map((mod) => mod.name).join(", "));
   return (
     await Promise.all(
       modules.map((mod) =>
-        pRetry(
-          async () => {
-            try {
-              return mod.installAsRoot
-                ? await writeContract(client, {
-                    chain: client.chain ?? null,
-                    address: worldDeploy.address,
-                    abi: worldAbi,
-                    // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
-                    functionName: "installRootModule",
-                    args: [mod.address, mod.installData],
-                  })
-                : await writeContract(client, {
-                    chain: client.chain ?? null,
-                    address: worldDeploy.address,
-                    abi: worldAbi,
-                    // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
-                    functionName: "installModule",
-                    args: [mod.address, mod.installData],
-                  });
-            } catch (error) {
-              if (error instanceof BaseError && error.message.includes("Module_AlreadyInstalled")) {
-                debug(`module ${mod.name} already installed`);
-                return;
+        lock.run(async () =>
+          pRetry(
+            async () => {
+              try {
+                return mod.installAsRoot
+                  ? await writeContract(client, {
+                      chain: client.chain ?? null,
+                      address: worldDeploy.address,
+                      abi: worldAbi,
+                      // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
+                      functionName: "installRootModule",
+                      args: [mod.address, mod.installData],
+                    })
+                  : await writeContract(client, {
+                      chain: client.chain ?? null,
+                      address: worldDeploy.address,
+                      abi: worldAbi,
+                      // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
+                      functionName: "installModule",
+                      args: [mod.address, mod.installData],
+                    });
+              } catch (error) {
+                if (error instanceof BaseError && error.message.includes("Module_AlreadyInstalled")) {
+                  debug(`module ${mod.name} already installed`);
+                  return;
+                }
+                throw error;
               }
-              throw error;
-            }
-          },
-          {
-            retries: 3,
-            onFailedAttempt: async (error) => {
-              const delay = error.attemptNumber * 500;
-              debug(`failed to install module ${mod.name}, retrying in ${delay}ms...`);
-              await wait(delay);
             },
-          }
+            {
+              retries: 3,
+              onFailedAttempt: async (error) => {
+                const delay = error.attemptNumber * 500;
+                debug(`failed to install module ${mod.name}, retrying in ${delay}ms...`);
+                await wait(delay);
+              },
+            }
+          )
         )
       )
     )

--- a/packages/cli/src/deploy/ensureWorldFactory.ts
+++ b/packages/cli/src/deploy/ensureWorldFactory.ts
@@ -11,6 +11,7 @@ import { deployer } from "./ensureDeployer";
 import { salt } from "./common";
 import { ensureContractsDeployed } from "./ensureContractsDeployed";
 import { Contract } from "./ensureContract";
+import { ConcurrencyLock } from "./concurrencyLock";
 
 export const accessManagementSystemDeployedBytecodeSize = size(
   accessManagementSystemBuild.deployedBytecode.object as Hex
@@ -108,11 +109,13 @@ export const worldFactoryContracts: readonly Contract[] = [
 ];
 
 export async function ensureWorldFactory(
-  client: Client<Transport, Chain | undefined, Account>
+  client: Client<Transport, Chain | undefined, Account>,
+  lock: ConcurrencyLock
 ): Promise<readonly Hex[]> {
   // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
   return await ensureContractsDeployed({
     client,
     contracts: worldFactoryContracts,
+    lock,
   });
 }

--- a/packages/cli/src/deploy/getSystems.ts
+++ b/packages/cli/src/deploy/getSystems.ts
@@ -7,42 +7,51 @@ import { debug } from "./debug";
 import { resourceLabel } from "./resourceLabel";
 import { getFunctions } from "./getFunctions";
 import { getResourceAccess } from "./getResourceAccess";
+import { ConcurrencyLock } from "./concurrencyLock";
 
 export async function getSystems({
   client,
   worldDeploy,
+  lock,
 }: {
   readonly client: Client;
   readonly worldDeploy: WorldDeploy;
+  readonly lock: ConcurrencyLock;
 }): Promise<readonly Omit<System, "abi" | "bytecode" | "deployedBytecodeSize">[]> {
   const [resourceIds, functions, resourceAccess] = await Promise.all([
     getResourceIds({ client, worldDeploy }),
-    getFunctions({ client, worldDeploy }),
-    getResourceAccess({ client, worldDeploy }),
+    getFunctions({ client, worldDeploy, lock }),
+    getResourceAccess({ client, worldDeploy, lock }),
   ]);
   const systems = resourceIds.map(hexToResource).filter((resource) => resource.type === "system");
 
   debug("looking up systems", systems.map(resourceLabel).join(", "));
+  const startedAt = new Date();
   return await Promise.all(
-    systems.map(async (system) => {
-      const { system: address, publicAccess } = await getTableValue({
-        client,
-        worldDeploy,
-        table: worldTables.world_Systems,
-        key: { systemId: system.resourceId },
-      });
-      const systemFunctions = functions.filter((func) => func.systemId === system.resourceId);
-      return {
-        address,
-        namespace: system.namespace,
-        name: system.name,
-        systemId: system.resourceId,
-        allowAll: publicAccess,
-        allowedAddresses: resourceAccess
-          .filter(({ resourceId }) => resourceId === system.resourceId)
-          .map(({ address }) => address),
-        functions: systemFunctions,
-      };
-    })
+    systems.map(async (system) =>
+      lock.run(async () => {
+        const elapsed = Math.round((new Date().getTime() - startedAt.getTime()) / 1000);
+        debug(`${system.name} started after ${elapsed}s.`);
+
+        const { system: address, publicAccess } = await getTableValue({
+          client,
+          worldDeploy,
+          table: worldTables.world_Systems,
+          key: { systemId: system.resourceId },
+        });
+        const systemFunctions = functions.filter((func) => func.systemId === system.resourceId);
+        return {
+          address,
+          namespace: system.namespace,
+          name: system.name,
+          systemId: system.resourceId,
+          allowAll: publicAccess,
+          allowedAddresses: resourceAccess
+            .filter(({ resourceId }) => resourceId === system.resourceId)
+            .map(({ address }) => address),
+          functions: systemFunctions,
+        };
+      })
+    )
   );
 }

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -29,6 +29,10 @@ export const deployOptions = {
     type: "boolean",
     desc: "Always run PostDeploy.s.sol after each deploy (including during upgrades). By default, PostDeploy.s.sol is only run once after a new world is deployed.",
   },
+  rpcConcurrency: {
+    type: "number",
+    desc: "Limit the concurrency of RPC calls",
+  },
 } as const satisfies Record<string, Options>;
 
 export type DeployOptions = InferredOptionTypes<typeof deployOptions>;
@@ -82,6 +86,7 @@ in your contracts directory to use the default anvil private key.`
     worldAddress: opts.worldAddress as Hex | undefined,
     client,
     config: resolvedConfig,
+    rpcConcurrency: opts.rpcConcurrency,
   });
   if (opts.worldAddress == null || opts.alwaysRunPostDeploy) {
     await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile);


### PR DESCRIPTION
This PR adds a concurrency option to the deploy command.

Resolve: https://github.com/latticexyz/mud/issues/2236

- This is a naive method using a lock
- Considering whether to use p-queue in line with p-retry