### PR TITLE
feat(store-sync): byte and boolean array type for in decoded indexer

### DIFF
--- a/.changeset/real-spoons-agree.md
+++ b/.changeset/real-spoons-agree.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Added column types to the decoded indexer instead of JSON blobs.

--- a/packages/store-sync/src/postgres-decoded/buildColumn.ts
+++ b/packages/store-sync/src/postgres-decoded/buildColumn.ts
@@ -6,10 +6,11 @@ import {
   asBigInt,
   asBigIntArray,
   asBoolArray,
+  asHexArray,
   asHex,
-  asJson,
   asNumber,
   asNumberArray,
+  asAddressArray,
 } from "../postgres/columnTypes";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -245,11 +246,10 @@ export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
     case "bytes30[]":
     case "bytes31[]":
     case "bytes32[]":
-      return asJson(name);
+      return asHexArray(name);
 
-    // TODO: normalize like address column type
     case "address[]":
-      return asJson(name);
+      return asAddressArray(name);
 
     case "string":
       return text(name);

--- a/packages/store-sync/src/postgres-decoded/buildColumn.ts
+++ b/packages/store-sync/src/postgres-decoded/buildColumn.ts
@@ -1,7 +1,16 @@
 import { boolean, text } from "drizzle-orm/pg-core";
 import { SchemaAbiType } from "@latticexyz/schema-type";
 import { assertExhaustive } from "@latticexyz/common/utils";
-import { asAddress, asBigInt, asBigIntArray, asHex, asJson, asNumber, asNumberArray } from "../postgres/columnTypes";
+import {
+  asAddress,
+  asBigInt,
+  asBigIntArray,
+  asBoolArray,
+  asHex,
+  asJson,
+  asNumber,
+  asNumberArray,
+} from "../postgres/columnTypes";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
@@ -124,6 +133,9 @@ export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
     case "address":
       return asAddress(name);
 
+    case "bool[]":
+      return asBoolArray(name);
+
     case "uint8[]":
     case "uint16[]":
     case "int8[]":
@@ -233,7 +245,6 @@ export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
     case "bytes30[]":
     case "bytes31[]":
     case "bytes32[]":
-    case "bool[]":
       return asJson(name);
 
     // TODO: normalize like address column type

--- a/packages/store-sync/src/postgres-decoded/buildTable.test.ts
+++ b/packages/store-sync/src/postgres-decoded/buildTable.test.ts
@@ -97,7 +97,7 @@ describe("buildTable", () => {
         "addrs": {
           "dataType": "custom",
           "name": "addrs",
-          "sqlName": "text",
+          "sqlName": "bytea",
         },
       }
     `);

--- a/packages/store-sync/src/postgres-decoded/createStorageAdapter.test.ts
+++ b/packages/store-sync/src/postgres-decoded/createStorageAdapter.test.ts
@@ -52,7 +52,7 @@ describe("createStorageAdapter", async () => {
         {
           "blockNumber": 20n,
           "chainId": 31337,
-          "version": "0.0.4",
+          "version": "0.0.5",
         },
       ]
     `);

--- a/packages/store-sync/src/postgres/columnTypes.ts
+++ b/packages/store-sync/src/postgres/columnTypes.ts
@@ -1,21 +1,5 @@
 import { customType } from "drizzle-orm/pg-core";
