### PR TITLE
refactor(world): `registerRootFunctionSelector` does not take selector

### DIFF
--- a/.changeset/fresh-suits-boil.md
+++ b/.changeset/fresh-suits-boil.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Remove the `systemFunctionSelector` argument from `registerRootFunctionSelector`, as it can be derived from the function selector instead.

--- a/docs/pages/world/reference/internal/init-module-implementation.mdx
+++ b/docs/pages/world/reference/internal/init-module-implementation.mdx
@@ -434,24 +434,22 @@ _Creates a mapping for a root World function without namespace or name prefix_
 ```solidity
 function registerRootFunctionSelector(
   ResourceId systemId,
-  string memory worldFunctionSignature,
-  bytes4 systemFunctionSelector
-) public onlyDelegatecall returns (bytes4 worldFunctionSelector);
+  string memory systemFunctionSignature
+) public onlyDelegatecall returns (bytes4 systemFunctionSelector);
 ```
 
 **Parameters**
 
-| Name                     | Type         | Description                         |
-| ------------------------ | ------------ | ----------------------------------- |
-| `systemId`               | `ResourceId` | The system ID                       |
-| `worldFunctionSignature` | `string`     | The signature of the World function |
-| `systemFunctionSelector` | `bytes4`     | The selector of the system function |
+| Name                      | Type         | Description                         |
+| ------------------------- | ------------ | ----------------------------------- |
+| `systemId`                | `ResourceId` | The system ID                       |
+| `systemFunctionSignature` | `string`     | The signature of the World function |
 
 **Returns**
 
-| Name                    | Type     | Description                        |
-| ----------------------- | -------- | ---------------------------------- |
-| `worldFunctionSelector` | `bytes4` | The selector of the World function |
+| Name                     | Type     | Description                        |
+| ------------------------ | -------- | ---------------------------------- |
+| `systemFunctionSelector` | `bytes4` | The selector of the World function |
 
 #### registerDelegation
 

--- a/docs/pages/world/reference/world-external.mdx
+++ b/docs/pages/world/reference/world-external.mdx
@@ -356,24 +356,22 @@ _Creates a mapping for a root World function without namespace or name prefix_
 ```solidity
 function registerRootFunctionSelector(
   ResourceId systemId,
-  string memory worldFunctionSignature,
-  bytes4 systemFunctionSelector
-) public onlyDelegatecall returns (bytes4 worldFunctionSelector);
+  string memory systemFunctionSignature
+) public onlyDelegatecall returns (bytes4 systemFunctionSelector);
 ```
 
 **Parameters**
 
-| Name                     | Type         | Description                         |
-| ------------------------ | ------------ | ----------------------------------- |
-| `systemId`               | `ResourceId` | The system ID                       |
-| `worldFunctionSignature` | `string`     | The signature of the World function |
-| `systemFunctionSelector` | `bytes4`     | The selector of the system function |
+| Name                      | Type         | Description                         |
+| ------------------------- | ------------ | ----------------------------------- |
+| `systemId`                | `ResourceId` | The system ID                       |
+| `systemFunctionSignature` | `string`     | The signature of the World function |
 
 **Returns**
 
-| Name                    | Type     | Description                        |
-| ----------------------- | -------- | ---------------------------------- |
-| `worldFunctionSelector` | `bytes4` | The selector of the World function |
+| Name                     | Type     | Description                        |
+| ------------------------ | -------- | ---------------------------------- |
+| `systemFunctionSelector` | `bytes4` | The selector of the World function |
 
 #### registerDelegation
 

