### PR TITLE
fix(dev-tools): fix `callFrom` transaction display errors for non-root namespace functions

### DIFF
--- a/.changeset/kind-rats-compare.md
+++ b/.changeset/kind-rats-compare.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/dev-tools": patch
+---
+
+Fixed `call`/`callFrom` transaction display errors for non-root namespace functions in dev-tools.

--- a/packages/dev-tools/src/actions/WriteFunction.tsx
+++ b/packages/dev-tools/src/actions/WriteFunction.tsx
@@ -1,0 +1,49 @@
+import { decodeFunctionData, AbiFunctionSignatureNotFoundError, type Hex } from "viem";
+import { type ContractWrite } from "@latticexyz/common";
+import { useDevToolsContext } from "../DevToolsContext";
+import { WriteFunctionNameAndArgs } from "./WriteFunctionNameAndArgs";
+import { WriteFunction as WriteFunctionZustand } from "../zustand/WriteFunction";
+
+type Props = {
+  write: ContractWrite;
+};
+
+// Displays the function name and arguments of `write` (e.g., 'addTask("something")').
+export function WriteFunction({ write }: Props) {
+  const { worldAbi, useStore } = useDevToolsContext();
+
+  const worldFunctionName = write.request.functionName;
+  const worldFunctionArgs = write.request.args;
+
+  // Just use the World function if it's not `call`/`callFrom`.
+  if (worldFunctionName !== "call" && worldFunctionName !== "callFrom") {
+    return <WriteFunctionNameAndArgs name={worldFunctionName} args={worldFunctionArgs} />;
+  }
+
+  const systemFunctionCalldata = worldFunctionArgs![worldFunctionArgs!.length - 1] as Hex;
+
+  // Decode the calldata properly if the client store is available.
+  if (useStore) {
+    return (
+      <WriteFunctionZustand worldFunctionName={worldFunctionName} systemFunctionCalldata={systemFunctionCalldata} />
+    );
+  }
+
+  // Try using the World ABI to decode `systemFunctionCalldata`.
+  // Since the calldata corresponds to a System's function, this may not be successful.
+  // For instance, non-root System calls could result in an error.
+  try {
+    const functionData = decodeFunctionData({ abi: worldAbi, data: systemFunctionCalldata });
+
+    return (
+      <WriteFunctionNameAndArgs name={functionData.functionName} args={functionData.args} viaName={worldFunctionName} />
+    );
+  } catch (error) {
+    if (!(error instanceof AbiFunctionSignatureNotFoundError)) {
+      throw error;
+    }
+  }
+
+  // Fallback that uses the World function (e.g., "callFrom(args)").
+  return <WriteFunctionNameAndArgs name={worldFunctionName} args={worldFunctionArgs} />;
+}

