### PR TITLE
[WIP] add failing test case for sending value to batchCall

### DIFF
--- a/packages/world/src/codegen/interfaces/IBatchCallSystem.sol
+++ b/packages/world/src/codegen/interfaces/IBatchCallSystem.sol
@@ -10,7 +10,9 @@ import { SystemCallData, SystemCallFromData } from "./../../modules/init/types.s
  * @dev This interface is automatically generated from the corresponding system contract. Do not edit manually.
  */
 interface IBatchCallSystem {
-  function batchCall(SystemCallData[] calldata systemCalls) external returns (bytes[] memory returnDatas);
+  function batchCall(SystemCallData[] calldata systemCalls) external payable returns (bytes[] memory returnDatas);
 
-  function batchCallFrom(SystemCallFromData[] calldata systemCalls) external returns (bytes[] memory returnDatas);
+  function batchCallFrom(
+    SystemCallFromData[] calldata systemCalls
+  ) external payable returns (bytes[] memory returnDatas);
 }

--- a/packages/world/src/modules/init/implementations/BatchCallSystem.sol
+++ b/packages/world/src/modules/init/implementations/BatchCallSystem.sol
@@ -20,7 +20,7 @@ contract BatchCallSystem is System, LimitedCallContext {
    */
   function batchCall(
     SystemCallData[] calldata systemCalls
-  ) public onlyDelegatecall returns (bytes[] memory returnDatas) {
+  ) public payable onlyDelegatecall returns (bytes[] memory returnDatas) {
     IBaseWorld world = IBaseWorld(_world());
     returnDatas = new bytes[](systemCalls.length);
 
@@ -42,7 +42,7 @@ contract BatchCallSystem is System, LimitedCallContext {
    */
   function batchCallFrom(
     SystemCallFromData[] calldata systemCalls
-  ) public onlyDelegatecall returns (bytes[] memory returnDatas) {
+  ) public payable onlyDelegatecall returns (bytes[] memory returnDatas) {
     IBaseWorld world = IBaseWorld(_world());
     returnDatas = new bytes[](systemCalls.length);
 


### PR DESCRIPTION
Sending `value` to `batchCall` is currently not supported (as the functions are non-payable). If we add `payable` we need to be careful to manually adjust the Balance table to avoid double accounting (currently the balance would be added to the root namespace and every namespace that is being called as part of the batch call)