### PR TITLE
fix(cli): throw warning for duplicate systems

### DIFF
--- a/.changeset/calm-drinks-dance.md
+++ b/.changeset/calm-drinks-dance.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/cli": patch
+"@latticexyz/world": patch
+---
+
+Attempting to deploy multiple systems where there are overlapping system IDs now throws an error.

--- a/packages/cli/src/deploy/resolveConfig.ts
+++ b/packages/cli/src/deploy/resolveConfig.ts
@@ -70,6 +70,24 @@ export function resolveConfig<config extends ConfigInput>({
     };
   });
 
+  systems.forEach((item, index) => {
+    let duplicateName = "";
+    if (
+      systems.some((elem, idx) => {
+        const found = elem.systemId === item.systemId && idx !== index;
+        if (found) {
+          duplicateName = elem.name;
+        }
+        return found;
+      })
+    ) {
+      throw new Error(`Found two systems with the same system ID: ${item.name} ${duplicateName}. 
+      
+      System IDs are generated from the first 14 bytes of the name, so you may need to rename one of these systems to avoid the overlap.
+      `);
+    }
+  });
+
   // ugh (https://github.com/latticexyz/mud/issues/1668)
   const resolveContext = {
     tableIds: Object.fromEntries(

--- a/packages/cli/src/deploy/resolveConfig.ts
+++ b/packages/cli/src/deploy/resolveConfig.ts
@@ -70,17 +70,17 @@ export function resolveConfig<config extends ConfigInput>({
     };
   });
 
-  systems.forEach((item, index) => {
+  systems.forEach((item) => {
     let duplicateName = "";
-    if (
-      systems.some((elem, idx) => {
-        const found = elem.systemId === item.systemId && idx !== index;
-        if (found) {
-          duplicateName = elem.name;
-        }
-        return found;
-      })
-    ) {
+    const overlappingSystem = systems.some((elem) => {
+      const found = elem.systemId === item.systemId && elem !== item;
+      if (found) {
+        duplicateName = elem.name;
+      }
+      return found;
+    });
+
+    if (overlappingSystem) {
       throw new Error(`Found two systems with the same system ID: ${item.name} ${duplicateName}. 
       
       System IDs are generated from the first 14 bytes of the name, so you may need to rename one of these systems to avoid the overlap.

--- a/packages/world/ts/config/resolveWorldConfig.ts
+++ b/packages/world/ts/config/resolveWorldConfig.ts
@@ -1,4 +1,4 @@
-import { STORE_NAME_MAX_LENGTH, UnrecognizedSystemErrorFactory } from "@latticexyz/config";
+import { UnrecognizedSystemErrorFactory } from "@latticexyz/config";
 import { StoreConfig } from "@latticexyz/store";
 import { SystemConfig, WorldConfig } from "./types";
 
@@ -55,7 +55,7 @@ export function resolveWorldConfig(config: StoreConfig & WorldConfig, existingCo
  * Default value for accessListSystems is []
  */
 export function resolveSystemConfig(systemName: string, config?: SystemConfig, existingContracts?: string[]) {
-  const name = (config?.name ?? systemName).slice(0, STORE_NAME_MAX_LENGTH);
+  const name = config?.name ?? systemName;
   const registerFunctionSelectors = config?.registerFunctionSelectors ?? true;
   const openAccess = config?.openAccess ?? true;
   const accessListAddresses: string[] = [];


### PR DESCRIPTION
Resolves #2263 

Throw error when systems with the same ids occur.