### PR TITLE
refactor(store): event interfaces for Store libraries 

### DIFF
--- a/.changeset/heavy-shirts-dance.md
+++ b/.changeset/heavy-shirts-dance.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": patch
+---
+
+Added interfaces for all errors that are used by `StoreCore`, which includes `FieldLayout`, `PackedCounter`, `Schema`, and `Slice`. This interfaces are inherited by `IStore`, ensuring that all possible errors are included in the `IStore` ABI for proper decoding in the frontend.

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -269,62 +269,6 @@ function slice32(bytes memory data, uint256 start) internal pure returns (bytes3
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes blob. |
 
-## FieldLayout_Empty
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_Empty();
-```
-
-## FieldLayout_InvalidStaticDataLength
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-```
-
-## FieldLayout_StaticLengthDoesNotFitInAWord
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthDoesNotFitInAWord(uint256 index);
-```
-
-## FieldLayout_StaticLengthIsNotZero
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthIsNotZero(uint256 index);
-```
-
-## FieldLayout_StaticLengthIsZero
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthIsZero(uint256 index);
-```
-
-## FieldLayout_TooManyDynamicFields
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-```
-
-## FieldLayout_TooManyFields
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
-```
-
 ## FieldLayoutInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
@@ -811,26 +755,6 @@ type and a name_
 type ResourceId is bytes32;
 ```
 
-## Schema_InvalidLength
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
-
-_Error raised when the provided schema has an invalid length._
-
-```solidity
-error Schema_InvalidLength(uint256 length);
-```
-
-## Schema_StaticTypeAfterDynamicType
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
-
-_Error raised when a static type is placed after a dynamic type in a schema._
-
-```solidity
-error Schema_StaticTypeAfterDynamicType();
-```
-
 ## SchemaInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
@@ -1035,14 +959,6 @@ _Defines and handles the encoding/decoding of Schemas which describe the layout 
 
 ```solidity
 type Schema is bytes32;
-```
-
-## Slice_OutOfBounds
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Slice.sol)
-
-```solidity
-error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 ```
 
 ## SliceInstance

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -269,6 +269,62 @@ function slice32(bytes memory data, uint256 start) internal pure returns (bytes3
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes blob. |
 
+## FieldLayout_Empty
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_Empty();
+```
+
+## FieldLayout_InvalidStaticDataLength
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
+```
+
+## FieldLayout_StaticLengthDoesNotFitInAWord
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthDoesNotFitInAWord(uint256 index);
+```
+
+## FieldLayout_StaticLengthIsNotZero
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthIsNotZero(uint256 index);
+```
+
+## FieldLayout_StaticLengthIsZero
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthIsZero(uint256 index);
+```
+
+## FieldLayout_TooManyDynamicFields
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
+```
+
+## FieldLayout_TooManyFields
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
+```
+
 ## FieldLayoutInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
@@ -469,50 +525,6 @@ function encode(uint256[] memory _staticFieldLengths, uint256 numDynamicFields) 
 | Name     | Type          | Description                                                  |
 | -------- | ------------- | ------------------------------------------------------------ |
 | `<none>` | `FieldLayout` | A FieldLayout structure containing the encoded field layout. |
-
-### Errors
-
-#### FieldLayoutLib_TooManyFields
-
-```solidity
-error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
-```
-
-#### FieldLayoutLib_TooManyDynamicFields
-
-```solidity
-error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-```
-
-#### FieldLayoutLib_Empty
-
-```solidity
-error FieldLayoutLib_Empty();
-```
-
-#### FieldLayoutLib_InvalidStaticDataLength
-
-```solidity
-error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-```
-
-#### FieldLayoutLib_StaticLengthIsZero
-
-```solidity
-error FieldLayoutLib_StaticLengthIsZero(uint256 index);
-```
-
-#### FieldLayoutLib_StaticLengthIsNotZero
-
-```solidity
-error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
-```
-
-#### FieldLayoutLib_StaticLengthDoesNotFitInAWord
-
-```solidity
-error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
-```
 
 ## FieldLayout
 
@@ -799,6 +811,26 @@ type and a name_
 type ResourceId is bytes32;
 ```
 
+## Schema_InvalidLength
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
+
+_Error raised when the provided schema has an invalid length._
+
+```solidity
+error Schema_InvalidLength(uint256 length);
+```
+
+## Schema_StaticTypeAfterDynamicType
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
+
+_Error raised when a static type is placed after a dynamic type in a schema._
+
+```solidity
+error Schema_StaticTypeAfterDynamicType();
+```
+
 ## SchemaInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
@@ -1021,6 +1053,14 @@ _Defines and handles the encoding/decoding of Schemas which describe the layout 
 
 ```solidity
 type Schema is bytes32;
+```
+
+## Slice_OutOfBounds
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Slice.sol)
+
+```solidity
+error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 ```
 
 ## SliceInstance

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -269,6 +269,62 @@ function slice32(bytes memory data, uint256 start) internal pure returns (bytes3
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes blob. |
 
+## FieldLayout_Empty
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_Empty();
+```
+
+## FieldLayout_InvalidStaticDataLength
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
+```
+
+## FieldLayout_StaticLengthDoesNotFitInAWord
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthDoesNotFitInAWord(uint256 index);
+```
+
+## FieldLayout_StaticLengthIsNotZero
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthIsNotZero(uint256 index);
+```
+
+## FieldLayout_StaticLengthIsZero
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_StaticLengthIsZero(uint256 index);
+```
+
+## FieldLayout_TooManyDynamicFields
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
+```
+
+## FieldLayout_TooManyFields
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
+
+```solidity
+error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
+```
+
 ## FieldLayoutInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
@@ -469,50 +525,6 @@ function encode(uint256[] memory _staticFieldLengths, uint256 numDynamicFields) 
 | Name     | Type          | Description                                                  |
 | -------- | ------------- | ------------------------------------------------------------ |
 | `<none>` | `FieldLayout` | A FieldLayout structure containing the encoded field layout. |
-
-### Errors
-
-#### FieldLayoutLib_TooManyFields
-
-```solidity
-error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
-```
-
-#### FieldLayoutLib_TooManyDynamicFields
-
-```solidity
-error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-```
-
-#### FieldLayoutLib_Empty
-
-```solidity
-error FieldLayoutLib_Empty();
-```
-
-#### FieldLayoutLib_InvalidStaticDataLength
-
-```solidity
-error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-```
-
-#### FieldLayoutLib_StaticLengthIsZero
-
-```solidity
-error FieldLayoutLib_StaticLengthIsZero(uint256 index);
-```
-
-#### FieldLayoutLib_StaticLengthIsNotZero
-
-```solidity
-error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
-```
-
-#### FieldLayoutLib_StaticLengthDoesNotFitInAWord
-
-```solidity
-error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
-```
 
 ## FieldLayout
 
@@ -799,6 +811,26 @@ type and a name_
 type ResourceId is bytes32;
 ```
 
+## Schema_InvalidLength
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
+
+_Error raised when the provided schema has an invalid length._
+
+```solidity
+error Schema_InvalidLength(uint256 length);
+```
+
+## Schema_StaticTypeAfterDynamicType
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
+
+_Error raised when a static type is placed after a dynamic type in a schema._
+
+```solidity
+error Schema_StaticTypeAfterDynamicType();
+```
+
 ## SchemaInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
@@ -991,24 +1023,6 @@ function encode(SchemaType[] memory schemas) internal pure returns (Schema);
 | -------- | -------- | ------------------- |
 | `<none>` | `Schema` | The encoded Schema. |
 
-### Errors
-
-#### SchemaLib_InvalidLength
-
-_Error raised when the provided schema has an invalid length._
-
-```solidity
-error SchemaLib_InvalidLength(uint256 length);
-```
-
-#### SchemaLib_StaticTypeAfterDynamicType
-
-_Error raised when a static type is placed after a dynamic type in a schema._
-
-```solidity
-error SchemaLib_StaticTypeAfterDynamicType();
-```
-
 ## Schema
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
@@ -1021,6 +1035,14 @@ _Defines and handles the encoding/decoding of Schemas which describe the layout 
 
 ```solidity
 type Schema is bytes32;
+```
+
+## Slice_OutOfBounds
+
+[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Slice.sol)
+
+```solidity
+error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 ```
 
 ## SliceInstance
@@ -1191,14 +1213,6 @@ function getSubslice(bytes memory data, uint256 start, uint256 end) internal pur
 | Name     | Type    | Description                           |
 | -------- | ------- | ------------------------------------- |
 | `<none>` | `Slice` | A new Slice representing the subslice |
-
-### Errors
-
-#### Slice_OutOfBounds
-
-```solidity
-error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
-```
 
 ## Slice
 

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -269,62 +269,6 @@ function slice32(bytes memory data, uint256 start) internal pure returns (bytes3
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes blob. |
 
-## FieldLayout_Empty
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_Empty();
-```
-
-## FieldLayout_InvalidStaticDataLength
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-```
-
-## FieldLayout_StaticLengthDoesNotFitInAWord
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthDoesNotFitInAWord(uint256 index);
-```
-
-## FieldLayout_StaticLengthIsNotZero
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthIsNotZero(uint256 index);
-```
-
-## FieldLayout_StaticLengthIsZero
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_StaticLengthIsZero(uint256 index);
-```
-
-## FieldLayout_TooManyDynamicFields
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-```
-
-## FieldLayout_TooManyFields
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
-
-```solidity
-error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
-```
-
 ## FieldLayoutInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/FieldLayout.sol)
@@ -525,6 +469,50 @@ function encode(uint256[] memory _staticFieldLengths, uint256 numDynamicFields) 
 | Name     | Type          | Description                                                  |
 | -------- | ------------- | ------------------------------------------------------------ |
 | `<none>` | `FieldLayout` | A FieldLayout structure containing the encoded field layout. |
+
+### Errors
+
+#### FieldLayoutLib_TooManyFields
+
+```solidity
+error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
+```
+
+#### FieldLayoutLib_TooManyDynamicFields
+
+```solidity
+error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
+```
+
+#### FieldLayoutLib_Empty
+
+```solidity
+error FieldLayoutLib_Empty();
+```
+
+#### FieldLayoutLib_InvalidStaticDataLength
+
+```solidity
+error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
+```
+
+#### FieldLayoutLib_StaticLengthIsZero
+
+```solidity
+error FieldLayoutLib_StaticLengthIsZero(uint256 index);
+```
+
+#### FieldLayoutLib_StaticLengthIsNotZero
+
+```solidity
+error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
+```
+
+#### FieldLayoutLib_StaticLengthDoesNotFitInAWord
+
+```solidity
+error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
+```
 
 ## FieldLayout
 
@@ -811,26 +799,6 @@ type and a name_
 type ResourceId is bytes32;
 ```
 
-## Schema_InvalidLength
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
-
-_Error raised when the provided schema has an invalid length._
-
-```solidity
-error Schema_InvalidLength(uint256 length);
-```
-
-## Schema_StaticTypeAfterDynamicType
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
-
-_Error raised when a static type is placed after a dynamic type in a schema._
-
-```solidity
-error Schema_StaticTypeAfterDynamicType();
-```
-
 ## SchemaInstance
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Schema.sol)
@@ -1053,14 +1021,6 @@ _Defines and handles the encoding/decoding of Schemas which describe the layout 
 
 ```solidity
 type Schema is bytes32;
-```
-
-## Slice_OutOfBounds
-
-[Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/Slice.sol)
-
-```solidity
-error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 ```
 
 ## SliceInstance