--- a/packages/cli/src/deploy/ensureFunctions.ts
+++ b/packages/cli/src/deploy/ensureFunctions.ts
@@ -50,7 +50,7 @@ export async function ensureFunctions({
               abi: worldAbi,
               // TODO: replace with batchCall (https://github.com/latticexyz/mud/issues/1645)
               functionName: "registerRootFunctionSelector",
-              args: [func.systemId, func.systemFunctionSignature, func.systemFunctionSelector],
+              args: [func.systemId, func.systemFunctionSignature],
             }),
           {
             retries: 3,

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -75,13 +75,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -93,13 +93,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -117,7 +117,7 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456749
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -135,7 +135,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715707
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -153,7 +153,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715707
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -165,7 +165,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715707
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -183,7 +183,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715707
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -267,7 +267,7 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromCallboundDelegation",
     "name": "register a callbound delegation",
-    "gasUsed": 139044
+    "gasUsed": 139066
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
@@ -279,7 +279,7 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromSystemDelegation",
     "name": "register a systembound delegation",
-    "gasUsed": 136166
+    "gasUsed": 136188
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
@@ -291,7 +291,7 @@
     "file": "test/StandardDelegationsModule.t.sol",
     "test": "testCallFromTimeboundDelegation",
     "name": "register a timebound delegation",
-    "gasUsed": 132709
+    "gasUsed": 132731
   },
   {
     "file": "test/StandardDelegationsModule.t.sol",
@@ -303,7 +303,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 715495
+    "gasUsed": 715516
   },
   {
     "file": "test/UniqueEntityModule.t.sol",
@@ -315,7 +315,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstallRoot",
     "name": "installRoot unique entity module",
-    "gasUsed": 685964
+    "gasUsed": 685985
   },
   {
     "file": "test/UniqueEntityModule.t.sol",

--- a/packages/world-modules/test/SystemSwitch.t.sol
+++ b/packages/world-modules/test/SystemSwitch.t.sol
@@ -125,11 +125,7 @@ contract SystemSwitchTest is Test, GasReporter {
   }
 
   function testCallRootFromRootWorldSelector() public {
-    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
-      rootSystemBId,
-      "echo(string)",
-      EchoSystem.echo.selector
-    );
+    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(rootSystemBId, "echo(string)");
     bytes memory callData = abi.encodeWithSelector(worldFunctionSelector, "hello");
 
     vm.prank(caller);
@@ -164,11 +160,7 @@ contract SystemSwitchTest is Test, GasReporter {
   }
 
   function testCallRootFromNonRootWorldSelector() public {
-    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
-      rootSystemBId,
-      "echo(string)",
-      EchoSystem.echo.selector
-    );
+    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(rootSystemBId, "echo(string)");
     bytes memory callData = abi.encodeWithSelector(worldFunctionSelector, "hello");
 
     vm.prank(caller);
@@ -203,11 +195,7 @@ contract SystemSwitchTest is Test, GasReporter {
   }
 
   function testCallNonRootFromRootWorldSelector() public {
-    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
-      systemBId,
-      "echo(string)",
-      EchoSystem.echo.selector
-    );
+    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(systemBId, "echo(string)");
     bytes memory callData = abi.encodeWithSelector(worldFunctionSelector, "hello");
 
     vm.prank(caller);
@@ -250,11 +238,7 @@ contract SystemSwitchTest is Test, GasReporter {
   }
 
   function testCallNonRootFromNonRootWorldSelector() public {
-    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(
-      systemBId,
-      "echo(string)",
-      EchoSystem.echo.selector
-    );
+    bytes4 worldFunctionSelector = world.registerRootFunctionSelector(systemBId, "echo(string)");
     bytes memory callData = abi.encodeWithSelector(worldFunctionSelector, "hello");
 
     vm.prank(caller);

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -63,7 +63,7 @@
     "file": "test/Factories.t.sol",
     "test": "testWorldFactoryGas",
     "name": "deploy world via WorldFactory",
-    "gasUsed": 12657699
+    "gasUsed": 12650607
   },
   {
     "file": "test/World.t.sol",
@@ -81,7 +81,7 @@
     "file": "test/World.t.sol",
     "test": "testCallFromUnlimitedDelegation",
     "name": "register an unlimited delegation",
-    "gasUsed": 74727
+    "gasUsed": 74749
   },
   {
     "file": "test/World.t.sol",
@@ -105,25 +105,25 @@
     "file": "test/World.t.sol",
     "test": "testRegisterFunctionSelector",
     "name": "Register a function selector",
-    "gasUsed": 116605
+    "gasUsed": 116539
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterNamespace",
     "name": "Register a new namespace",
-    "gasUsed": 144062
+    "gasUsed": 144073
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterRootFunctionSelector",
     "name": "Register a root function selector",
-    "gasUsed": 107427
+    "gasUsed": 106939
   },
   {
     "file": "test/World.t.sol",
     "test": "testRegisterSystem",
     "name": "register a system",
-    "gasUsed": 185337
+    "gasUsed": 185359
   },
   {
     "file": "test/World.t.sol",

--- a/packages/world/src/codegen/interfaces/IWorldRegistrationSystem.sol
+++ b/packages/world/src/codegen/interfaces/IWorldRegistrationSystem.sol
@@ -28,9 +28,8 @@ interface IWorldRegistrationSystem {
 
   function registerRootFunctionSelector(
     ResourceId systemId,
-    string memory worldFunctionSignature,
-    bytes4 systemFunctionSelector
-  ) external returns (bytes4 worldFunctionSelector);
+    string memory systemFunctionSignature
+  ) external returns (bytes4 systemFunctionSelector);
 
   function registerDelegation(address delegatee, ResourceId delegationControlId, bytes memory initCallData) external;
 

--- a/packages/world/src/modules/init/InitModule.sol
+++ b/packages/world/src/modules/init/InitModule.sol
@@ -166,10 +166,7 @@ contract InitModule is Module {
       msgSender: _msgSender(),
       msgValue: 0,
       target: registrationSystem,
-      callData: abi.encodeCall(
-        WorldRegistrationSystem.registerRootFunctionSelector,
-        (systemId, functionSignature, bytes4(keccak256(bytes(functionSignature))))
-      )
+      callData: abi.encodeCall(WorldRegistrationSystem.registerRootFunctionSelector, (systemId, functionSignature))
     });
   }
 }

