### PR TITLE
fix: use correct command to generate benchmark data

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Generate test data
         working-directory: ./e2e
-        run: pnpm run generate-test-data-records
+        run: pnpm run generate-bench-data-bulk
 
       - name: Run benchmarks
         run: pnpm run bench

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "pnpm recursive run build",
     "clean": "pnpm recursive run clean",
-    "generate-test-data-records": "pnpm run --filter=test-data generate-test-data-records",
+    "generate-bench-data-bulk": "pnpm run --filter=test-data generate-bench-data-bulk",
     "playwright-install": "pnpx playwright@1.35.1 install --with-deps chromium",
     "test": "pnpm recursive run test",
     "test:ci": "pnpm run test"


### PR DESCRIPTION
This command was renamed in https://github.com/latticexyz/mud/pull/2228 but not updated in https://github.com/latticexyz/mud/pull/2234