### PR TITLE
docs: fix link to getting started

### DIFF
--- a/docs/pages/guides/extending-world.mdx
+++ b/docs/pages/guides/extending-world.mdx
@@ -152,7 +152,7 @@ The easiest way to create the Solidity code is to use the MUD template:
 
 ## Deploy to the blockchain
 
-1. To have a `World` with the `Counter` example to modify, go to a separate command line window and create a blockchain with a `World` using [the TypeScript template](/template/typescript/getting-started) and start the execution.
+1. To have a `World` with the `Counter` example to modify, go to a separate command line window and create a blockchain with a `World` using [the TypeScript template](/templates/typescript/getting-started) and start the execution.
    Choose either the `react-ecs` user interface or the `vanilla` one.
 
    ```sh copy

--- a/docs/pages/guides/hello-world.mdx
+++ b/docs/pages/guides/hello-world.mdx
@@ -3,8 +3,8 @@
 On this page you learn how to modify a `World` before it is deployed to the blockchain.
 If you want to learn how to modify a `World` that is already deployed, [see the extending world page](./extending-world).
 
-The examples on this page use [the vanilla template](../template/typescript/vanilla).
-[See this page for installation instructions](../template/typescript/getting-started).
+The examples on this page use [the vanilla template](../templates/typescript/vanilla).
+[See this page for installation instructions](../templates/typescript/getting-started).
 Most examples are written under the assumption that they are independent, and built on top of a new vanilla template.
 The exception is filtering data synchronization, because it needs a table that isn't a singleton.
 

--- a/docs/pages/world/balance.mdx
+++ b/docs/pages/world/balance.mdx
@@ -24,7 +24,7 @@ uint256 balance = Balances.get(<namespace>);
 <summary>See this in action</summary>
 
 1. Have a MUD application running.
-   The easiest way to do this is to [run the template locally](/template/typescript/getting-started).
+   The easiest way to do this is to [run the template locally](/templates/typescript/getting-started).
 
 1. Here we are not concerned with the client, so change to the `contracts` page.
    Because we are not concerned with the client, all the file names will be relative to `.../packages/contracts`.


### PR DESCRIPTION
It was `template/typescript/getting-started` rather than `templates/typescript/getting-started`