### PR TITLE
test(world-modules): fix failing token fuzz test

### DIFF
--- a/packages/world-modules/test/ERC721.t.sol
+++ b/packages/world-modules/test/ERC721.t.sol
@@ -307,6 +307,9 @@ contract ERC721Test is Test, GasReporter, IERC721Events, IERC721Errors {
 
     ERC721Recipient recipient = new ERC721Recipient();
 
+    // These should not be equal!!!
+    assertEq(from, address(recipient));
+
     token.mint(from, id);
 
     vm.prank(from);

--- a/packages/world-modules/test/ERC721.t.sol
+++ b/packages/world-modules/test/ERC721.t.sol
@@ -300,6 +300,32 @@ contract ERC721Test is Test, GasReporter, IERC721Events, IERC721Errors {
     assertEq(token.balanceOf(from), 0);
   }
 
+  function testSafeTransferFromToERC721Recipient() public {
+    uint256 id = 2116498058;
+    address from = 0x03A6a84cD762D9707A21605b548aaaB891562aAb;
+    address operator = 0x0000000000000000000000000000000000001421;
+
+    ERC721Recipient recipient = new ERC721Recipient();
+
+    token.mint(from, id);
+
+    vm.prank(from);
+    token.setApprovalForAll(operator, true);
+
+    vm.prank(operator);
+    token.safeTransferFrom(from, address(recipient), id);
+
+    assertEq(token.getApproved(id), address(0));
+    assertEq(token.ownerOf(id), address(recipient));
+    assertEq(token.balanceOf(address(recipient)), 1);
+    assertEq(token.balanceOf(from), 0);
+
+    assertEq(recipient.operator(), operator);
+    assertEq(recipient.from(), from);
+    assertEq(recipient.id(), id);
+    assertEq(recipient.data(), "");
+  }
+
   function testSafeTransferFromToERC721Recipient(uint256 id, address from, address operator) public {
     _assumeDifferentNonZero(from, operator);
 

--- a/packages/world-modules/test/ERC721.t.sol
+++ b/packages/world-modules/test/ERC721.t.sol
@@ -300,39 +300,9 @@ contract ERC721Test is Test, GasReporter, IERC721Events, IERC721Errors {
     assertEq(token.balanceOf(from), 0);
   }
 
-  function testSafeTransferFromToERC721Recipient() public {
-    uint256 id = 2116498058;
-    address from = 0x03A6a84cD762D9707A21605b548aaaB891562aAb;
-    address operator = 0x0000000000000000000000000000000000001421;
-
-    ERC721Recipient recipient = new ERC721Recipient();
-
-    // These should not be equal!!!
-    assertEq(from, address(recipient));
-
-    token.mint(from, id);
-
-    vm.prank(from);
-    token.setApprovalForAll(operator, true);
-
-    vm.prank(operator);
-    token.safeTransferFrom(from, address(recipient), id);
-
-    assertEq(token.getApproved(id), address(0));
-    assertEq(token.ownerOf(id), address(recipient));
-    assertEq(token.balanceOf(address(recipient)), 1);
-    assertEq(token.balanceOf(from), 0);
-
-    assertEq(recipient.operator(), operator);
-    assertEq(recipient.from(), from);
-    assertEq(recipient.id(), id);
-    assertEq(recipient.data(), "");
-  }
-
   function testSafeTransferFromToERC721Recipient(uint256 id, address from, address operator) public {
-    _assumeDifferentNonZero(from, operator);
-
     ERC721Recipient recipient = new ERC721Recipient();
+    _assumeDifferentNonZero(from, operator, address(recipient));
 
     token.mint(from, id);
 


### PR DESCRIPTION
Once in a blue moon, the fuzzed `from` address in `testSafeTransferFromToERC721Recipient` is equal to the `recipient` that is deployed during the test. Not sure the probability of this but interesting that it happened [here](https://github.com/latticexyz/mud/actions/runs/8082938117/job/22084862341)!

The addresses being equal means that `from` sends tokens to itself, so the assertion that it's balance decreases to zero (`assertEq(token.balanceOf(from), 0)`) fails. 

Update: looks like we missed an assumption. Fixed by coping the approach from `testSafeTransferFromToERC721RecipientWithData`.

