### PR TITLE
fix: add bytes12 to Bytes.sol

### DIFF
--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -218,7 +218,7 @@ function slice12(bytes memory data, uint256 start) internal pure returns (bytes1
 
 | Name    | Type      | Description                                                      |
 | ------- | --------- | ---------------------------------------------------------------- |
-| `data`  | `bytes`   | The bytes blob from which a 16-byte sequence is to be extracted. |
+| `data`  | `bytes`   | The bytes blob from which a 12-byte sequence is to be extracted. |
 | `start` | `uint256` | The starting position within the bytes blob for extraction.      |
 
 **Returns**

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -206,6 +206,27 @@ function slice8(bytes memory data, uint256 start) internal pure returns (bytes8 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes8` | The extracted bytes8 value from the specified position in the bytes blob. |
 
+#### slice12
+
+_Extracts a 12-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function slice12(bytes memory data, uint256 start) internal pure returns (bytes12 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 16-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes12` | The extracted bytes12 value from the specified position in the bytes blob. |
+
 #### slice16
 
 _Extracts a 16-byte sequence from a bytes blob starting at a specific position._

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -155,6 +155,18 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 12-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 12-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes12 value from the specified position in the bytes blob.
+   */
+  function slice12(bytes memory data, uint256 start) internal pure returns (bytes12 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
    * @dev Extracts a 20-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 20-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.


### PR DESCRIPTION
To support packed uint96 types in tables.