### PR TITLE
feat(store-sync): wait for idle after each chunk of logs in a block

### DIFF
--- a/.changeset/nasty-rice-pull.md
+++ b/.changeset/nasty-rice-pull.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": minor
+---
+
+`createStoreSync` now [waits for idle](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) between each chunk of logs in a block to allow for downstream render cycles to trigger. This means that hydrating logs from an indexer will no longer block until hydration completes, but rather allow for `onProgress` callbacks to trigger.

--- a/e2e/packages/sync-test/syncToRecs.test.ts
+++ b/e2e/packages/sync-test/syncToRecs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { rpcHttpUrl } from "./setup/constants";
+import { deployContracts } from "./setup";
+import { createAsyncErrorHandler } from "./asyncErrors";
+import { createWorld, getComponentValueStrict } from "@latticexyz/recs";
+import { singletonEntity, syncToRecs } from "@latticexyz/store-sync/recs";
+import mudConfig from "../contracts/mud.config";
+import { transportObserver } from "@latticexyz/common";
+import { ClientConfig, createPublicClient, http, isHex } from "viem";
+import { getNetworkConfig } from "../client-vanilla/src/mud/getNetworkConfig";
+
+describe("syncToRecs", () => {
+  const asyncErrorHandler = createAsyncErrorHandler();
+
+  it("has the correct sync progress percentage", async () => {
+    asyncErrorHandler.resetErrors();
+
+    const { stdout } = await deployContracts(rpcHttpUrl);
+
+    const [, worldAddress] = stdout.match(/worldAddress: '(0x[0-9a-f]+)'/i) ?? [];
+    if (!isHex(worldAddress)) {
+      throw new Error("world address not found in output, did the deploy fail?");
+    }
+
+    const networkConfig = await getNetworkConfig();
+    const clientOptions = {
+      chain: networkConfig.chain,
+      transport: transportObserver(http(rpcHttpUrl ?? undefined)),
+      pollingInterval: 1000,
+    } as const satisfies ClientConfig;
+
+    const publicClient = createPublicClient(clientOptions);
+
+    const world = createWorld();
+
+    const { components } = await syncToRecs({
+      world,
+      config: mudConfig,
+      address: worldAddress,
+      publicClient,
+    });
+
+    expect(getComponentValueStrict(components.SyncProgress, singletonEntity).percentage).toMatchInlineSnapshot(`
+      100
+    `);
+  });
+});

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -145,7 +145,7 @@ export async function createStoreSync<TConfig extends StoreConfig = StoreConfig>
         await storageAdapter({ blockNumber, logs: chunk });
         onProgress?.({
           step: SyncStep.SNAPSHOT,
-          percentage: (i / chunks.length) * 100,
+          percentage: ((i  + 1) / chunks.length) * 100,
           latestBlockNumber: 0n,
           lastBlockNumberProcessed: blockNumber,
           message: "Hydrating from snapshot",

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -48,6 +48,10 @@ type CreateStoreSyncOptions<TConfig extends StoreConfig = StoreConfig> = SyncOpt
   }) => void;
 };
 
+function sleep<T>(timeout: number, returns?: T): Promise<T> {
+  return new Promise<T>((resolve) => setTimeout(() => resolve(returns as T), timeout));
+}
+
 export async function createStoreSync<TConfig extends StoreConfig = StoreConfig>({
   storageAdapter,
   onProgress,
@@ -145,11 +149,12 @@ export async function createStoreSync<TConfig extends StoreConfig = StoreConfig>
         await storageAdapter({ blockNumber, logs: chunk });
         onProgress?.({
           step: SyncStep.SNAPSHOT,
-          percentage: ((i + chunk.length) / chunks.length) * 100,
+          percentage: Math.floor((i / chunks.length) * 100),
           latestBlockNumber: 0n,
           lastBlockNumberProcessed: blockNumber,
           message: "Hydrating from snapshot",
         });
+        await sleep(1);
       }
 
       onProgress?.({

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -145,7 +145,7 @@ export async function createStoreSync<TConfig extends StoreConfig = StoreConfig>
         await storageAdapter({ blockNumber, logs: chunk });
         onProgress?.({
           step: SyncStep.SNAPSHOT,
-          percentage: ((i  + 1) / chunks.length) * 100,
+          percentage: ((i + 1) / chunks.length) * 100,
           latestBlockNumber: 0n,
           lastBlockNumberProcessed: blockNumber,
           message: "Hydrating from snapshot",


### PR DESCRIPTION
don't ask me why or how, but adding `sleep(1)` after calling the `storageAdapter` made hydration updates show up in the client. i was going crazy trying to figure out why i wasn't receiving them in the main thread, but then remembered having a similar problem in DF with how async calls were being handled. if someone actually knows the mechanism that is being abused here lmk and we can come up with a less obscure solution.

also once i started receiving updates i realized the % calculation was wrong, so fixed that too.

getting these updates is important so i can properly benchmark how long hydration takes on the sky strife end. my manual calculations on my pc are ~5 seconds.