### PR TITLE
docs(world): add comments for prohibitDirectCallback modifier

### DIFF
--- a/docs/pages/world/reference/world.mdx
+++ b/docs/pages/world/reference/world.mdx
@@ -45,9 +45,9 @@ constructor();
 #### prohibitDirectCallback
 
 _Prevents the World contract from calling itself.
-The world is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root system happen as a delegatecall to the system.
-However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
-If it was possible to make the `World` call itself, it would be possible to access internal tables that only the `World` should have access to._
+If the World is able to call itself via delegatecall from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
+Ideally this should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
+However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods._
 
 ```solidity
 modifier prohibitDirectCallback();

--- a/docs/pages/world/reference/world.mdx
+++ b/docs/pages/world/reference/world.mdx
@@ -44,7 +44,10 @@ constructor();
 
 #### prohibitDirectCallback
 
-_Prevents the World contract from calling itself._
+_Prevents the World contract from calling itself.
+The world is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root system happen as a delegatecall to the system.
+However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
+If it was possible to make the `World` call itself, it would be possible to access internal tables that only the `World` should have access to._
 
 ```solidity
 modifier prohibitDirectCallback();

--- a/docs/pages/world/reference/world.mdx
+++ b/docs/pages/world/reference/world.mdx
@@ -45,7 +45,7 @@ constructor();
 #### prohibitDirectCallback
 
 _Prevents the World contract from calling itself.
-If the World is able to call itself via delegatecall from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
+If the World is able to call itself via `delegatecall` from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
 Ideally this should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
 However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods._
 

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -51,9 +51,9 @@ contract World is StoreData, IWorldKernel {
 
   /**
    * @dev Prevents the World contract from calling itself.
-   * The `World` is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
+   * If the World is able to call itself via delegatecall from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
+   * This should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
    * However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
-   * If it was possible to make the `World` call itself, it would be possible to access internal tables that only the `World` should have access to.
    */
   modifier prohibitDirectCallback() {
     if (msg.sender == address(this)) {

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -51,6 +51,9 @@ contract World is StoreData, IWorldKernel {
 
   /**
    * @dev Prevents the World contract from calling itself.
+   * The world is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root system happen as a delegatecall to the system.
+   * However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
+   * If it was possible to make the `World` call itself, it would be possible to access internal tables that only the `World` should have access to.
    */
   modifier prohibitDirectCallback() {
     if (msg.sender == address(this)) {

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -51,7 +51,7 @@ contract World is StoreData, IWorldKernel {
 
   /**
    * @dev Prevents the World contract from calling itself.
-   * If the World is able to call itself via delegatecall from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
+   * If the World is able to call itself via `delegatecall` from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
    * Ideally this should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
    * However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
    */

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -52,7 +52,7 @@ contract World is StoreData, IWorldKernel {
   /**
    * @dev Prevents the World contract from calling itself.
    * If the World is able to call itself via delegatecall from a system, the system would have root access to context like internal tables, causing a potential vulnerability.
-   * This should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
+   * Ideally this should not happen because all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
    * However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
    */
   modifier prohibitDirectCallback() {

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -51,7 +51,7 @@ contract World is StoreData, IWorldKernel {
 
   /**
    * @dev Prevents the World contract from calling itself.
-   * The world is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root system happen as a delegatecall to the system.
+   * The `World` is not able to call itself; all operations to internal tables happen as internal library calls, and all calls to root systems happen as a `delegatecall` to the system.
    * However, since this is an important invariant, we make it explicit by reverting if `msg.sender` is `address(this)` in all `World` methods.
    * If it was possible to make the `World` call itself, it would be possible to access internal tables that only the `World` should have access to.
    */


### PR DESCRIPTION
Closes https://github.com/latticexyz/mud/issues/2106 by explaining why we use the `prohibitDirectCallback` modifier.

The comment is a rewording of the PR description from the original PR that added it https://github.com/latticexyz/mud/pull/1563