--- a/packages/world/src/modules/init/functionSignatures.sol
+++ b/packages/world/src/modules/init/functionSignatures.sol
@@ -53,7 +53,7 @@ function getFunctionSignaturesRegistration() pure returns (string[14] memory) {
     "unregisterSystemHook(bytes32,address)",
     "registerSystem(bytes32,address,bool)",
     "registerFunctionSelector(bytes32,string)",
-    "registerRootFunctionSelector(bytes32,string,bytes4)",
+    "registerRootFunctionSelector(bytes32,string)",
     "registerDelegation(address,bytes32,bytes)",
     "unregisterDelegation(address)",
     "registerNamespaceDelegation(bytes32,bytes32,bytes)",

--- a/packages/world/src/modules/init/implementations/WorldRegistrationSystem.sol
+++ b/packages/world/src/modules/init/implementations/WorldRegistrationSystem.sol
@@ -223,31 +223,29 @@ contract WorldRegistrationSystem is System, IWorldErrors, LimitedCallContext {
    * @notice Registers a root World function selector
    * @dev Creates a mapping for a root World function without namespace or name prefix
    * @param systemId The system ID
-   * @param worldFunctionSignature The signature of the World function
-   * @param systemFunctionSelector The selector of the system function
-   * @return worldFunctionSelector The selector of the World function
+   * @param systemFunctionSignature The signature of the World function
+   * @return systemFunctionSelector The selector of the World function
    */
   function registerRootFunctionSelector(
     ResourceId systemId,
-    string memory worldFunctionSignature,
-    bytes4 systemFunctionSelector
-  ) public onlyDelegatecall returns (bytes4 worldFunctionSelector) {
+    string memory systemFunctionSignature
+  ) public onlyDelegatecall returns (bytes4 systemFunctionSelector) {
     // Require the caller to own the root namespace
     AccessControl.requireOwner(ROOT_NAMESPACE_ID, _msgSender());
 
     // Compute the function selector from the provided signature
-    worldFunctionSelector = bytes4(keccak256(bytes(worldFunctionSignature)));
+    systemFunctionSelector = bytes4(keccak256(bytes(systemFunctionSignature)));
 
     // Require the function selector to be globally unique
-    ResourceId existingSystemId = FunctionSelectors._getSystemId(worldFunctionSelector);
+    ResourceId existingSystemId = FunctionSelectors._getSystemId(systemFunctionSelector);
 
-    if (ResourceId.unwrap(existingSystemId) != 0) revert World_FunctionSelectorAlreadyExists(worldFunctionSelector);
+    if (ResourceId.unwrap(existingSystemId) != 0) revert World_FunctionSelectorAlreadyExists(systemFunctionSelector);
 
     // Register the function selector
-    FunctionSelectors._set(worldFunctionSelector, systemId, systemFunctionSelector);
+    FunctionSelectors._set(systemFunctionSelector, systemId, systemFunctionSelector);
 
     // Register the function signature for offchain use
-    FunctionSignatures._set(worldFunctionSelector, worldFunctionSignature);
+    FunctionSignatures._set(systemFunctionSelector, systemFunctionSignature);
   }
 
   /**

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -1645,11 +1645,11 @@ contract WorldTest is Test, GasReporter {
     world.registerNamespace(systemId.getNamespaceId());
     world.registerSystem(systemId, system, true);
 
-    string memory worldFunc = "msgSender()";
+    string memory systemFunc = "msgSender()";
 
     // Expect an error when trying to register a root function selector from an account without access
     _expectAccessDenied(address(0x01), "", "", RESOURCE_NAMESPACE);
-    world.registerRootFunctionSelector(systemId, worldFunc);
+    world.registerRootFunctionSelector(systemId, systemFunc);
 
     // Expect the World to not be able to register a root function selector when calling the function externally
     vm.prank(address(world));
@@ -1662,13 +1662,13 @@ contract WorldTest is Test, GasReporter {
     world.registerRootFunctionSelector(systemId, "smth");
 
     startGasReport("Register a root function selector");
-    bytes4 functionSelector = world.registerRootFunctionSelector(systemId, worldFunc);
+    bytes4 functionSelector = world.registerRootFunctionSelector(systemId, systemFunc);
     endGasReport();
 
-    assertEq(functionSelector, bytes4(keccak256(bytes(worldFunc))), "wrong function selector returned");
+    assertEq(functionSelector, bytes4(keccak256(bytes(systemFunc))), "wrong function selector returned");
 
     // Call the system via the World with the registered function selector
-    (bool success, bytes memory data) = address(world).call(abi.encodeWithSignature(worldFunc));
+    (bool success, bytes memory data) = address(world).call(abi.encodeWithSignature(systemFunc));
 
     assertTrue(success, "call failed");
     assertEq(abi.decode(data, (address)), address(this), "wrong address returned");

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -1645,12 +1645,11 @@ contract WorldTest is Test, GasReporter {
     world.registerNamespace(systemId.getNamespaceId());
     world.registerSystem(systemId, system, true);
 
-    string memory worldFunc = "testSelector()";
-    bytes4 sysFunc = WorldTestSystem.msgSender.selector;
+    string memory worldFunc = "msgSender()";
 
     // Expect an error when trying to register a root function selector from an account without access
     _expectAccessDenied(address(0x01), "", "", RESOURCE_NAMESPACE);
-    world.registerRootFunctionSelector(systemId, worldFunc, sysFunc);
+    world.registerRootFunctionSelector(systemId, worldFunc);
 
     // Expect the World to not be able to register a root function selector when calling the function externally
     vm.prank(address(world));
@@ -1660,10 +1659,10 @@ contract WorldTest is Test, GasReporter {
         world.registerRootFunctionSelector.selector
       )
     );
-    world.registerRootFunctionSelector(systemId, "smth", "smth");
+    world.registerRootFunctionSelector(systemId, "smth");
 
     startGasReport("Register a root function selector");
-    bytes4 functionSelector = world.registerRootFunctionSelector(systemId, worldFunc, sysFunc);
+    bytes4 functionSelector = world.registerRootFunctionSelector(systemId, worldFunc);
     endGasReport();
 
     assertEq(functionSelector, bytes4(keccak256(bytes(worldFunc))), "wrong function selector returned");
@@ -1675,7 +1674,7 @@ contract WorldTest is Test, GasReporter {
     assertEq(abi.decode(data, (address)), address(this), "wrong address returned");
 
     // Register a function selector to the error function
-    functionSelector = world.registerRootFunctionSelector(systemId, "err(string)", WorldTestSystem.err.selector);
+    functionSelector = world.registerRootFunctionSelector(systemId, "err(string)");
 
     // Expect errors to be passed through
     vm.expectRevert(abi.encodeWithSelector(WorldTestSystem.WorldTestSystemError.selector, "test error"));
@@ -1712,7 +1711,7 @@ contract WorldTest is Test, GasReporter {
 
     world.registerNamespace(systemId.getNamespaceId());
     world.registerSystem(systemId, system, true);
-    world.registerRootFunctionSelector(systemId, "receiveEther()", WorldTestSystem.receiveEther.selector);
+    world.registerRootFunctionSelector(systemId, "receiveEther()");
 
     // create new funded address and impersonate
     address alice = makeAddr("alice");
@@ -1739,7 +1738,7 @@ contract WorldTest is Test, GasReporter {
     ResourceId systemId = WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: namespace, name: name });
     world.registerNamespace(systemId.getNamespaceId());
     world.registerSystem(systemId, system, true);
-    world.registerRootFunctionSelector(systemId, "msgSender()", WorldTestSystem.msgSender.selector);
+    world.registerRootFunctionSelector(systemId, "msgSender()");
 
     // create new funded address and impersonate
     address alice = makeAddr("alice");
@@ -1766,7 +1765,7 @@ contract WorldTest is Test, GasReporter {
     bytes16 name = "testSystem";
     ResourceId systemId = WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: namespace, name: name });
     world.registerSystem(systemId, system, true);
-    world.registerRootFunctionSelector(systemId, "systemFallback()", bytes4(""));
+    world.registerRootFunctionSelector(systemId, "systemFallback()");
 
     // create new funded address and impersonate
     address alice = makeAddr("alice");
@@ -1792,7 +1791,7 @@ contract WorldTest is Test, GasReporter {
     bytes16 name = "testSystem";
     ResourceId systemId = WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: namespace, name: name });
     world.registerSystem(systemId, system, true);
-    world.registerRootFunctionSelector(systemId, "systemFallback()", bytes4(""));
+    world.registerRootFunctionSelector(systemId, "systemFallback()");
 
     // create new funded address and impersonate
     address alice = makeAddr("alice");
@@ -1818,7 +1817,7 @@ contract WorldTest is Test, GasReporter {
     bytes16 name = "testSystem";
     ResourceId systemId = WorldResourceIdLib.encode({ typeId: RESOURCE_SYSTEM, namespace: namespace, name: name });
     world.registerSystem(systemId, system, true);
-    world.registerRootFunctionSelector(systemId, "receiveEther()", WorldTestSystem.receiveEther.selector);
+    world.registerRootFunctionSelector(systemId, "receiveEther()");
 
     // create new funded address and impersonate
     address alice = makeAddr("alice");

--- a/packages/world/test/WorldBalance.t.sol
+++ b/packages/world/test/WorldBalance.t.sol
@@ -43,7 +43,7 @@ contract WorldBalanceTest is Test, GasReporter {
     world.registerSystem(rootSystemId, rootSystem, true);
     world.registerSystem(nonRootSystemId, nonRootSystem, true);
 
-    world.registerRootFunctionSelector(rootSystemId, "echoValue()", rootSystem.echoValue.selector);
+    world.registerRootFunctionSelector(rootSystemId, "echoValue()");
     world.registerFunctionSelector(nonRootSystemId, "echoValue()");
   }
 


### PR DESCRIPTION
The signature and selector provided to this function are equivalent - we can derive the selector instead of passing it in.

We should actually rename this function to `registerRootFunctionSignature`!