### PR TITLE
fix(store-sync): track changed records together in zustand

### DIFF
--- a/.changeset/sharp-students-compare.md
+++ b/.changeset/sharp-students-compare.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Fixes an issue with Zustand store sync where multiple updates to a record for a key in the same block did not get tracked and applied properly.

--- a/packages/store-sync/src/zustand/createStorageAdapter.ts
+++ b/packages/store-sync/src/zustand/createStorageAdapter.ts
@@ -20,8 +20,8 @@ export function createStorageAdapter<tables extends Tables>({
   return async function zustandStorageAdapter({ blockNumber, logs }) {
     // TODO: clean this up so that we do one store write per block
 
-    const updatedIds: string[] = [];
-    const deletedIds: string[] = [];
+    // record id => is deleted
+    const touchedIds: Map<string, boolean> = new Map();
 
     const rawRecords = { ...store.getState().rawRecords };
 
@@ -54,7 +54,7 @@ export function createStorageAdapter<tables extends Tables>({
           encodedLengths: log.args.encodedLengths,
           dynamicData: log.args.dynamicData,
         };
-        updatedIds.push(id);
+        touchedIds.set(id, false);
       } else if (log.eventName === "Store_SpliceStaticData") {
         debug("splicing static data", {
           namespace: table.namespace,
@@ -75,7 +75,7 @@ export function createStorageAdapter<tables extends Tables>({
           ...previousRecord,
           staticData,
         };
-        updatedIds.push(id);
+        touchedIds.set(id, false);
       } else if (log.eventName === "Store_SpliceDynamicData") {
         debug("splicing dynamic data", {
           namespace: table.namespace,
@@ -98,7 +98,7 @@ export function createStorageAdapter<tables extends Tables>({
           encodedLengths,
           dynamicData,
         };
-        updatedIds.push(id);
+        touchedIds.set(id, false);
       } else if (log.eventName === "Store_DeleteRecord") {
         debug("deleting record", {
           namespace: table.namespace,
@@ -107,14 +107,18 @@ export function createStorageAdapter<tables extends Tables>({
           log,
         });
         delete rawRecords[id];
-        deletedIds.push(id);
+        touchedIds.set(id, true);
       }
     }
 
-    if (!updatedIds.length && !deletedIds.length) return;
+    if (!touchedIds.size) return;
 
-    const records = {
-      ...Object.fromEntries(Object.entries(store.getState().records).filter(([id]) => !deletedIds.includes(id))),
+    const updatedIds = Array.from(touchedIds.keys()).filter((id) => touchedIds.get(id) === false);
+    const deletedIds = Array.from(touchedIds.keys()).filter((id) => touchedIds.get(id) === true);
+
+    const previousRecords = store.getState().records;
+    const records: typeof previousRecords = {
+      ...Object.fromEntries(Object.entries(previousRecords).filter(([id]) => !deletedIds.includes(id))),
       ...Object.fromEntries(
         updatedIds
           .map((id) => {


### PR DESCRIPTION
when playing with this in #2355, I noticed a possible edge case where tracking these updated IDs separately meant that an update -> delete or delete -> update for the same record in the same block could give the wrong results in the end (out of sync from chain state)