--- a/docs/pages/store/reference/store.mdx
+++ b/docs/pages/store/reference/store.mdx
@@ -5,7 +5,7 @@
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/IStore.sol)
 
 **Inherits:**
-[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors)
+[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors), [IFieldLayoutErrors](/src/IFieldLayoutErrors.sol/interface.IFieldLayoutErrors.md), [IPackedCounterErrors](/src/IPackedCounterErrors.sol/interface.IPackedCounterErrors.md)
 
 ## IStoreEvents
 

--- a/docs/pages/store/reference/store.mdx
+++ b/docs/pages/store/reference/store.mdx
@@ -5,7 +5,9 @@
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/IStore.sol)
 
 **Inherits:**
-[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors)
+[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors), [IFieldLayoutErrors](/src/IFieldLayoutErrors.sol/interface.IFieldLayoutErrors.md), [IPackedCounterErrors](/src/IPackedCounterErrors.sol/interface.IPackedCounterErrors.md), [ISchemaErrors](/src/ISchemaErrors.sol/interface.ISchemaErrors.md), [ISliceErrors](/src/ISliceErrors.sol/interface.ISliceErrors.md)
+
+IStore implements the error interfaces for each library that it uses.
 
 ## IStoreEvents
 
@@ -103,6 +105,8 @@ event Store_DeleteRecord(ResourceId indexed tableId, bytes32[] keyTuple);
 ## IStoreErrors
 
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/IStoreErrors.sol)
+
+This interface includes errors for Store.
 
 ### Errors
 

--- a/docs/pages/store/reference/store.mdx
+++ b/docs/pages/store/reference/store.mdx
@@ -108,6 +108,9 @@ event Store_DeleteRecord(ResourceId indexed tableId, bytes32[] keyTuple);
 
 This interface includes errors for Store.
 
+_We bundle these errors in an interface (instead of at the file-level or in their corresponding library) so they can be inherited by IStore.
+This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend._
+
 ### Errors
 
 #### Store_TableAlreadyExists

