### PR TITLE
fix(common): move prepare just before send tx

### DIFF
--- a/packages/common/src/sendTransaction.ts
+++ b/packages/common/src/sendTransaction.ts
@@ -52,17 +52,15 @@ export async function sendTransaction<
       account,
     } as CallParameters<TChain>);
 
-    // TODO: estimate gas
-
     return request;
   }
-
-  const preparedRequest = await prepare();
 
   return await nonceManager.mempoolQueue.add(
     () =>
       pRetry(
         async () => {
+          const preparedRequest = await prepare();
+
           if (!nonceManager.hasNonce()) {
             await nonceManager.resetNonce();
           }

--- a/packages/common/src/writeContract.ts
+++ b/packages/common/src/writeContract.ts
@@ -63,12 +63,12 @@ export async function writeContract<
     return result.request as unknown as WriteContractParameters<abi, functionName, args, chain, account, chainOverride>;
   }
 
-  const preparedWrite = await prepareWrite();
-
   return nonceManager.mempoolQueue.add(
     () =>
       pRetry(
         async () => {
+          const preparedWrite = await prepareWrite();
+
           if (!nonceManager.hasNonce()) {
             await nonceManager.resetNonce();
           }


### PR DESCRIPTION
somewhat addresses #2081 in that we no longer attempt to parallelize simulate with other things and just do it ahead of the tx we're about to send (see https://github.com/latticexyz/mud/issues/2081#issuecomment-1976837638 for more context) 

I figure a working but slightly slower tx queue is better than a non working one