-import superjson from "superjson";
 import { Address, ByteArray, bytesToHex, getAddress, Hex, hexToBytes } from "viem";
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const asJson = <TData>(name: string) =>
-  customType<{ data: TData; driverData: string }>({
-    dataType() {
-      // TODO: move to json column type? if we do, we'll prob wanna choose something other than superjson since it adds one level of depth (json/meta keys)
-      return "text";
-    },
-    toDriver(data: TData): string {
-      return superjson.stringify(data);
-    },
-    fromDriver(driverData: string): TData {
-      return superjson.parse(driverData);
-    },
-  })(name);
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asNumber = (name: string, columnType: string) =>
@@ -112,5 +96,33 @@ export const asBigIntArray = (name: string, columnType: string) =>
     },
     fromDriver(driverData: string[]): bigint[] {
       return driverData.map((datum) => BigInt(datum));
+    },
+  })(name);
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const asHexArray = (name: string) =>
+  customType<{ data: Hex[]; driverData: ByteArray[] }>({
+    dataType() {
+      return "bytea";
+    },
+    toDriver(data: Hex[]): ByteArray[] {
+      return data.map((datum) => hexToBytes(datum));
+    },
+    fromDriver(driverData: ByteArray[]): Hex[] {
+      return driverData.map((datum) => bytesToHex(datum));
+    },
+  })(name);
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const asAddressArray = (name: string) =>
+  customType<{ data: Address[]; driverData: ByteArray[] }>({
+    dataType() {
+      return "bytea";
+    },
+    toDriver(data: Address[]): ByteArray[] {
+      return data.map((datum) => hexToBytes(datum));
+    },
+    fromDriver(driverData: ByteArray[]): Address[] {
+      return driverData.map((datum) => getAddress(bytesToHex(datum)));
     },
   })(name);

--- a/packages/store-sync/src/postgres/columnTypes.ts
+++ b/packages/store-sync/src/postgres/columnTypes.ts
@@ -61,7 +61,7 @@ export const asAddress = (name: string) =>
 export const asBoolArray = (name: string) =>
   customType<{ data: boolean[]; driverData: string[] }>({
     dataType() {
-      return "bool";
+      return "bool[]";
     },
     toDriver(data: boolean[]): string[] {
       return data.map((datum) => String(datum));
@@ -103,12 +103,16 @@ export const asBigIntArray = (name: string, columnType: string) =>
 export const asHexArray = (name: string) =>
   customType<{ data: Hex[]; driverData: ByteArray[] }>({
     dataType() {
-      return "bytea";
+      return "bytea[]";
     },
     toDriver(data: Hex[]): ByteArray[] {
+      console.log(data);
+
       return data.map((datum) => hexToBytes(datum));
     },
     fromDriver(driverData: ByteArray[]): Hex[] {
+      console.log(driverData);
+
       return driverData.map((datum) => bytesToHex(datum));
     },
   })(name);
@@ -117,7 +121,7 @@ export const asHexArray = (name: string) =>
 export const asAddressArray = (name: string) =>
   customType<{ data: Address[]; driverData: ByteArray[] }>({
     dataType() {
-      return "bytea";
+      return "bytea[]";
     },
     toDriver(data: Address[]): ByteArray[] {
       return data.map((datum) => hexToBytes(datum));

--- a/packages/store-sync/src/postgres/columnTypes.ts
+++ b/packages/store-sync/src/postgres/columnTypes.ts
@@ -74,6 +74,20 @@ export const asAddress = (name: string) =>
   })(name);
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const asBoolArray = (name: string) =>
+  customType<{ data: boolean[]; driverData: string[] }>({
+    dataType() {
+      return "bool";
+    },
+    toDriver(data: boolean[]): string[] {
+      return data.map((datum) => String(datum));
+    },
+    fromDriver(driverData: string[]): boolean[] {
+      return driverData.map((datum) => Boolean(datum));
+    },
+  })(name);
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asNumberArray = (name: string, columnType: string) =>
   customType<{ data: number[]; driverData: string[] }>({
     dataType() {

--- a/packages/store-sync/src/postgres/createStorageAdapter.test.ts
+++ b/packages/store-sync/src/postgres/createStorageAdapter.test.ts
@@ -50,7 +50,7 @@ describe("createStorageAdapter", async () => {
         {
           "blockNumber": 20n,
           "chainId": 31337,
-          "version": "0.0.4",
+          "version": "0.0.5",
         },
       ]
     `);

--- a/packages/store-sync/src/postgres/version.ts
+++ b/packages/store-sync/src/postgres/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.0.4";
+export const version = "0.0.5";


### PR DESCRIPTION
`byteX` and `bool` arrays now have array column types instead of JSON blobs. 

Seems like the drivers are incorrectly set up as the indexer errors when trying to store a byte array:
`PostgresError: column "hooks" is of type bytea[] but expression is of type bytea`