--- a/docs/pages/store/reference/store.mdx
+++ b/docs/pages/store/reference/store.mdx
@@ -5,7 +5,7 @@
 [Git Source](https://github.com/latticexyz/mud/blob/main/packages/store/src/IStore.sol)
 
 **Inherits:**
-[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors), [IFieldLayoutErrors](/src/IFieldLayoutErrors.sol/interface.IFieldLayoutErrors.md), [IPackedCounterErrors](/src/IPackedCounterErrors.sol/interface.IPackedCounterErrors.md)
+[IStoreData](/store/reference/store#istoredata), [IStoreRegistration](/store/reference/store#istoreregistration), [IStoreErrors](/store/reference/store#istoreerrors)
 
 ## IStoreEvents
 

--- a/packages/store/src/FieldLayout.sol
+++ b/packages/store/src/FieldLayout.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.24;
 
 import { WORD_SIZE, WORD_LAST_INDEX, BYTE_TO_BITS, MAX_TOTAL_FIELDS, MAX_DYNAMIC_FIELDS, LayoutOffsets } from "./constants.sol";
+import { IFieldLayoutErrors } from "./IFieldLayoutErrors.sol";
 
 /**
  * @title FieldLayout
@@ -27,14 +28,6 @@ using FieldLayoutInstance for FieldLayout global;
  * various constraints regarding the length and size of the fields.
  */
 library FieldLayoutLib {
-  error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
-  error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-  error FieldLayoutLib_Empty();
-  error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-  error FieldLayoutLib_StaticLengthIsZero(uint256 index);
-  error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
-  error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
-
   /**
    * @notice Encodes the given field layout into a single bytes32.
    * @dev Ensures various constraints on the length and size of the fields.
@@ -47,17 +40,18 @@ library FieldLayoutLib {
     uint256 fieldLayout;
     uint256 totalLength;
     uint256 totalFields = _staticFieldLengths.length + numDynamicFields;
-    if (totalFields > MAX_TOTAL_FIELDS) revert FieldLayoutLib_TooManyFields(totalFields, MAX_TOTAL_FIELDS);
+    if (totalFields > MAX_TOTAL_FIELDS)
+      revert IFieldLayoutErrors.FieldLayoutLib_TooManyFields(totalFields, MAX_TOTAL_FIELDS);
     if (numDynamicFields > MAX_DYNAMIC_FIELDS)
-      revert FieldLayoutLib_TooManyDynamicFields(numDynamicFields, MAX_DYNAMIC_FIELDS);
+      revert IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields(numDynamicFields, MAX_DYNAMIC_FIELDS);
 
     // Compute the total static length and store the field lengths in the encoded fieldLayout
     for (uint256 i; i < _staticFieldLengths.length; ) {
       uint256 staticByteLength = _staticFieldLengths[i];
       if (staticByteLength == 0) {
-        revert FieldLayoutLib_StaticLengthIsZero(i);
+        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero(i);
       } else if (staticByteLength > WORD_SIZE) {
-        revert FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
+        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
       }
 
       unchecked {
@@ -156,18 +150,18 @@ library FieldLayoutInstance {
    */
   function validate(FieldLayout fieldLayout) internal pure {
     if (fieldLayout.isEmpty()) {
-      revert FieldLayoutLib.FieldLayoutLib_Empty();
+      revert IFieldLayoutErrors.FieldLayoutLib_Empty();
     }
 
     uint256 _numDynamicFields = fieldLayout.numDynamicFields();
     if (_numDynamicFields > MAX_DYNAMIC_FIELDS) {
-      revert FieldLayoutLib.FieldLayoutLib_TooManyDynamicFields(_numDynamicFields, MAX_DYNAMIC_FIELDS);
+      revert IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields(_numDynamicFields, MAX_DYNAMIC_FIELDS);
     }
 
     uint256 _numStaticFields = fieldLayout.numStaticFields();
     uint256 _numTotalFields = _numStaticFields + _numDynamicFields;
     if (_numTotalFields > MAX_TOTAL_FIELDS) {
-      revert FieldLayoutLib.FieldLayoutLib_TooManyFields(_numTotalFields, MAX_TOTAL_FIELDS);
+      revert IFieldLayoutErrors.FieldLayoutLib_TooManyFields(_numTotalFields, MAX_TOTAL_FIELDS);
     }
 
     // Static lengths must be valid
@@ -175,9 +169,9 @@ library FieldLayoutInstance {
     for (uint256 i; i < _numStaticFields; ) {
       uint256 staticByteLength = fieldLayout.atIndex(i);
       if (staticByteLength == 0) {
-        revert FieldLayoutLib.FieldLayoutLib_StaticLengthIsZero(i);
+        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero(i);
       } else if (staticByteLength > WORD_SIZE) {
-        revert FieldLayoutLib.FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
+        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
       }
       _staticDataLength += staticByteLength;
       unchecked {
@@ -186,13 +180,16 @@ library FieldLayoutInstance {
     }
     // Static length sums must match
     if (_staticDataLength != fieldLayout.staticDataLength()) {
-      revert FieldLayoutLib.FieldLayoutLib_InvalidStaticDataLength(fieldLayout.staticDataLength(), _staticDataLength);
+      revert IFieldLayoutErrors.FieldLayoutLib_InvalidStaticDataLength(
+        fieldLayout.staticDataLength(),
+        _staticDataLength
+      );
     }
     // Unused fields must be zero
     for (uint256 i = _numStaticFields; i < MAX_TOTAL_FIELDS; i++) {
       uint256 staticByteLength = fieldLayout.atIndex(i);
       if (staticByteLength != 0) {
-        revert FieldLayoutLib.FieldLayoutLib_StaticLengthIsNotZero(i);
+        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsNotZero(i);
       }
     }
   }

--- a/packages/store/src/FieldLayout.sol
+++ b/packages/store/src/FieldLayout.sol
@@ -41,17 +41,17 @@ library FieldLayoutLib {
     uint256 totalLength;
     uint256 totalFields = _staticFieldLengths.length + numDynamicFields;
     if (totalFields > MAX_TOTAL_FIELDS)
-      revert IFieldLayoutErrors.FieldLayoutLib_TooManyFields(totalFields, MAX_TOTAL_FIELDS);
+      revert IFieldLayoutErrors.FieldLayout_TooManyFields(totalFields, MAX_TOTAL_FIELDS);
     if (numDynamicFields > MAX_DYNAMIC_FIELDS)
-      revert IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields(numDynamicFields, MAX_DYNAMIC_FIELDS);
+      revert IFieldLayoutErrors.FieldLayout_TooManyDynamicFields(numDynamicFields, MAX_DYNAMIC_FIELDS);
 
     // Compute the total static length and store the field lengths in the encoded fieldLayout
     for (uint256 i; i < _staticFieldLengths.length; ) {
       uint256 staticByteLength = _staticFieldLengths[i];
       if (staticByteLength == 0) {
-        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero(i);
+        revert IFieldLayoutErrors.FieldLayout_StaticLengthIsZero(i);
       } else if (staticByteLength > WORD_SIZE) {
-        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
+        revert IFieldLayoutErrors.FieldLayout_StaticLengthDoesNotFitInAWord(i);
       }
 
       unchecked {
@@ -150,18 +150,18 @@ library FieldLayoutInstance {
    */
   function validate(FieldLayout fieldLayout) internal pure {
     if (fieldLayout.isEmpty()) {
-      revert IFieldLayoutErrors.FieldLayoutLib_Empty();
+      revert IFieldLayoutErrors.FieldLayout_Empty();
     }
 
     uint256 _numDynamicFields = fieldLayout.numDynamicFields();
     if (_numDynamicFields > MAX_DYNAMIC_FIELDS) {
-      revert IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields(_numDynamicFields, MAX_DYNAMIC_FIELDS);
+      revert IFieldLayoutErrors.FieldLayout_TooManyDynamicFields(_numDynamicFields, MAX_DYNAMIC_FIELDS);
     }
 
     uint256 _numStaticFields = fieldLayout.numStaticFields();
     uint256 _numTotalFields = _numStaticFields + _numDynamicFields;
     if (_numTotalFields > MAX_TOTAL_FIELDS) {
-      revert IFieldLayoutErrors.FieldLayoutLib_TooManyFields(_numTotalFields, MAX_TOTAL_FIELDS);
+      revert IFieldLayoutErrors.FieldLayout_TooManyFields(_numTotalFields, MAX_TOTAL_FIELDS);
     }
 
     // Static lengths must be valid
@@ -169,9 +169,9 @@ library FieldLayoutInstance {
     for (uint256 i; i < _numStaticFields; ) {
       uint256 staticByteLength = fieldLayout.atIndex(i);
       if (staticByteLength == 0) {
-        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero(i);
+        revert IFieldLayoutErrors.FieldLayout_StaticLengthIsZero(i);
       } else if (staticByteLength > WORD_SIZE) {
-        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord(i);
+        revert IFieldLayoutErrors.FieldLayout_StaticLengthDoesNotFitInAWord(i);
       }
       _staticDataLength += staticByteLength;
       unchecked {
@@ -180,16 +180,13 @@ library FieldLayoutInstance {
     }
     // Static length sums must match
     if (_staticDataLength != fieldLayout.staticDataLength()) {
-      revert IFieldLayoutErrors.FieldLayoutLib_InvalidStaticDataLength(
-        fieldLayout.staticDataLength(),
-        _staticDataLength
-      );
+      revert IFieldLayoutErrors.FieldLayout_InvalidStaticDataLength(fieldLayout.staticDataLength(), _staticDataLength);
     }
     // Unused fields must be zero
     for (uint256 i = _numStaticFields; i < MAX_TOTAL_FIELDS; i++) {
       uint256 staticByteLength = fieldLayout.atIndex(i);
       if (staticByteLength != 0) {
-        revert IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsNotZero(i);
+        revert IFieldLayoutErrors.FieldLayout_StaticLengthIsNotZero(i);
       }
     }
   }

--- a/packages/store/src/IFieldLayoutErrors.sol
+++ b/packages/store/src/IFieldLayoutErrors.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.8.24;
  * @title IFieldLayoutErrors
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  * @notice This interface includes errors for the FieldLayout library.
+ * @dev We bundle these errors in an interface (instead of at the file-level or in their corresponding libraries) so they can be inherited by IStore.
+ * This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend.
  */
 interface IFieldLayoutErrors {
   error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);

--- a/packages/store/src/IFieldLayoutErrors.sol
+++ b/packages/store/src/IFieldLayoutErrors.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+interface IFieldLayoutErrors {
+  error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
+  error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
+  error FieldLayoutLib_Empty();
+  error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
+  error FieldLayoutLib_StaticLengthIsZero(uint256 index);
+  error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
+  error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
+}

--- a/packages/store/src/IFieldLayoutErrors.sol
+++ b/packages/store/src/IFieldLayoutErrors.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+/**
+ * @title IFieldLayoutErrors
+ * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice This interface includes errors for the FieldLayout library.
+ */
 interface IFieldLayoutErrors {
   error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
   error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);

--- a/packages/store/src/IFieldLayoutErrors.sol
+++ b/packages/store/src/IFieldLayoutErrors.sol
@@ -2,11 +2,11 @@
 pragma solidity >=0.8.24;
 
 interface IFieldLayoutErrors {
-  error FieldLayoutLib_TooManyFields(uint256 numFields, uint256 maxFields);
-  error FieldLayoutLib_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
-  error FieldLayoutLib_Empty();
-  error FieldLayoutLib_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
-  error FieldLayoutLib_StaticLengthIsZero(uint256 index);
-  error FieldLayoutLib_StaticLengthIsNotZero(uint256 index);
-  error FieldLayoutLib_StaticLengthDoesNotFitInAWord(uint256 index);
+  error FieldLayout_TooManyFields(uint256 numFields, uint256 maxFields);
+  error FieldLayout_TooManyDynamicFields(uint256 numFields, uint256 maxFields);
+  error FieldLayout_Empty();
+  error FieldLayout_InvalidStaticDataLength(uint256 staticDataLength, uint256 computedStaticDataLength);
+  error FieldLayout_StaticLengthIsZero(uint256 index);
+  error FieldLayout_StaticLengthIsNotZero(uint256 index);
+  error FieldLayout_StaticLengthDoesNotFitInAWord(uint256 index);
 }

--- a/packages/store/src/IPackedCounterErrors.sol
+++ b/packages/store/src/IPackedCounterErrors.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+/**
+ * @title IPackedCounterErrors
+ * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice This interface includes errors for the PackedCounter library.
+ */
 interface IPackedCounterErrors {
   error PackedCounter_InvalidLength(uint256 length);
 }

--- a/packages/store/src/IPackedCounterErrors.sol
+++ b/packages/store/src/IPackedCounterErrors.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+interface IPackedCounterErrors {
+  error PackedCounter_InvalidLength(uint256 length);
+}

--- a/packages/store/src/IPackedCounterErrors.sol
+++ b/packages/store/src/IPackedCounterErrors.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.8.24;
  * @title IPackedCounterErrors
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  * @notice This interface includes errors for the PackedCounter library.
+ * @dev We bundle these errors in an interface (instead of at the file-level or in their corresponding libraries) so they can be inherited by IStore.
+ * This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend.
  */
 interface IPackedCounterErrors {
   error PackedCounter_InvalidLength(uint256 length);

--- a/packages/store/src/ISchemaErrors.sol
+++ b/packages/store/src/ISchemaErrors.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+/**
+ * @title ISchemaErrors
+ * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice This interface includes errors for the Schema library.
+ */
 interface ISchemaErrors {
   /// @dev Error raised when the provided schema has an invalid length.
   error Schema_InvalidLength(uint256 length);

--- a/packages/store/src/ISchemaErrors.sol
+++ b/packages/store/src/ISchemaErrors.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.8.24;
  * @title ISchemaErrors
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  * @notice This interface includes errors for the Schema library.
+ * @dev We bundle these errors in an interface (instead of at the file-level or in their corresponding libraries) so they can be inherited by IStore.
+ * This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend.
  */
 interface ISchemaErrors {
   /// @dev Error raised when the provided schema has an invalid length.

--- a/packages/store/src/ISchemaErrors.sol
+++ b/packages/store/src/ISchemaErrors.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.24;
 
 interface ISchemaErrors {
   /// @dev Error raised when the provided schema has an invalid length.
-  error SchemaLib_InvalidLength(uint256 length);
+  error Schema_InvalidLength(uint256 length);
 
   /// @dev Error raised when a static type is placed after a dynamic type in a schema.
-  error SchemaLib_StaticTypeAfterDynamicType();
+  error Schema_StaticTypeAfterDynamicType();
 }

--- a/packages/store/src/ISchemaErrors.sol
+++ b/packages/store/src/ISchemaErrors.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+interface ISchemaErrors {
+  /// @dev Error raised when the provided schema has an invalid length.
+  error SchemaLib_InvalidLength(uint256 length);
+
+  /// @dev Error raised when a static type is placed after a dynamic type in a schema.
+  error SchemaLib_StaticTypeAfterDynamicType();
+}

--- a/packages/store/src/ISliceErrors.sol
+++ b/packages/store/src/ISliceErrors.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-library ISliceErrors {
+interface ISliceErrors {
   error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 }

--- a/packages/store/src/ISliceErrors.sol
+++ b/packages/store/src/ISliceErrors.sol
@@ -5,6 +5,8 @@ pragma solidity >=0.8.24;
  * @title ISliceErrors
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  * @notice This interface includes errors for the Slice library.
+ * @dev We bundle these errors in an interface (instead of at the file-level or in their corresponding libraries) so they can be inherited by IStore.
+ * This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend.
  */
 interface ISliceErrors {
   error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);

--- a/packages/store/src/ISliceErrors.sol
+++ b/packages/store/src/ISliceErrors.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+library ISliceErrors {
+  error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
+}

--- a/packages/store/src/ISliceErrors.sol
+++ b/packages/store/src/ISliceErrors.sol
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
+/**
+ * @title ISliceErrors
+ * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice This interface includes errors for the Slice library.
+ */
 interface ISliceErrors {
   error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
 }

--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -12,6 +12,7 @@ import { ISliceErrors } from "./ISliceErrors.sol";
 /**
  * @title IStore
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice IStore implements the error interfaces for each library that it uses.
  */
 interface IStore is
   IStoreData,

--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -4,9 +4,11 @@ pragma solidity >=0.8.24;
 import { IStoreErrors } from "./IStoreErrors.sol";
 import { IStoreData } from "./IStoreData.sol";
 import { IStoreRegistration } from "./IStoreRegistration.sol";
+import { IPackedCounterErrors } from "./IPackedCounterErrors.sol";
+import { IFieldLayoutErrors } from "./IFieldLayoutErrors.sol";
 
 /**
  * @title IStore
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  */
-interface IStore is IStoreData, IStoreRegistration, IStoreErrors {}
+interface IStore is IStoreData, IStoreRegistration, IStoreErrors, IFieldLayoutErrors, IPackedCounterErrors {}

--- a/packages/store/src/IStore.sol
+++ b/packages/store/src/IStore.sol
@@ -4,11 +4,21 @@ pragma solidity >=0.8.24;
 import { IStoreErrors } from "./IStoreErrors.sol";
 import { IStoreData } from "./IStoreData.sol";
 import { IStoreRegistration } from "./IStoreRegistration.sol";
-import { IPackedCounterErrors } from "./IPackedCounterErrors.sol";
 import { IFieldLayoutErrors } from "./IFieldLayoutErrors.sol";
+import { IPackedCounterErrors } from "./IPackedCounterErrors.sol";
+import { ISchemaErrors } from "./ISchemaErrors.sol";
+import { ISliceErrors } from "./ISliceErrors.sol";
 
 /**
  * @title IStore
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  */
-interface IStore is IStoreData, IStoreRegistration, IStoreErrors, IFieldLayoutErrors, IPackedCounterErrors {}
+interface IStore is
+  IStoreData,
+  IStoreRegistration,
+  IStoreErrors,
+  IFieldLayoutErrors,
+  IPackedCounterErrors,
+  ISchemaErrors,
+  ISliceErrors
+{}

--- a/packages/store/src/IStoreErrors.sol
+++ b/packages/store/src/IStoreErrors.sol
@@ -3,6 +3,11 @@ pragma solidity >=0.8.24;
 
 import { ResourceId } from "./ResourceId.sol";
 
+/**
+ * @title IStoreErrors
+ * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
+ * @notice This interface includes errors for Store.
+ */
 interface IStoreErrors {
   // Errors include a stringified version of the tableId for easier debugging if cleartext tableIds are used
   error Store_TableAlreadyExists(ResourceId tableId, string tableIdString);

--- a/packages/store/src/IStoreErrors.sol
+++ b/packages/store/src/IStoreErrors.sol
@@ -7,6 +7,8 @@ import { ResourceId } from "./ResourceId.sol";
  * @title IStoreErrors
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  * @notice This interface includes errors for Store.
+ * @dev We bundle these errors in an interface (instead of at the file-level or in their corresponding library) so they can be inherited by IStore.
+ * This ensures that all possible errors are included in the IStore ABI for proper decoding in the frontend.
  */
 interface IStoreErrors {
   // Errors include a stringified version of the tableId for easier debugging if cleartext tableIds are used

--- a/packages/store/src/PackedCounter.sol
+++ b/packages/store/src/PackedCounter.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.24;
 
 import { BYTE_TO_BITS } from "./constants.sol";
+import { IPackedCounterErrors } from "./IPackedCounterErrors.sol";
 
 /**
  * @title PackedCounter Type Definition
@@ -139,8 +140,6 @@ library PackedCounterLib {
  * @dev Offers decoding, extracting, and setting functionalities for a PackedCounter.
  */
 library PackedCounterInstance {
-  error PackedCounter_InvalidLength(uint256 length);
-
   /**
    * @notice Decode the accumulated counter from a PackedCounter.
    * @dev Extracts the right-most 7 bytes of a PackedCounter.
@@ -178,7 +177,7 @@ library PackedCounterInstance {
     uint256 newValueAtIndex
   ) internal pure returns (PackedCounter) {
     if (newValueAtIndex > MAX_VAL) {
-      revert PackedCounter_InvalidLength(newValueAtIndex);
+      revert IPackedCounterErrors.PackedCounter_InvalidLength(newValueAtIndex);
     }
 
     uint256 rawPackedCounter = uint256(PackedCounter.unwrap(packedCounter));

--- a/packages/store/src/Schema.sol
+++ b/packages/store/src/Schema.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.24;
 import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol";
 
 import { WORD_LAST_INDEX, BYTE_TO_BITS, MAX_TOTAL_FIELDS, MAX_DYNAMIC_FIELDS, LayoutOffsets } from "./constants.sol";
+import { ISchemaErrors } from "./ISchemaErrors.sol";
 
 /**
  * @title Schema handling in Lattice
@@ -24,19 +25,13 @@ using SchemaInstance for Schema global;
  * @dev Static utility functions for handling Schemas.
  */
 library SchemaLib {
-  /// @dev Error raised when the provided schema has an invalid length.
-  error SchemaLib_InvalidLength(uint256 length);
-
-  /// @dev Error raised when a static type is placed after a dynamic type in a schema.
-  error SchemaLib_StaticTypeAfterDynamicType();
-
   /**
    * @notice Encodes a given schema into a single bytes32.
    * @param schemas The list of SchemaTypes that constitute the schema.
    * @return The encoded Schema.
    */
   function encode(SchemaType[] memory schemas) internal pure returns (Schema) {
-    if (schemas.length > MAX_TOTAL_FIELDS) revert SchemaLib_InvalidLength(schemas.length);
+    if (schemas.length > MAX_TOTAL_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(schemas.length);
     uint256 schema;
     uint256 totalLength;
     uint256 dynamicFields;
@@ -54,7 +49,7 @@ library SchemaLib {
         }
       } else if (dynamicFields > 0) {
         // Revert if we have seen a dynamic field before, but now we see a static field
-        revert SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
       }
 
       unchecked {
@@ -68,7 +63,7 @@ library SchemaLib {
     }
 
     // Require MAX_DYNAMIC_FIELDS
-    if (dynamicFields > MAX_DYNAMIC_FIELDS) revert SchemaLib_InvalidLength(dynamicFields);
+    if (dynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(dynamicFields);
 
     // Get the static field count
     uint256 staticFields;
@@ -162,23 +157,23 @@ library SchemaInstance {
    */
   function validate(Schema schema, bool allowEmpty) internal pure {
     // Schema must not be empty
-    if (!allowEmpty && schema.isEmpty()) revert SchemaLib.SchemaLib_InvalidLength(0);
+    if (!allowEmpty && schema.isEmpty()) revert ISchemaErrors.SchemaLib_InvalidLength(0);
 
     // Schema must have no more than MAX_DYNAMIC_FIELDS
     uint256 _numDynamicFields = schema.numDynamicFields();
-    if (_numDynamicFields > MAX_DYNAMIC_FIELDS) revert SchemaLib.SchemaLib_InvalidLength(_numDynamicFields);
+    if (_numDynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(_numDynamicFields);
 
     uint256 _numStaticFields = schema.numStaticFields();
     // Schema must not have more than MAX_TOTAL_FIELDS in total
     uint256 _numTotalFields = _numStaticFields + _numDynamicFields;
-    if (_numTotalFields > MAX_TOTAL_FIELDS) revert SchemaLib.SchemaLib_InvalidLength(_numTotalFields);
+    if (_numTotalFields > MAX_TOTAL_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(_numTotalFields);
 
     // No dynamic field can be before a dynamic field
     uint256 _staticDataLength;
     for (uint256 i; i < _numStaticFields; ) {
       uint256 staticByteLength = schema.atIndex(i).getStaticByteLength();
       if (staticByteLength == 0) {
-        revert SchemaLib.SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
       }
       _staticDataLength += staticByteLength;
       unchecked {
@@ -188,14 +183,14 @@ library SchemaInstance {
 
     // Static length sums must match
     if (_staticDataLength != schema.staticDataLength()) {
-      revert SchemaLib.SchemaLib_InvalidLength(schema.staticDataLength());
+      revert ISchemaErrors.SchemaLib_InvalidLength(schema.staticDataLength());
     }
 
     // No static field can be after a dynamic field
     for (uint256 i = _numStaticFields; i < _numTotalFields; ) {
       uint256 staticByteLength = schema.atIndex(i).getStaticByteLength();
       if (staticByteLength > 0) {
-        revert SchemaLib.SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
       }
       unchecked {
         i++;

--- a/packages/store/src/Schema.sol
+++ b/packages/store/src/Schema.sol
@@ -31,7 +31,7 @@ library SchemaLib {
    * @return The encoded Schema.
    */
   function encode(SchemaType[] memory schemas) internal pure returns (Schema) {
-    if (schemas.length > MAX_TOTAL_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(schemas.length);
+    if (schemas.length > MAX_TOTAL_FIELDS) revert ISchemaErrors.Schema_InvalidLength(schemas.length);
     uint256 schema;
     uint256 totalLength;
     uint256 dynamicFields;
@@ -49,7 +49,7 @@ library SchemaLib {
         }
       } else if (dynamicFields > 0) {
         // Revert if we have seen a dynamic field before, but now we see a static field
-        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.Schema_StaticTypeAfterDynamicType();
       }
 
       unchecked {
@@ -63,7 +63,7 @@ library SchemaLib {
     }
 
     // Require MAX_DYNAMIC_FIELDS
-    if (dynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(dynamicFields);
+    if (dynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.Schema_InvalidLength(dynamicFields);
 
     // Get the static field count
     uint256 staticFields;
@@ -157,23 +157,23 @@ library SchemaInstance {
    */
   function validate(Schema schema, bool allowEmpty) internal pure {
     // Schema must not be empty
-    if (!allowEmpty && schema.isEmpty()) revert ISchemaErrors.SchemaLib_InvalidLength(0);
+    if (!allowEmpty && schema.isEmpty()) revert ISchemaErrors.Schema_InvalidLength(0);
 
     // Schema must have no more than MAX_DYNAMIC_FIELDS
     uint256 _numDynamicFields = schema.numDynamicFields();
-    if (_numDynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(_numDynamicFields);
+    if (_numDynamicFields > MAX_DYNAMIC_FIELDS) revert ISchemaErrors.Schema_InvalidLength(_numDynamicFields);
 
     uint256 _numStaticFields = schema.numStaticFields();
     // Schema must not have more than MAX_TOTAL_FIELDS in total
     uint256 _numTotalFields = _numStaticFields + _numDynamicFields;
-    if (_numTotalFields > MAX_TOTAL_FIELDS) revert ISchemaErrors.SchemaLib_InvalidLength(_numTotalFields);
+    if (_numTotalFields > MAX_TOTAL_FIELDS) revert ISchemaErrors.Schema_InvalidLength(_numTotalFields);
 
     // No dynamic field can be before a dynamic field
     uint256 _staticDataLength;
     for (uint256 i; i < _numStaticFields; ) {
       uint256 staticByteLength = schema.atIndex(i).getStaticByteLength();
       if (staticByteLength == 0) {
-        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.Schema_StaticTypeAfterDynamicType();
       }
       _staticDataLength += staticByteLength;
       unchecked {
@@ -183,14 +183,14 @@ library SchemaInstance {
 
     // Static length sums must match
     if (_staticDataLength != schema.staticDataLength()) {
-      revert ISchemaErrors.SchemaLib_InvalidLength(schema.staticDataLength());
+      revert ISchemaErrors.Schema_InvalidLength(schema.staticDataLength());
     }
 
     // No static field can be after a dynamic field
     for (uint256 i = _numStaticFields; i < _numTotalFields; ) {
       uint256 staticByteLength = schema.atIndex(i).getStaticByteLength();
       if (staticByteLength > 0) {
-        revert ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType();
+        revert ISchemaErrors.Schema_StaticTypeAfterDynamicType();
       }
       unchecked {
         i++;

--- a/packages/store/src/Slice.sol
+++ b/packages/store/src/Slice.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.24;
 
 import { Memory } from "./Memory.sol";
 import { DecodeSlice } from "./tightcoder/DecodeSlice.sol";
+import { ISliceErrors } from "./ISliceErrors.sol";
 
 // Acknowledgements:
 // Based on @dk1a's Slice.sol library (https://github.com/dk1a/solidity-stringutils/blob/main/src/Slice.sol)
@@ -18,8 +19,6 @@ using DecodeSlice for Slice global;
  * @author MUD (https://mud.dev) by Lattice (https://lattice.xyz)
  */
 library SliceLib {
-  error Slice_OutOfBounds(bytes data, uint256 start, uint256 end);
-
   uint256 constant MASK_LEN = uint256(type(uint128).max);
 
   /**
@@ -57,7 +56,7 @@ library SliceLib {
    */
   function getSubslice(bytes memory data, uint256 start, uint256 end) internal pure returns (Slice) {
     // TODO this check helps catch bugs and can eventually be removed
-    if (start > end || end > data.length) revert Slice_OutOfBounds(data, start, end);
+    if (start > end || end > data.length) revert ISliceErrors.Slice_OutOfBounds(data, start, end);
 
     uint256 pointer;
     assembly {

--- a/packages/store/test/FieldLayout.t.sol
+++ b/packages/store/test/FieldLayout.t.sol
@@ -6,6 +6,7 @@ import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
 import { FieldLayout, FieldLayoutLib } from "../src/FieldLayout.sol";
 import { FieldLayoutEncodeHelper } from "./FieldLayoutEncodeHelper.sol";
 import { MAX_TOTAL_FIELDS, MAX_DYNAMIC_FIELDS } from "../src/constants.sol";
+import { IFieldLayoutErrors } from "../src/IFieldLayoutErrors.sol";
 
 // TODO add tests for all lengths
 contract FieldLayoutTest is Test, GasReporter {
@@ -36,12 +37,14 @@ contract FieldLayoutTest is Test, GasReporter {
   }
 
   function testInvalidFieldLayoutStaticTypeIsZero() public {
-    vm.expectRevert(abi.encodeWithSelector(FieldLayoutLib.FieldLayoutLib_StaticLengthIsZero.selector, 1));
+    vm.expectRevert(abi.encodeWithSelector(IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero.selector, 1));
     FieldLayoutEncodeHelper.encode(1, 0, 1);
   }
 
   function testInvalidFieldLayoutStaticTypeDoesNotFitInAWord() public {
-    vm.expectRevert(abi.encodeWithSelector(FieldLayoutLib.FieldLayoutLib_StaticLengthDoesNotFitInAWord.selector, 1));
+    vm.expectRevert(
+      abi.encodeWithSelector(IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord.selector, 1)
+    );
     FieldLayoutEncodeHelper.encode(1, 33, 1);
   }
 
@@ -97,7 +100,7 @@ contract FieldLayoutTest is Test, GasReporter {
     fieldLayout[16] = 32;
     vm.expectRevert(
       abi.encodeWithSelector(
-        FieldLayoutLib.FieldLayoutLib_TooManyFields.selector,
+        IFieldLayoutErrors.FieldLayoutLib_TooManyFields.selector,
         fieldLayout.length + dynamicFields,
         MAX_TOTAL_FIELDS
       )
@@ -117,7 +120,7 @@ contract FieldLayoutTest is Test, GasReporter {
     uint256 dynamicFields = 6;
     vm.expectRevert(
       abi.encodeWithSelector(
-        FieldLayoutLib.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
         fieldLayout.length + dynamicFields,
         MAX_DYNAMIC_FIELDS
       )
@@ -202,7 +205,7 @@ contract FieldLayoutTest is Test, GasReporter {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        FieldLayoutLib.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
         encodedFieldLayout.numDynamicFields(),
         MAX_DYNAMIC_FIELDS
       )

--- a/packages/store/test/FieldLayout.t.sol
+++ b/packages/store/test/FieldLayout.t.sol
@@ -37,14 +37,12 @@ contract FieldLayoutTest is Test, GasReporter {
   }
 
   function testInvalidFieldLayoutStaticTypeIsZero() public {
-    vm.expectRevert(abi.encodeWithSelector(IFieldLayoutErrors.FieldLayoutLib_StaticLengthIsZero.selector, 1));
+    vm.expectRevert(abi.encodeWithSelector(IFieldLayoutErrors.FieldLayout_StaticLengthIsZero.selector, 1));
     FieldLayoutEncodeHelper.encode(1, 0, 1);
   }
 
   function testInvalidFieldLayoutStaticTypeDoesNotFitInAWord() public {
-    vm.expectRevert(
-      abi.encodeWithSelector(IFieldLayoutErrors.FieldLayoutLib_StaticLengthDoesNotFitInAWord.selector, 1)
-    );
+    vm.expectRevert(abi.encodeWithSelector(IFieldLayoutErrors.FieldLayout_StaticLengthDoesNotFitInAWord.selector, 1));
     FieldLayoutEncodeHelper.encode(1, 33, 1);
   }
 
@@ -100,7 +98,7 @@ contract FieldLayoutTest is Test, GasReporter {
     fieldLayout[16] = 32;
     vm.expectRevert(
       abi.encodeWithSelector(
-        IFieldLayoutErrors.FieldLayoutLib_TooManyFields.selector,
+        IFieldLayoutErrors.FieldLayout_TooManyFields.selector,
         fieldLayout.length + dynamicFields,
         MAX_TOTAL_FIELDS
       )
@@ -120,7 +118,7 @@ contract FieldLayoutTest is Test, GasReporter {
     uint256 dynamicFields = 6;
     vm.expectRevert(
       abi.encodeWithSelector(
-        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayout_TooManyDynamicFields.selector,
         fieldLayout.length + dynamicFields,
         MAX_DYNAMIC_FIELDS
       )
@@ -205,7 +203,7 @@ contract FieldLayoutTest is Test, GasReporter {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayout_TooManyDynamicFields.selector,
         encodedFieldLayout.numDynamicFields(),
         MAX_DYNAMIC_FIELDS
       )

--- a/packages/store/test/Schema.t.sol
+++ b/packages/store/test/Schema.t.sol
@@ -7,6 +7,7 @@ import { SchemaType } from "@latticexyz/schema-type/src/solidity/SchemaType.sol"
 import { Schema, SchemaLib } from "../src/Schema.sol";
 import { SchemaEncodeHelper } from "./SchemaEncodeHelper.sol";
 import { WORD_LAST_INDEX, BYTE_TO_BITS, LayoutOffsets } from "../src/constants.sol";
+import { ISchemaErrors } from "../src/ISchemaErrors.sol";
 
 /**
  * @notice Encodes a given schema into a single bytes32, without checks.
@@ -89,7 +90,7 @@ contract SchemaTest is Test, GasReporter {
   }
 
   function testInvalidSchemaStaticAfterDynamic() public {
-    vm.expectRevert(abi.encodeWithSelector(SchemaLib.SchemaLib_StaticTypeAfterDynamicType.selector));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType.selector));
     SchemaEncodeHelper.encode(SchemaType.UINT8, SchemaType.UINT32_ARRAY, SchemaType.UINT16);
   }
 
@@ -159,7 +160,7 @@ contract SchemaTest is Test, GasReporter {
     schema[26] = SchemaType.UINT32_ARRAY;
     schema[27] = SchemaType.UINT32_ARRAY;
     schema[28] = SchemaType.UINT32_ARRAY;
-    vm.expectRevert(abi.encodeWithSelector(SchemaLib.SchemaLib_InvalidLength.selector, schema.length));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, schema.length));
     SchemaLib.encode(schema);
   }
 
@@ -183,7 +184,7 @@ contract SchemaTest is Test, GasReporter {
     schema[3] = SchemaType.UINT32_ARRAY;
     schema[4] = SchemaType.UINT32_ARRAY;
     schema[5] = SchemaType.UINT32_ARRAY;
-    vm.expectRevert(abi.encodeWithSelector(SchemaLib.SchemaLib_InvalidLength.selector, schema.length));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, schema.length));
     SchemaLib.encode(schema);
   }
 
@@ -296,7 +297,7 @@ contract SchemaTest is Test, GasReporter {
     Schema encodedSchema = Schema.wrap(keccak256("some invalid schema"));
 
     vm.expectRevert(
-      abi.encodeWithSelector(SchemaLib.SchemaLib_InvalidLength.selector, encodedSchema.numDynamicFields())
+      abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, encodedSchema.numDynamicFields())
     );
 
     encodedSchema.validate({ allowEmpty: false });
@@ -334,7 +335,7 @@ contract SchemaTest is Test, GasReporter {
     schema[27] = SchemaType.UINT32_ARRAY;
     Schema encodedSchema = encodeUnsafe(schema);
 
-    vm.expectRevert(SchemaLib.SchemaLib_StaticTypeAfterDynamicType.selector);
+    vm.expectRevert(ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType.selector);
 
     encodedSchema.validate({ allowEmpty: false });
   }

--- a/packages/store/test/Schema.t.sol
+++ b/packages/store/test/Schema.t.sol
@@ -90,7 +90,7 @@ contract SchemaTest is Test, GasReporter {
   }
 
   function testInvalidSchemaStaticAfterDynamic() public {
-    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType.selector));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.Schema_StaticTypeAfterDynamicType.selector));
     SchemaEncodeHelper.encode(SchemaType.UINT8, SchemaType.UINT32_ARRAY, SchemaType.UINT16);
   }
 
@@ -160,7 +160,7 @@ contract SchemaTest is Test, GasReporter {
     schema[26] = SchemaType.UINT32_ARRAY;
     schema[27] = SchemaType.UINT32_ARRAY;
     schema[28] = SchemaType.UINT32_ARRAY;
-    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, schema.length));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.Schema_InvalidLength.selector, schema.length));
     SchemaLib.encode(schema);
   }
 
@@ -184,7 +184,7 @@ contract SchemaTest is Test, GasReporter {
     schema[3] = SchemaType.UINT32_ARRAY;
     schema[4] = SchemaType.UINT32_ARRAY;
     schema[5] = SchemaType.UINT32_ARRAY;
-    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, schema.length));
+    vm.expectRevert(abi.encodeWithSelector(ISchemaErrors.Schema_InvalidLength.selector, schema.length));
     SchemaLib.encode(schema);
   }
 
@@ -297,7 +297,7 @@ contract SchemaTest is Test, GasReporter {
     Schema encodedSchema = Schema.wrap(keccak256("some invalid schema"));
 
     vm.expectRevert(
-      abi.encodeWithSelector(ISchemaErrors.SchemaLib_InvalidLength.selector, encodedSchema.numDynamicFields())
+      abi.encodeWithSelector(ISchemaErrors.Schema_InvalidLength.selector, encodedSchema.numDynamicFields())
     );
 
     encodedSchema.validate({ allowEmpty: false });
@@ -335,7 +335,7 @@ contract SchemaTest is Test, GasReporter {
     schema[27] = SchemaType.UINT32_ARRAY;
     Schema encodedSchema = encodeUnsafe(schema);
 
-    vm.expectRevert(ISchemaErrors.SchemaLib_StaticTypeAfterDynamicType.selector);
+    vm.expectRevert(ISchemaErrors.Schema_StaticTypeAfterDynamicType.selector);
 
     encodedSchema.validate({ allowEmpty: false });
   }

--- a/packages/store/test/StoreCore.t.sol
+++ b/packages/store/test/StoreCore.t.sol
@@ -26,6 +26,7 @@ import { MirrorSubscriber, indexerTableId } from "./MirrorSubscriber.sol";
 import { RevertSubscriber } from "./RevertSubscriber.sol";
 import { EchoSubscriber } from "./EchoSubscriber.sol";
 import { setDynamicDataLengthAtIndex } from "./setDynamicDataLengthAtIndex.sol";
+import { IFieldLayoutErrors } from "../src/IFieldLayoutErrors.sol";
 
 struct TestStruct {
   uint128 firstData;
@@ -130,7 +131,7 @@ contract StoreCoreTest is Test, StoreMock {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        FieldLayoutLib.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
         invalidFieldLayout.numDynamicFields(),
         5
       )

--- a/packages/store/test/StoreCore.t.sol
+++ b/packages/store/test/StoreCore.t.sol
@@ -131,7 +131,7 @@ contract StoreCoreTest is Test, StoreMock {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        IFieldLayoutErrors.FieldLayoutLib_TooManyDynamicFields.selector,
+        IFieldLayoutErrors.FieldLayout_TooManyDynamicFields.selector,
         invalidFieldLayout.numDynamicFields(),
         5
       )


### PR DESCRIPTION
Exploring my comment on https://github.com/latticexyz/mud/issues/2158#issuecomment-1971071251

Basically some errors (`FieldLayoutLib_*`, `PackedCounter_*`, etc.), are not included in the `IStore` ABI because they are not defined in that interface or anything it inherits. Instead, they are defined in libraries and are referenced only in the _implementation_ of Store.

Some solutions:
- Define error interfaces for each library, eg. `IPackedCounterErrors` (this PR)
- Move every error to a single `IStoreErrors`
- Use abstract contracts [like OpenZeppelin](https://github.com/ethereum/solidity/issues/13086#issuecomment-1445324173) (I'm not sure how that works)
- Stop using interfaces and have clients import the `Store` implementation