### PR TITLE
fix(world-modules): token modules always register namespace

### DIFF
--- a/.changeset/dull-otters-smash.md
+++ b/.changeset/dull-otters-smash.md
@@ -2,4 +2,4 @@
 "@latticexyz/world-modules": patch
 ---
 
-Updated the ERC20 and ERC721 implementations to always register the token namespace.
+ERC20 and ERC721 implementations now always register the token namespace, instead of checking if it has already been registered. This prevents issues with registering the namespace beforehand, namely that only the owner of a system can create a puppet for it.

--- a/.changeset/dull-otters-smash.md
+++ b/.changeset/dull-otters-smash.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world-modules": patch
+---
+
+Updated the ERC20 and ERC721 implementations to always register the token namespace.

--- a/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
+++ b/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
@@ -75,9 +75,7 @@ contract ERC20ModuleRegistrationLibrary {
   function register(IBaseWorld world, bytes14 namespace) public {
     // Register the namespace if it doesn't exist yet
     ResourceId tokenNamespace = WorldResourceIdLib.encodeNamespace(namespace);
-    if (!ResourceIds.getExists(tokenNamespace)) {
-      world.registerNamespace(tokenNamespace);
-    }
+    world.registerNamespace(tokenNamespace);
 
     // Register the tables
     Allowances.register(_allowancesTableId(namespace));

--- a/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
@@ -79,9 +79,7 @@ contract ERC721ModuleRegistrationLibrary {
   function register(IBaseWorld world, bytes14 namespace) public {
     // Register the namespace if it doesn't exist yet
     ResourceId tokenNamespace = WorldResourceIdLib.encodeNamespace(namespace);
-    if (!ResourceIds.getExists(tokenNamespace)) {
-      world.registerNamespace(tokenNamespace);
-    }
+    world.registerNamespace(tokenNamespace);
 
     // Register the tables
     OperatorApproval.register(_operatorApprovalTableId(namespace));


### PR DESCRIPTION
Updates the ERC20 and ERC721 implementations to always register the token namespace, instead of checking if it has already been registered. This prevents issues with registering the namespace beforehand, namely that only the owner of a system can create a puppet for it.

Fixes https://github.com/latticexyz/mud/issues/2354