### PR TITLE
feat(examples): support external wallet delegating to burner wallet within example

### DIFF
--- a/examples/minimal/packages/client-react-external-wallet/package.json
+++ b/examples/minimal/packages/client-react-external-wallet/package.json
@@ -14,6 +14,7 @@
     "@latticexyz/common": "link:../../../../packages/common",
     "@latticexyz/dev-tools": "link:../../../../packages/dev-tools",
     "@latticexyz/store-sync": "link:../../../../packages/store-sync",
+    "@latticexyz/world": "link:../../../../packages/world",
     "@tanstack/react-query": "5.22.2",
     "contracts": "workspace:*",
     "p-retry": "^5.1.2",

--- a/examples/minimal/packages/client-react-external-wallet/src/App.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/App.tsx
@@ -27,7 +27,7 @@ const Incrementer = ({
   const delegation = network.useStore((state) =>
     state.getValue(network.tables.UserDelegationControl, {
       delegator: externalWalletClient.account.address,
-      delegatee: network.burnerWalletClient.account.address,
+      delegatee: network.burnerClient.account.address,
     })
   );
 
@@ -38,7 +38,7 @@ const Incrementer = ({
   if (delegation && isDelegated(delegation.delegationControlId)) {
     return (
       <div>
-        <div>Burner wallet account: {network.burnerWalletClient.account.address}</div>
+        <div>Burner wallet account: {network.burnerClient.account.address}</div>
         <button type="button" onClick={() => increment(externalWalletClient, network)}>
           Increment
         </button>

--- a/examples/minimal/packages/client-react-external-wallet/src/App.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/App.tsx
@@ -1,21 +1,56 @@
-import { useMUD } from "./mud/customWalletClient";
-import { increment } from "./mud/systemCalls";
+import { SyncStep } from "@latticexyz/store-sync";
+import { useMUD, type MUDNetwork, type ExternalWalletClient } from "./mud/NetworkContext";
+import { increment, isDelegated, delegateToBurner } from "./mud/systemCalls";
 
 export const App = () => {
-  const { network, walletClient } = useMUD();
+  const { network, externalWalletClient } = useMUD();
 
   const counter = network.useStore((state) => state.getValue(network.tables.CounterTable, {}));
 
   return (
     <div>
       <div>Counter: {counter?.value ?? "unset"}</div>
+      {externalWalletClient && <Incrementer network={network} externalWalletClient={externalWalletClient} />}
+    </div>
+  );
+};
+
+const Incrementer = ({
+  network,
+  externalWalletClient,
+}: {
+  network: MUDNetwork;
+  externalWalletClient: ExternalWalletClient;
+}) => {
+  const syncProgress = network.useStore((state) => state.syncProgress);
+
+  const delegation = network.useStore((state) =>
+    state.getValue(network.tables.UserDelegationControl, {
+      delegator: externalWalletClient.account.address,
+      delegatee: network.burnerWalletClient.account.address,
+    })
+  );
+
+  if (syncProgress.step !== SyncStep.LIVE) {
+    return <div>Loading</div>;
+  }
+
+  if (delegation && isDelegated(delegation.delegationControlId)) {
+    return (
       <div>
-        {walletClient && (
-          <button type="button" onClick={() => increment(walletClient, network)}>
-            Increment
-          </button>
-        )}
+        <div>Burner wallet account: {network.burnerWalletClient.account.address}</div>
+        <button type="button" onClick={() => increment(externalWalletClient, network)}>
+          Increment
+        </button>
       </div>
+    );
+  }
+
+  return (
+    <div>
+      <button type="button" onClick={() => delegateToBurner(externalWalletClient, network)}>
+        Set up burner wallet account
+      </button>
     </div>
   );
 };

--- a/examples/minimal/packages/client-react-external-wallet/src/App.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/App.tsx
@@ -1,5 +1,5 @@
 import { SyncStep } from "@latticexyz/store-sync";
-import { useMUD, type MUDNetwork, type ExternalWalletClient } from "./mud/NetworkContext";
+import { useMUD } from "./mud/NetworkContext";
 import { increment, isDelegated, delegateToBurner } from "./mud/systemCalls";
 
 export const App = () => {

--- a/examples/minimal/packages/client-react-external-wallet/src/DevTools.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/DevTools.tsx
@@ -1,14 +1,13 @@
 import { useEffect } from "react";
-import { useMUD } from "./mud/customWalletClient";
+import { useMUD } from "./mud/NetworkContext";
 import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
 import mudConfig from "contracts/mud.config";
 
+// Displays dev-tools for the burner wallet
 export const DevTools = () => {
-  const { network, walletClient } = useMUD();
+  const { network } = useMUD();
 
   useEffect(() => {
-    if (!walletClient) return;
-
     // TODO: Handle unmount properly by updating the dev-tools implementation.
     let unmount: (() => void) | null = null;
 
@@ -17,7 +16,7 @@ export const DevTools = () => {
         mount({
           config: mudConfig,
           publicClient: network.publicClient,
-          walletClient: walletClient,
+          walletClient: network.burnerWalletClient,
           latestBlock$: network.latestBlock$,
           storedBlockLogs$: network.storedBlockLogs$,
           worldAddress: network.worldAddress,
@@ -37,7 +36,7 @@ export const DevTools = () => {
         unmount();
       }
     };
-  }, [walletClient?.account.address]);
+  }, [network]);
 
   return null;
 };

--- a/examples/minimal/packages/client-react-external-wallet/src/DevTools.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/DevTools.tsx
@@ -16,7 +16,7 @@ export const DevTools = () => {
         mount({
           config: mudConfig,
           publicClient: network.publicClient,
-          walletClient: network.burnerWalletClient,
+          walletClient: network.burnerClient,
           latestBlock$: network.latestBlock$,
           storedBlockLogs$: network.storedBlockLogs$,
           worldAddress: network.worldAddress,

--- a/examples/minimal/packages/client-react-external-wallet/src/ExternalWallet.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/ExternalWallet.tsx
@@ -32,7 +32,7 @@ function Account() {
 
   return (
     <div>
-      <div>{address}</div>
+      <div>External wallet account: {address}</div>
       <div>
         Connected to {chain?.name ?? chainId}
         {chainId && !chains.map((x) => x.id).includes(chainId) ? " (unsupported)" : ""}

--- a/examples/minimal/packages/client-react-external-wallet/src/mud/NetworkContext.tsx
+++ b/examples/minimal/packages/client-react-external-wallet/src/mud/NetworkContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, type ReactNode, useContext } from "react";
+import { useAccount, useWalletClient } from "wagmi";
 import { type SetupNetworkResult } from "./setupNetwork";
 
 export type MUDNetwork = SetupNetworkResult;
@@ -21,3 +22,18 @@ export const useMUDNetwork = () => {
   if (!value) throw new Error("Must be used within a MUDNetworkProvider");
   return value;
 };
+
+export const useMUD = () => {
+  const network = useMUDNetwork();
+  const { data: connectorWalletClient } = useWalletClient();
+  const { chainId } = useAccount();
+
+  let externalWalletClient;
+  if (network.publicClient.chain.id === chainId && connectorWalletClient?.chain.id === chainId) {
+    externalWalletClient = connectorWalletClient;
+  }
+
+  return { network, externalWalletClient };
+};
+
+export type ExternalWalletClient = NonNullable<ReturnType<typeof useMUD>["externalWalletClient"]>;

--- a/examples/minimal/packages/client-react-external-wallet/src/mud/customClient.ts
+++ b/examples/minimal/packages/client-react-external-wallet/src/mud/customClient.ts
@@ -13,6 +13,7 @@ import type {
 import { sendTransaction, writeContract, simulateContract } from "viem/actions";
 import pRetry from "p-retry";
 import { getNonceManager, type ContractWrite } from "@latticexyz/common";
+import { type SyncResult } from "@latticexyz/store-sync";
 
 const burnerBlockTag = "pending";
 
@@ -89,5 +90,11 @@ export const setupObserverActions = (onWrite: (write: ContractWrite) => void) =>
 
       return result;
     },
+  });
+};
+
+export const setupStoreSyncActions = (syncResult: SyncResult) => {
+  return () => ({
+    waitForStoreSync: syncResult.waitForTransaction,
   });
 };

--- a/examples/minimal/packages/client-react-external-wallet/src/mud/setupNetwork.ts
+++ b/examples/minimal/packages/client-react-external-wallet/src/mud/setupNetwork.ts
@@ -38,9 +38,6 @@ export async function setupNetwork() {
   });
 
   const write$ = new Subject<ContractWrite>();
-  let nextWriteId = 0;
-  const onWrite = (write: ContractWrite) =>
-    write$.next({ id: `${write.id}:${nextWriteId++}`, request: write.request, result: write.result });
 
   const burnerClient = createWalletClient({
     ...clientOptions,
@@ -48,7 +45,7 @@ export async function setupNetwork() {
   })
     .extend(publicActions)
     .extend(burnerActions)
-    .extend(setupObserverActions(onWrite));
+    .extend(setupObserverActions(write$));
 
   return {
     worldAddress: networkConfig.worldAddress,

--- a/examples/minimal/packages/client-react-external-wallet/src/mud/systemCalls.ts
+++ b/examples/minimal/packages/client-react-external-wallet/src/mud/systemCalls.ts
@@ -7,9 +7,8 @@ import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
 // Executes the `increment` system call on behalf of the external wallet using the burner wallet.
 // This is solely for demonstrating burner wallet delegation, as the `increment` call can actually be made by any sender.
 export const increment = async (externalWalletClient: ExternalWalletClient, network: MUDNetwork) => {
-  const { request } = await network.publicClient.simulateContract({
-    account: network.burnerWalletClient.account,
-    blockTag: "pending", // burner uses this tag
+  const { request } = await network.burnerClient.simulateContract({
+    account: network.burnerClient.account,
     address: network.worldAddress,
     abi: IWorldAbi,
     functionName: "callFrom",
@@ -22,7 +21,7 @@ export const increment = async (externalWalletClient: ExternalWalletClient, netw
     }),
   });
 
-  const tx = await network.burnerWalletClient.writeContract(request);
+  const tx = await network.burnerClient.writeContract(request);
 
   network.waitForTransaction(tx);
 };
@@ -38,7 +37,7 @@ export const delegateToBurner = async (externalWalletClient: ExternalWalletClien
     address: network.worldAddress,
     abi: IWorldAbi,
     functionName: "registerDelegation",
-    args: [network.burnerWalletClient.account.address, UNLIMITED_DELEGATION, "0x0"],
+    args: [network.burnerClient.account.address, UNLIMITED_DELEGATION, "0x0"],
   });
 
   const tx1 = await externalWalletClient.writeContract(request);
@@ -46,7 +45,7 @@ export const delegateToBurner = async (externalWalletClient: ExternalWalletClien
 
   // for transaction fees
   const tx2 = await externalWalletClient.sendTransaction({
-    to: network.burnerWalletClient.account.address,
+    to: network.burnerClient.account.address,
     value: parseEther("0.001"),
   });
   network.waitForTransaction(tx2);

--- a/examples/minimal/pnpm-lock.yaml
+++ b/examples/minimal/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@latticexyz/store-sync':
         specifier: link:../../../../packages/store-sync
         version: link:../../../../packages/store-sync
+      '@latticexyz/world':
+        specifier: link:../../../../packages/world
+        version: link:../../../../packages/world
       '@tanstack/react-query':
         specifier: 5.22.2
         version: 5.22.2(react@18.2.0)


### PR DESCRIPTION
This PR targets https://github.com/latticexyz/mud/pull/2307, which implements external wallet support in the example project. In this PR, external wallets delegate to local storage burner wallets, and the burner wallets send transactions on behalf of the external wallets.

I created this as a separate PR to see the diff required for the change. However, please feel free to merge this with the target PR if it simplifies the review process or if it is ready for merging.