--- a/packages/dev-tools/src/actions/WriteFunctionNameAndArgs.tsx
+++ b/packages/dev-tools/src/actions/WriteFunctionNameAndArgs.tsx
@@ -1,0 +1,21 @@
+import { serialize } from "../serialize";
+
+type Props = {
+  name: string;
+  args: readonly unknown[] | undefined;
+  viaName?: string;
+};
+
+export function WriteFunctionNameAndArgs({ name, args, viaName }: Props) {
+  return (
+    <>
+      {name}({args?.map((value) => serialize(value)).join(", ")})
+      {viaName && (
+        <>
+          {" "}
+          <span className="text-xs text-white/40">via {viaName}</span>
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/dev-tools/src/actions/WriteSummary.tsx
+++ b/packages/dev-tools/src/actions/WriteSummary.tsx
@@ -1,10 +1,4 @@
-import {
-  decodeEventLog,
-  AbiEventSignatureNotFoundError,
-  decodeFunctionData,
-  Hex,
-  AbiFunctionSignatureNotFoundError,
-} from "viem";
+import { decodeEventLog, AbiEventSignatureNotFoundError } from "viem";
 import { twMerge } from "tailwind-merge";
 import { isDefined } from "@latticexyz/common/utils";
 import { PendingIcon } from "../icons/PendingIcon";
@@ -18,6 +12,7 @@ import { ErrorTrace } from "../ErrorTrace";
 import { ContractWrite, hexToResource, resourceToLabel } from "@latticexyz/common";
 import { useDevToolsContext } from "../DevToolsContext";
 import { hexKeyTupleToEntity } from "@latticexyz/store-sync/recs";
+import { WriteFunction } from "./WriteFunction";
 
 type Props = {
   write: ContractWrite;
@@ -62,28 +57,6 @@ export function WriteSummary({ write }: Props) {
           .filter(isDefined)
       : null;
 
-  let functionName = write.request.functionName;
-  let functionArgs = write.request.args;
-  if (functionName === "call" || functionName === "callFrom") {
-    const functionSelectorAndArgs: Hex = write.request?.args?.length
-      ? (write.request.args[write.request.args.length - 1] as Hex)
-      : `0x`;
-
-    // TODO: Since `functionSelectorAndArgs` corresponds to a System's function, decoding it using
-    // the World ABI may not always be successful. For instance, namespaced system calls could
-    // result in an error.
-    // See also https://github.com/latticexyz/mud/issues/2382
-    try {
-      const functionData = decodeFunctionData({ abi: worldAbi, data: functionSelectorAndArgs });
-      functionName = functionData.functionName;
-      functionArgs = functionData.args;
-    } catch (error) {
-      if (!(error instanceof AbiFunctionSignatureNotFoundError)) {
-        throw error;
-      }
-    }
-  }
-
   return (
     <details
       onToggle={(event) => {
@@ -101,10 +74,7 @@ export function WriteSummary({ write }: Props) {
         )}
       >
         <div className="flex-1 font-mono text-white whitespace-nowrap overflow-hidden text-ellipsis">
-          {functionName}({functionArgs?.map((value) => serialize(value)).join(", ")}){" "}
-          {write.request.functionName !== functionName ? (
-            <span className="text-xs text-white/40">via {write.request.functionName}</span>
-          ) : null}
+          <WriteFunction write={write} />
         </div>
         {transactionReceipt.status === "fulfilled" ? (
           <a

--- a/packages/dev-tools/src/actions/WriteSummary.tsx
+++ b/packages/dev-tools/src/actions/WriteSummary.tsx
@@ -1,4 +1,10 @@
-import { decodeEventLog, AbiEventSignatureNotFoundError, decodeFunctionData, Hex } from "viem";
+import {
+  decodeEventLog,
+  AbiEventSignatureNotFoundError,
+  decodeFunctionData,
+  Hex,
+  AbiFunctionSignatureNotFoundError,
+} from "viem";
 import { twMerge } from "tailwind-merge";
 import { isDefined } from "@latticexyz/common/utils";
 import { PendingIcon } from "../icons/PendingIcon";
@@ -62,9 +68,20 @@ export function WriteSummary({ write }: Props) {
     const functionSelectorAndArgs: Hex = write.request?.args?.length
       ? (write.request.args[write.request.args.length - 1] as Hex)
       : `0x`;
-    const functionData = decodeFunctionData({ abi: worldAbi, data: functionSelectorAndArgs });
-    functionName = functionData.functionName;
-    functionArgs = functionData.args;
+
+    // TODO: Since `functionSelectorAndArgs` corresponds to a System's function, decoding it using
+    // the World ABI may not always be successful. For instance, namespaced system calls could
+    // result in an error.
+    // See also https://github.com/latticexyz/mud/issues/2382
+    try {
+      const functionData = decodeFunctionData({ abi: worldAbi, data: functionSelectorAndArgs });
+      functionName = functionData.functionName;
+      functionArgs = functionData.args;
+    } catch (error) {
+      if (!(error instanceof AbiFunctionSignatureNotFoundError)) {
+        throw error;
+      }
+    }
   }
 
   return (

--- a/packages/dev-tools/src/zustand/WriteFunction.tsx
+++ b/packages/dev-tools/src/zustand/WriteFunction.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { slice, parseAbiItem, decodeAbiParameters, type Hex } from "viem";
+import { worldTables } from "@latticexyz/store-sync";
+import { useDevToolsContext } from "../DevToolsContext";
+import { WriteFunctionNameAndArgs } from "../actions/WriteFunctionNameAndArgs";
+
+type Props = {
+  worldFunctionName: string;
+  systemFunctionCalldata: Hex;
+};
+
+export function WriteFunction({ worldFunctionName, systemFunctionCalldata }: Props) {
+  const { useStore } = useDevToolsContext();
+  if (!useStore) throw new Error("Missing useStore");
+
+  // The first 4 bytes of calldata represent the function selector.
+  const systemFunctionSelector = slice(systemFunctionCalldata, 0, 4);
+
+  const getSystemFunctionSignature = (state: ReturnType<(typeof useStore)["getState"]>) =>
+    state.getValue(worldTables.FunctionSignatures, { functionSelector: systemFunctionSelector })?.functionSignature;
+
+  // React doesn't like using hooks from another copy of React libs, so we have to use the non-React API to get data out of Zustand
+  const [systemFunctionSignature, setSystemFunctionSignature] = useState(
+    getSystemFunctionSignature(useStore.getState()),
+  );
+
+  useEffect(() => {
+    return useStore.subscribe((state) => {
+      if (systemFunctionSignature) return;
+
+      const signature = getSystemFunctionSignature(state);
+      if (signature) {
+        setSystemFunctionSignature(signature);
+      }
+    });
+  }, [useStore, systemFunctionSignature]);
+
+  // Not synced yet
+  if (!systemFunctionSignature) return null;
+
+  const systemFunctionAbiItem = parseAbiItem(`function ${systemFunctionSignature}`);
+  if (systemFunctionAbiItem.type !== "function") throw new Error("Unreachable");
+
+  const systemFunctionArgs = systemFunctionAbiItem.inputs.length
+    ? decodeAbiParameters(systemFunctionAbiItem.inputs, slice(systemFunctionCalldata, 4))
+    : undefined;
+
+  return (
+    <WriteFunctionNameAndArgs name={systemFunctionAbiItem.name} args={systemFunctionArgs} viaName={worldFunctionName} />
+  );
+}


### PR DESCRIPTION
This PR is a spin-off from #2366.

Currently, in dev-tools, errors occur when `world.call()` / `world.callFrom()` transactions containing non-root namespace System functions are submitted. (Error: `decodeFunctionData.ts:67 Uncaught AbiFunctionSignatureNotFoundError: Encoded function signature "0x67238562" not found on ABI.`) This problem arises because dev-tools uses the World ABI to decode System function calldata for displaying actions (e.g., 'addTask("something") via callFrom').

This PR resolves the error. Now, dev-tools uses the `FunctionSignatures` off-chain table through Zustand if available for proper calldata decoding, as enabled by #2392. Otherwise, it attempts decoding with the World ABI, then proceeds without decoding if unsuccessful.

For the React component structure, I extracted the section displaying the function name and args from `WriteSummary` into `WriteFunction` and made the implementation.

All paths have been tested:

- root/non-root namespace
- `world.doSomething(...)` (fallback call) / `world.callFrom(...)`
- with/without `useStore`
- with/without System function args