### PR TITLE
fix(store): restore bytesN helpers

### DIFF
--- a/.changeset/lemon-falcons-arrive.md
+++ b/.changeset/lemon-falcons-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@latticexyz/store": minor
+"@latticexyz/store": patch
 ---
 
 Restored `Bytes.sliceN` helpers that were previously (mistakenly) removed and renamed them to `Bytes.getBytesN`.

--- a/.changeset/lemon-falcons-arrive.md
+++ b/.changeset/lemon-falcons-arrive.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": minor
+---
+
+Restored `Bytes.sliceN` helpers that were previously (mistakenly) removed and renamed them to `Bytes.getBytesN`.

--- a/.changeset/lemon-falcons-arrive.md
+++ b/.changeset/lemon-falcons-arrive.md
@@ -3,3 +3,5 @@
 ---
 
 Restored `Bytes.sliceN` helpers that were previously (mistakenly) removed and renamed them to `Bytes.getBytesN`.
+
+If you're upgrading an existing MUD project, you can rerun codegen with `mud build` to update your table libraries to the new function names.

--- a/docs/pages/store/reference/misc.mdx
+++ b/docs/pages/store/reference/misc.mdx
@@ -57,14 +57,15 @@ function setBytes4(bytes memory input, uint256 index, bytes4 overwrite) internal
 | -------- | ------- | ------------------------------------------------------------------------- |
 | `<none>` | `bytes` | The modified bytes blob with the new 4-byte value at the specified index. |
 
-#### slice1
+#### getBytes1
 
-SLICE
+GET
+Used by codegen libraries
 
 _Extracts a single byte from a bytes blob starting at a specific position._
 
 ```solidity
-function slice1(bytes memory data, uint256 start) internal pure returns (bytes1 output);
+function getBytes1(bytes memory data, uint256 start) internal pure returns (bytes1 output);
 ```
 
 **Parameters**
@@ -80,12 +81,12 @@ function slice1(bytes memory data, uint256 start) internal pure returns (bytes1 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes1` | The extracted bytes1 value from the specified position in the bytes blob. |
 
-#### slice1
+#### getBytes1
 
 _Extracts a single byte from a bytes32 value starting at a specific position._
 
 ```solidity
-function slice1(bytes32 data, uint256 start) internal pure returns (bytes1 output);
+function getBytes1(bytes32 data, uint256 start) internal pure returns (bytes1 output);
 ```
 
 **Parameters**
@@ -101,12 +102,12 @@ function slice1(bytes32 data, uint256 start) internal pure returns (bytes1 outpu
 | -------- | -------- | ---------------------------------------------------------------------------- |
 | `output` | `bytes1` | The extracted bytes1 value from the specified position in the bytes32 value. |
 
-#### slice2
+#### getBytes2
 
 _Extracts a 2-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice2(bytes memory data, uint256 start) internal pure returns (bytes2 output);
+function getBytes2(bytes memory data, uint256 start) internal pure returns (bytes2 output);
 ```
 
 **Parameters**
@@ -122,12 +123,12 @@ function slice2(bytes memory data, uint256 start) internal pure returns (bytes2 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes2` | The extracted bytes2 value from the specified position in the bytes blob. |
 
-#### slice2
+#### getBytes2
 
 _Extracts a 2-byte sequence from a bytes32 value starting at a specific position._
 
 ```solidity
-function slice2(bytes32 data, uint256 start) internal pure returns (bytes2 output);
+function getBytes2(bytes32 data, uint256 start) internal pure returns (bytes2 output);
 ```
 
 **Parameters**
@@ -143,12 +144,54 @@ function slice2(bytes32 data, uint256 start) internal pure returns (bytes2 outpu
 | -------- | -------- | ---------------------------------------------------------------------------- |
 | `output` | `bytes2` | The extracted bytes2 value from the specified position in the bytes32 value. |
 
-#### slice4
+#### getBytes3
+
+_Extracts a 3-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes3(bytes memory data, uint256 start) internal pure returns (bytes3 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                     |
+| ------- | --------- | --------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 3-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `output` | `bytes3` | The extracted bytes3 value from the specified position in the bytes blob. |
+
+#### getBytes3
+
+_Extracts a 3-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes3(bytes32 data, uint256 start) internal pure returns (bytes3 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 3-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes3` | The extracted bytes3 value from the specified position in the bytes32 value. |
+
+#### getBytes4
 
 _Extracts a 4-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice4(bytes memory data, uint256 start) internal pure returns (bytes4 output);
+function getBytes4(bytes memory data, uint256 start) internal pure returns (bytes4 output);
 ```
 
 **Parameters**
@@ -164,12 +207,33 @@ function slice4(bytes memory data, uint256 start) internal pure returns (bytes4 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes4` | The extracted bytes4 value from the specified position in the bytes blob. |
 
-#### slice5
+#### getBytes4
+
+_Extracts a 4-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes4(bytes32 data, uint256 start) internal pure returns (bytes4 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 4-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes4` | The extracted bytes4 value from the specified position in the bytes32 value. |
+
+#### getBytes5
 
 _Extracts a 5-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice5(bytes memory data, uint256 start) internal pure returns (bytes5 output);
+function getBytes5(bytes memory data, uint256 start) internal pure returns (bytes5 output);
 ```
 
 **Parameters**
@@ -185,12 +249,117 @@ function slice5(bytes memory data, uint256 start) internal pure returns (bytes5 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes5` | The extracted bytes5 value from the specified position in the bytes blob. |
 
-#### slice8
+#### getBytes5
+
+_Extracts a 5-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes5(bytes32 data, uint256 start) internal pure returns (bytes5 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 5-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes5` | The extracted bytes5 value from the specified position in the bytes32 value. |
+
+#### getBytes6
+
+_Extracts a 6-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes6(bytes memory data, uint256 start) internal pure returns (bytes6 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                     |
+| ------- | --------- | --------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 6-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `output` | `bytes6` | The extracted bytes6 value from the specified position in the bytes blob. |
+
+#### getBytes6
+
+_Extracts a 6-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes6(bytes32 data, uint256 start) internal pure returns (bytes6 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 6-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes6` | The extracted bytes6 value from the specified position in the bytes32 value. |
+
+#### getBytes7
+
+_Extracts a 7-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes7(bytes memory data, uint256 start) internal pure returns (bytes7 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                     |
+| ------- | --------- | --------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 7-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `output` | `bytes7` | The extracted bytes7 value from the specified position in the bytes blob. |
+
+#### getBytes7
+
+_Extracts a 7-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes7(bytes32 data, uint256 start) internal pure returns (bytes7 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 7-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes7` | The extracted bytes7 value from the specified position in the bytes32 value. |
+
+#### getBytes8
 
 _Extracts a 8-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice8(bytes memory data, uint256 start) internal pure returns (bytes8 output);
+function getBytes8(bytes memory data, uint256 start) internal pure returns (bytes8 output);
 ```
 
 **Parameters**
@@ -206,12 +375,327 @@ function slice8(bytes memory data, uint256 start) internal pure returns (bytes8 
 | -------- | -------- | ------------------------------------------------------------------------- |
 | `output` | `bytes8` | The extracted bytes8 value from the specified position in the bytes blob. |
 
-#### slice16
+#### getBytes8
+
+_Extracts a 8-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes8(bytes32 data, uint256 start) internal pure returns (bytes8 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 8-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes8` | The extracted bytes8 value from the specified position in the bytes32 value. |
+
+#### getBytes9
+
+_Extracts a 9-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes9(bytes memory data, uint256 start) internal pure returns (bytes9 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                     |
+| ------- | --------- | --------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 9-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                               |
+| -------- | -------- | ------------------------------------------------------------------------- |
+| `output` | `bytes9` | The extracted bytes9 value from the specified position in the bytes blob. |
+
+#### getBytes9
+
+_Extracts a 9-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes9(bytes32 data, uint256 start) internal pure returns (bytes9 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                        |
+| ------- | --------- | ------------------------------------------------------------------ |
+| `data`  | `bytes32` | The bytes32 value from which a 9-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.     |
+
+**Returns**
+
+| Name     | Type     | Description                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------- |
+| `output` | `bytes9` | The extracted bytes9 value from the specified position in the bytes32 value. |
+
+#### getBytes10
+
+_Extracts a 10-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes10(bytes memory data, uint256 start) internal pure returns (bytes10 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 10-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes10` | The extracted bytes10 value from the specified position in the bytes blob. |
+
+#### getBytes10
+
+_Extracts a 10-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes10(bytes32 data, uint256 start) internal pure returns (bytes10 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 10-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes10` | The extracted bytes10 value from the specified position in the bytes32 value. |
+
+#### getBytes11
+
+_Extracts a 11-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes11(bytes memory data, uint256 start) internal pure returns (bytes11 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 11-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes11` | The extracted bytes11 value from the specified position in the bytes blob. |
+
+#### getBytes11
+
+_Extracts a 11-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes11(bytes32 data, uint256 start) internal pure returns (bytes11 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 11-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes11` | The extracted bytes11 value from the specified position in the bytes32 value. |
+
+#### getBytes12
+
+_Extracts a 12-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes12(bytes memory data, uint256 start) internal pure returns (bytes12 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 12-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes12` | The extracted bytes12 value from the specified position in the bytes blob. |
+
+#### getBytes12
+
+_Extracts a 12-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes12(bytes32 data, uint256 start) internal pure returns (bytes12 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 12-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes12` | The extracted bytes12 value from the specified position in the bytes32 value. |
+
+#### getBytes13
+
+_Extracts a 13-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes13(bytes memory data, uint256 start) internal pure returns (bytes13 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 13-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes13` | The extracted bytes13 value from the specified position in the bytes blob. |
+
+#### getBytes13
+
+_Extracts a 13-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes13(bytes32 data, uint256 start) internal pure returns (bytes13 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 13-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes13` | The extracted bytes13 value from the specified position in the bytes32 value. |
+
+#### getBytes14
+
+_Extracts a 14-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes14(bytes memory data, uint256 start) internal pure returns (bytes14 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 14-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes14` | The extracted bytes14 value from the specified position in the bytes blob. |
+
+#### getBytes14
+
+_Extracts a 14-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes14(bytes32 data, uint256 start) internal pure returns (bytes14 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 14-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes14` | The extracted bytes14 value from the specified position in the bytes32 value. |
+
+#### getBytes15
+
+_Extracts a 15-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes15(bytes memory data, uint256 start) internal pure returns (bytes15 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 15-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes15` | The extracted bytes15 value from the specified position in the bytes blob. |
+
+#### getBytes15
+
+_Extracts a 15-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes15(bytes32 data, uint256 start) internal pure returns (bytes15 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 15-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes15` | The extracted bytes15 value from the specified position in the bytes32 value. |
+
+#### getBytes16
 
 _Extracts a 16-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice16(bytes memory data, uint256 start) internal pure returns (bytes16 output);
+function getBytes16(bytes memory data, uint256 start) internal pure returns (bytes16 output);
 ```
 
 **Parameters**
@@ -227,12 +711,159 @@ function slice16(bytes memory data, uint256 start) internal pure returns (bytes1
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes16` | The extracted bytes16 value from the specified position in the bytes blob. |
 
-#### slice20
+#### getBytes16
+
+_Extracts a 16-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes16(bytes32 data, uint256 start) internal pure returns (bytes16 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 16-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes16` | The extracted bytes16 value from the specified position in the bytes32 value. |
+
+#### getBytes17
+
+_Extracts a 17-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes17(bytes memory data, uint256 start) internal pure returns (bytes17 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 17-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes17` | The extracted bytes17 value from the specified position in the bytes blob. |
+
+#### getBytes17
+
+_Extracts a 17-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes17(bytes32 data, uint256 start) internal pure returns (bytes17 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 17-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes17` | The extracted bytes17 value from the specified position in the bytes32 value. |
+
+#### getBytes18
+
+_Extracts a 18-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes18(bytes memory data, uint256 start) internal pure returns (bytes18 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 18-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes18` | The extracted bytes18 value from the specified position in the bytes blob. |
+
+#### getBytes18
+
+_Extracts a 18-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes18(bytes32 data, uint256 start) internal pure returns (bytes18 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 18-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes18` | The extracted bytes18 value from the specified position in the bytes32 value. |
+
+#### getBytes19
+
+_Extracts a 19-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes19(bytes memory data, uint256 start) internal pure returns (bytes19 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 19-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes19` | The extracted bytes19 value from the specified position in the bytes blob. |
+
+#### getBytes19
+
+_Extracts a 19-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes19(bytes32 data, uint256 start) internal pure returns (bytes19 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 19-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes19` | The extracted bytes19 value from the specified position in the bytes32 value. |
+
+#### getBytes20
 
 _Extracts a 20-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice20(bytes memory data, uint256 start) internal pure returns (bytes20 output);
+function getBytes20(bytes memory data, uint256 start) internal pure returns (bytes20 output);
 ```
 
 **Parameters**
@@ -248,12 +879,495 @@ function slice20(bytes memory data, uint256 start) internal pure returns (bytes2
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes20` | The extracted bytes20 value from the specified position in the bytes blob. |
 
-#### slice32
+#### getBytes20
+
+_Extracts a 20-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes20(bytes32 data, uint256 start) internal pure returns (bytes20 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 20-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes20` | The extracted bytes20 value from the specified position in the bytes32 value. |
+
+#### getBytes21
+
+_Extracts a 21-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes21(bytes memory data, uint256 start) internal pure returns (bytes21 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 21-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes21` | The extracted bytes21 value from the specified position in the bytes blob. |
+
+#### getBytes21
+
+_Extracts a 21-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes21(bytes32 data, uint256 start) internal pure returns (bytes21 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 21-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes21` | The extracted bytes21 value from the specified position in the bytes32 value. |
+
+#### getBytes22
+
+_Extracts a 22-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes22(bytes memory data, uint256 start) internal pure returns (bytes22 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 22-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes22` | The extracted bytes22 value from the specified position in the bytes blob. |
+
+#### getBytes22
+
+_Extracts a 22-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes22(bytes32 data, uint256 start) internal pure returns (bytes22 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 22-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes22` | The extracted bytes22 value from the specified position in the bytes32 value. |
+
+#### getBytes23
+
+_Extracts a 23-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes23(bytes memory data, uint256 start) internal pure returns (bytes23 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 23-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes23` | The extracted bytes23 value from the specified position in the bytes blob. |
+
+#### getBytes23
+
+_Extracts a 23-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes23(bytes32 data, uint256 start) internal pure returns (bytes23 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 23-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes23` | The extracted bytes23 value from the specified position in the bytes32 value. |
+
+#### getBytes24
+
+_Extracts a 24-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes24(bytes memory data, uint256 start) internal pure returns (bytes24 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 24-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes24` | The extracted bytes24 value from the specified position in the bytes blob. |
+
+#### getBytes24
+
+_Extracts a 24-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes24(bytes32 data, uint256 start) internal pure returns (bytes24 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 24-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes24` | The extracted bytes24 value from the specified position in the bytes32 value. |
+
+#### getBytes25
+
+_Extracts a 25-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes25(bytes memory data, uint256 start) internal pure returns (bytes25 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 25-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes25` | The extracted bytes25 value from the specified position in the bytes blob. |
+
+#### getBytes25
+
+_Extracts a 25-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes25(bytes32 data, uint256 start) internal pure returns (bytes25 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 25-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes25` | The extracted bytes25 value from the specified position in the bytes32 value. |
+
+#### getBytes26
+
+_Extracts a 26-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes26(bytes memory data, uint256 start) internal pure returns (bytes26 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 26-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes26` | The extracted bytes26 value from the specified position in the bytes blob. |
+
+#### getBytes26
+
+_Extracts a 26-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes26(bytes32 data, uint256 start) internal pure returns (bytes26 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 26-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes26` | The extracted bytes26 value from the specified position in the bytes32 value. |
+
+#### getBytes27
+
+_Extracts a 27-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes27(bytes memory data, uint256 start) internal pure returns (bytes27 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 27-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes27` | The extracted bytes27 value from the specified position in the bytes blob. |
+
+#### getBytes27
+
+_Extracts a 27-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes27(bytes32 data, uint256 start) internal pure returns (bytes27 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 27-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes27` | The extracted bytes27 value from the specified position in the bytes32 value. |
+
+#### getBytes28
+
+_Extracts a 28-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes28(bytes memory data, uint256 start) internal pure returns (bytes28 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 28-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes28` | The extracted bytes28 value from the specified position in the bytes blob. |
+
+#### getBytes28
+
+_Extracts a 28-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes28(bytes32 data, uint256 start) internal pure returns (bytes28 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 28-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes28` | The extracted bytes28 value from the specified position in the bytes32 value. |
+
+#### getBytes29
+
+_Extracts a 29-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes29(bytes memory data, uint256 start) internal pure returns (bytes29 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 29-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes29` | The extracted bytes29 value from the specified position in the bytes blob. |
+
+#### getBytes29
+
+_Extracts a 29-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes29(bytes32 data, uint256 start) internal pure returns (bytes29 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 29-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes29` | The extracted bytes29 value from the specified position in the bytes32 value. |
+
+#### getBytes30
+
+_Extracts a 30-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes30(bytes memory data, uint256 start) internal pure returns (bytes30 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 30-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes30` | The extracted bytes30 value from the specified position in the bytes blob. |
+
+#### getBytes30
+
+_Extracts a 30-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes30(bytes32 data, uint256 start) internal pure returns (bytes30 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 30-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes30` | The extracted bytes30 value from the specified position in the bytes32 value. |
+
+#### getBytes31
+
+_Extracts a 31-byte sequence from a bytes blob starting at a specific position._
+
+```solidity
+function getBytes31(bytes memory data, uint256 start) internal pure returns (bytes31 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                      |
+| ------- | --------- | ---------------------------------------------------------------- |
+| `data`  | `bytes`   | The bytes blob from which a 31-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes blob for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                |
+| -------- | --------- | -------------------------------------------------------------------------- |
+| `output` | `bytes31` | The extracted bytes31 value from the specified position in the bytes blob. |
+
+#### getBytes31
+
+_Extracts a 31-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes31(bytes32 data, uint256 start) internal pure returns (bytes31 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 31-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes31` | The extracted bytes31 value from the specified position in the bytes32 value. |
+
+#### getBytes32
 
 _Extracts a 32-byte sequence from a bytes blob starting at a specific position._
 
 ```solidity
-function slice32(bytes memory data, uint256 start) internal pure returns (bytes32 output);
+function getBytes32(bytes memory data, uint256 start) internal pure returns (bytes32 output);
 ```
 
 **Parameters**
@@ -268,6 +1382,27 @@ function slice32(bytes memory data, uint256 start) internal pure returns (bytes3
 | Name     | Type      | Description                                                                |
 | -------- | --------- | -------------------------------------------------------------------------- |
 | `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes blob. |
+
+#### getBytes32
+
+_Extracts a 32-byte sequence from a bytes32 value starting at a specific position._
+
+```solidity
+function getBytes32(bytes32 data, uint256 start) internal pure returns (bytes32 output);
+```
+
+**Parameters**
+
+| Name    | Type      | Description                                                         |
+| ------- | --------- | ------------------------------------------------------------------- |
+| `data`  | `bytes32` | The bytes32 value from which a 32-byte sequence is to be extracted. |
+| `start` | `uint256` | The starting position within the bytes32 value for extraction.      |
+
+**Returns**
+
+| Name     | Type      | Description                                                                   |
+| -------- | --------- | ----------------------------------------------------------------------------- |
+| `output` | `bytes32` | The extracted bytes32 value from the specified position in the bytes32 value. |
 
 ## FieldLayoutInstance
 

--- a/e2e/packages/contracts/src/codegen/tables/Multi.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Multi.sol
@@ -289,9 +289,9 @@ library Multi {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (int256 num, bool value) {
-    num = (int256(uint256(Bytes.slice32(_blob, 0))));
+    num = (int256(uint256(Bytes.getBytes32(_blob, 0))));
 
-    value = (_toBool(uint8(Bytes.slice1(_blob, 32))));
+    value = (_toBool(uint8(Bytes.getBytes1(_blob, 32))));
   }
 
   /**

--- a/e2e/packages/contracts/src/codegen/tables/Vector.sol
+++ b/e2e/packages/contracts/src/codegen/tables/Vector.sol
@@ -244,9 +244,9 @@ library Vector {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (int32 x, int32 y) {
-    x = (int32(uint32(Bytes.slice4(_blob, 0))));
+    x = (int32(uint32(Bytes.getBytes4(_blob, 0))));
 
-    y = (int32(uint32(Bytes.slice4(_blob, 4))));
+    y = (int32(uint32(Bytes.getBytes4(_blob, 4))));
   }
 
   /**

--- a/examples/multiple-accounts/packages/contracts/src/codegen/tables/LastCall.sol
+++ b/examples/multiple-accounts/packages/contracts/src/codegen/tables/LastCall.sol
@@ -244,9 +244,9 @@ library LastCall {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint256 callTime, address sender) {
-    callTime = (uint256(Bytes.slice32(_blob, 0)));
+    callTime = (uint256(Bytes.getBytes32(_blob, 0)));
 
-    sender = (address(Bytes.slice20(_blob, 32)));
+    sender = (address(Bytes.getBytes20(_blob, 32)));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/latticexyz/mud.git"
   },
   "scripts": {
-    "all-codegen": "for dir in packages/store packages/world packages/world-modules packages/cli e2e/packages/contracts examples/*/packages/contracts templates/*/packages/contracts; do (cd \"$dir\" && pwd && pnpm build); done",
+    "all-codegen": "for dir in packages/store packages/world packages/world-modules packages/cli test/mock-game-contracts e2e/packages/contracts examples/*/packages/contracts templates/*/packages/contracts; do (cd \"$dir\" && pwd && pnpm build); done",
     "all-install": "for dir in . docs e2e examples/* templates/*; do (cd \"$dir\" && pwd && pnpm install); done",
     "bench": "pnpm run --recursive bench",
     "build": "turbo run build",

--- a/packages/cli/contracts/src/codegen/tables/Offchain.sol
+++ b/packages/cli/contracts/src/codegen/tables/Offchain.sol
@@ -114,7 +114,7 @@ library Offchain {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint256 value) {
-    value = (uint256(Bytes.slice32(_blob, 0)));
+    value = (uint256(Bytes.getBytes32(_blob, 0)));
   }
 
   /**

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -466,7 +466,7 @@ library Singleton {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (int256 v1) {
-    v1 = (int256(uint256(Bytes.slice32(_blob, 0))));
+    v1 = (int256(uint256(Bytes.getBytes32(_blob, 0))));
   }
 
   /**

--- a/packages/cli/contracts/src/codegen/tables/Statics.sol
+++ b/packages/cli/contracts/src/codegen/tables/Statics.sol
@@ -620,17 +620,17 @@ library Statics {
   function decodeStatic(
     bytes memory _blob
   ) internal pure returns (uint256 v1, int32 v2, bytes16 v3, address v4, bool v5, Enum1 v6) {
-    v1 = (uint256(Bytes.slice32(_blob, 0)));
+    v1 = (uint256(Bytes.getBytes32(_blob, 0)));
 
-    v2 = (int32(uint32(Bytes.slice4(_blob, 32))));
+    v2 = (int32(uint32(Bytes.getBytes4(_blob, 32))));
 
-    v3 = (Bytes.slice16(_blob, 36));
+    v3 = (Bytes.getBytes16(_blob, 36));
 
-    v4 = (address(Bytes.slice20(_blob, 52)));
+    v4 = (address(Bytes.getBytes20(_blob, 52)));
 
-    v5 = (_toBool(uint8(Bytes.slice1(_blob, 72))));
+    v5 = (_toBool(uint8(Bytes.getBytes1(_blob, 72))));
 
-    v6 = Enum1(uint8(Bytes.slice1(_blob, 73)));
+    v6 = Enum1(uint8(Bytes.getBytes1(_blob, 73)));
   }
 
   /**

--- a/packages/cli/contracts/src/codegen/tables/UserTyped.sol
+++ b/packages/cli/contracts/src/codegen/tables/UserTyped.sol
@@ -702,15 +702,15 @@ library UserTyped {
       ResourceId v5
     )
   {
-    v1 = TestTypeAddress.wrap(address(Bytes.slice20(_blob, 0)));
+    v1 = TestTypeAddress.wrap(address(Bytes.getBytes20(_blob, 0)));
 
-    v2 = TestTypeInt64.wrap(int64(uint64(Bytes.slice8(_blob, 20))));
+    v2 = TestTypeInt64.wrap(int64(uint64(Bytes.getBytes8(_blob, 20))));
 
-    v3 = TestTypeLibrary.TestTypeBool.wrap(_toBool(uint8(Bytes.slice1(_blob, 28))));
+    v3 = TestTypeLibrary.TestTypeBool.wrap(_toBool(uint8(Bytes.getBytes1(_blob, 28))));
 
-    v4 = TestTypeLibrary.TestTypeUint128.wrap(uint128(Bytes.slice16(_blob, 29)));
+    v4 = TestTypeLibrary.TestTypeUint128.wrap(uint128(Bytes.getBytes16(_blob, 29)));
 
-    v5 = ResourceId.wrap(Bytes.slice32(_blob, 45));
+    v5 = ResourceId.wrap(Bytes.getBytes32(_blob, 45));
   }
 
   /**

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -1,15 +1,21 @@
 [
   {
     "file": "test/Bytes.t.sol",
-    "test": "testSetBytes4Memory",
-    "name": "set bytes4 in bytes memory",
-    "gasUsed": 37
+    "test": "testGetBytes3",
+    "name": "get bytes3 with offset 1",
+    "gasUsed": 13
   },
   {
     "file": "test/Bytes.t.sol",
-    "test": "testSlice32",
-    "name": "slice bytes32 with offset 10",
+    "test": "testGetBytes32",
+    "name": "get bytes32 with offset 10",
     "gasUsed": 13
+  },
+  {
+    "file": "test/Bytes.t.sol",
+    "test": "testSetBytes4Memory",
+    "name": "set bytes4 in bytes memory",
+    "gasUsed": 37
   },
   {
     "file": "test/Callbacks.t.sol",

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -54,7 +54,9 @@ library Bytes {
 
   /************************************************************************
    *
-   *    SLICE
+   *    GET
+   *
+   *    Used by codegen libraries
    *
    ************************************************************************/
 
@@ -64,7 +66,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes1 value from the specified position in the bytes blob.
    */
-  function slice1(bytes memory data, uint256 start) internal pure returns (bytes1 output) {
+  function getBytes1(bytes memory data, uint256 start) internal pure returns (bytes1 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -76,7 +78,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes1 value from the specified position in the bytes32 value.
    */
-  function slice1(bytes32 data, uint256 start) internal pure returns (bytes1 output) {
+  function getBytes1(bytes32 data, uint256 start) internal pure returns (bytes1 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -88,7 +90,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes2 value from the specified position in the bytes blob.
    */
-  function slice2(bytes memory data, uint256 start) internal pure returns (bytes2 output) {
+  function getBytes2(bytes memory data, uint256 start) internal pure returns (bytes2 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -100,7 +102,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes2 value from the specified position in the bytes32 value.
    */
-  function slice2(bytes32 data, uint256 start) internal pure returns (bytes2 output) {
+  function getBytes2(bytes32 data, uint256 start) internal pure returns (bytes2 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -112,7 +114,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes3 value from the specified position in the bytes blob.
    */
-  function slice3(bytes memory data, uint256 start) internal pure returns (bytes3 output) {
+  function getBytes3(bytes memory data, uint256 start) internal pure returns (bytes3 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -124,7 +126,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes3 value from the specified position in the bytes32 value.
    */
-  function slice3(bytes32 data, uint256 start) internal pure returns (bytes3 output) {
+  function getBytes3(bytes32 data, uint256 start) internal pure returns (bytes3 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -136,7 +138,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes4 value from the specified position in the bytes blob.
    */
-  function slice4(bytes memory data, uint256 start) internal pure returns (bytes4 output) {
+  function getBytes4(bytes memory data, uint256 start) internal pure returns (bytes4 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -148,7 +150,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes4 value from the specified position in the bytes32 value.
    */
-  function slice4(bytes32 data, uint256 start) internal pure returns (bytes4 output) {
+  function getBytes4(bytes32 data, uint256 start) internal pure returns (bytes4 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -160,7 +162,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes5 value from the specified position in the bytes blob.
    */
-  function slice5(bytes memory data, uint256 start) internal pure returns (bytes5 output) {
+  function getBytes5(bytes memory data, uint256 start) internal pure returns (bytes5 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -172,7 +174,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes5 value from the specified position in the bytes32 value.
    */
-  function slice5(bytes32 data, uint256 start) internal pure returns (bytes5 output) {
+  function getBytes5(bytes32 data, uint256 start) internal pure returns (bytes5 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -184,7 +186,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes6 value from the specified position in the bytes blob.
    */
-  function slice6(bytes memory data, uint256 start) internal pure returns (bytes6 output) {
+  function getBytes6(bytes memory data, uint256 start) internal pure returns (bytes6 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -196,7 +198,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes6 value from the specified position in the bytes32 value.
    */
-  function slice6(bytes32 data, uint256 start) internal pure returns (bytes6 output) {
+  function getBytes6(bytes32 data, uint256 start) internal pure returns (bytes6 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -208,7 +210,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes7 value from the specified position in the bytes blob.
    */
-  function slice7(bytes memory data, uint256 start) internal pure returns (bytes7 output) {
+  function getBytes7(bytes memory data, uint256 start) internal pure returns (bytes7 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -220,7 +222,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes7 value from the specified position in the bytes32 value.
    */
-  function slice7(bytes32 data, uint256 start) internal pure returns (bytes7 output) {
+  function getBytes7(bytes32 data, uint256 start) internal pure returns (bytes7 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -232,7 +234,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes8 value from the specified position in the bytes blob.
    */
-  function slice8(bytes memory data, uint256 start) internal pure returns (bytes8 output) {
+  function getBytes8(bytes memory data, uint256 start) internal pure returns (bytes8 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -244,7 +246,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes8 value from the specified position in the bytes32 value.
    */
-  function slice8(bytes32 data, uint256 start) internal pure returns (bytes8 output) {
+  function getBytes8(bytes32 data, uint256 start) internal pure returns (bytes8 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -256,7 +258,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes9 value from the specified position in the bytes blob.
    */
-  function slice9(bytes memory data, uint256 start) internal pure returns (bytes9 output) {
+  function getBytes9(bytes memory data, uint256 start) internal pure returns (bytes9 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -268,7 +270,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes9 value from the specified position in the bytes32 value.
    */
-  function slice9(bytes32 data, uint256 start) internal pure returns (bytes9 output) {
+  function getBytes9(bytes32 data, uint256 start) internal pure returns (bytes9 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -280,7 +282,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes10 value from the specified position in the bytes blob.
    */
-  function slice10(bytes memory data, uint256 start) internal pure returns (bytes10 output) {
+  function getBytes10(bytes memory data, uint256 start) internal pure returns (bytes10 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -292,7 +294,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes10 value from the specified position in the bytes32 value.
    */
-  function slice10(bytes32 data, uint256 start) internal pure returns (bytes10 output) {
+  function getBytes10(bytes32 data, uint256 start) internal pure returns (bytes10 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -304,7 +306,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes11 value from the specified position in the bytes blob.
    */
-  function slice11(bytes memory data, uint256 start) internal pure returns (bytes11 output) {
+  function getBytes11(bytes memory data, uint256 start) internal pure returns (bytes11 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -316,7 +318,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes11 value from the specified position in the bytes32 value.
    */
-  function slice11(bytes32 data, uint256 start) internal pure returns (bytes11 output) {
+  function getBytes11(bytes32 data, uint256 start) internal pure returns (bytes11 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -328,7 +330,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes12 value from the specified position in the bytes blob.
    */
-  function slice12(bytes memory data, uint256 start) internal pure returns (bytes12 output) {
+  function getBytes12(bytes memory data, uint256 start) internal pure returns (bytes12 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -340,7 +342,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes12 value from the specified position in the bytes32 value.
    */
-  function slice12(bytes32 data, uint256 start) internal pure returns (bytes12 output) {
+  function getBytes12(bytes32 data, uint256 start) internal pure returns (bytes12 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -352,7 +354,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes13 value from the specified position in the bytes blob.
    */
-  function slice13(bytes memory data, uint256 start) internal pure returns (bytes13 output) {
+  function getBytes13(bytes memory data, uint256 start) internal pure returns (bytes13 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -364,7 +366,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes13 value from the specified position in the bytes32 value.
    */
-  function slice13(bytes32 data, uint256 start) internal pure returns (bytes13 output) {
+  function getBytes13(bytes32 data, uint256 start) internal pure returns (bytes13 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -376,7 +378,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes14 value from the specified position in the bytes blob.
    */
-  function slice14(bytes memory data, uint256 start) internal pure returns (bytes14 output) {
+  function getBytes14(bytes memory data, uint256 start) internal pure returns (bytes14 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -388,7 +390,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes14 value from the specified position in the bytes32 value.
    */
-  function slice14(bytes32 data, uint256 start) internal pure returns (bytes14 output) {
+  function getBytes14(bytes32 data, uint256 start) internal pure returns (bytes14 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -400,7 +402,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes15 value from the specified position in the bytes blob.
    */
-  function slice15(bytes memory data, uint256 start) internal pure returns (bytes15 output) {
+  function getBytes15(bytes memory data, uint256 start) internal pure returns (bytes15 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -412,7 +414,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes15 value from the specified position in the bytes32 value.
    */
-  function slice15(bytes32 data, uint256 start) internal pure returns (bytes15 output) {
+  function getBytes15(bytes32 data, uint256 start) internal pure returns (bytes15 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -424,7 +426,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes16 value from the specified position in the bytes blob.
    */
-  function slice16(bytes memory data, uint256 start) internal pure returns (bytes16 output) {
+  function getBytes16(bytes memory data, uint256 start) internal pure returns (bytes16 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -436,7 +438,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes16 value from the specified position in the bytes32 value.
    */
-  function slice16(bytes32 data, uint256 start) internal pure returns (bytes16 output) {
+  function getBytes16(bytes32 data, uint256 start) internal pure returns (bytes16 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -448,7 +450,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes17 value from the specified position in the bytes blob.
    */
-  function slice17(bytes memory data, uint256 start) internal pure returns (bytes17 output) {
+  function getBytes17(bytes memory data, uint256 start) internal pure returns (bytes17 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -460,7 +462,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes17 value from the specified position in the bytes32 value.
    */
-  function slice17(bytes32 data, uint256 start) internal pure returns (bytes17 output) {
+  function getBytes17(bytes32 data, uint256 start) internal pure returns (bytes17 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -472,7 +474,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes18 value from the specified position in the bytes blob.
    */
-  function slice18(bytes memory data, uint256 start) internal pure returns (bytes18 output) {
+  function getBytes18(bytes memory data, uint256 start) internal pure returns (bytes18 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -484,7 +486,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes18 value from the specified position in the bytes32 value.
    */
-  function slice18(bytes32 data, uint256 start) internal pure returns (bytes18 output) {
+  function getBytes18(bytes32 data, uint256 start) internal pure returns (bytes18 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -496,7 +498,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes19 value from the specified position in the bytes blob.
    */
-  function slice19(bytes memory data, uint256 start) internal pure returns (bytes19 output) {
+  function getBytes19(bytes memory data, uint256 start) internal pure returns (bytes19 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -508,7 +510,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes19 value from the specified position in the bytes32 value.
    */
-  function slice19(bytes32 data, uint256 start) internal pure returns (bytes19 output) {
+  function getBytes19(bytes32 data, uint256 start) internal pure returns (bytes19 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -520,7 +522,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes20 value from the specified position in the bytes blob.
    */
-  function slice20(bytes memory data, uint256 start) internal pure returns (bytes20 output) {
+  function getBytes20(bytes memory data, uint256 start) internal pure returns (bytes20 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -532,7 +534,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes20 value from the specified position in the bytes32 value.
    */
-  function slice20(bytes32 data, uint256 start) internal pure returns (bytes20 output) {
+  function getBytes20(bytes32 data, uint256 start) internal pure returns (bytes20 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -544,7 +546,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes21 value from the specified position in the bytes blob.
    */
-  function slice21(bytes memory data, uint256 start) internal pure returns (bytes21 output) {
+  function getBytes21(bytes memory data, uint256 start) internal pure returns (bytes21 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -556,7 +558,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes21 value from the specified position in the bytes32 value.
    */
-  function slice21(bytes32 data, uint256 start) internal pure returns (bytes21 output) {
+  function getBytes21(bytes32 data, uint256 start) internal pure returns (bytes21 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -568,7 +570,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes22 value from the specified position in the bytes blob.
    */
-  function slice22(bytes memory data, uint256 start) internal pure returns (bytes22 output) {
+  function getBytes22(bytes memory data, uint256 start) internal pure returns (bytes22 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -580,7 +582,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes22 value from the specified position in the bytes32 value.
    */
-  function slice22(bytes32 data, uint256 start) internal pure returns (bytes22 output) {
+  function getBytes22(bytes32 data, uint256 start) internal pure returns (bytes22 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -592,7 +594,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes23 value from the specified position in the bytes blob.
    */
-  function slice23(bytes memory data, uint256 start) internal pure returns (bytes23 output) {
+  function getBytes23(bytes memory data, uint256 start) internal pure returns (bytes23 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -604,7 +606,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes23 value from the specified position in the bytes32 value.
    */
-  function slice23(bytes32 data, uint256 start) internal pure returns (bytes23 output) {
+  function getBytes23(bytes32 data, uint256 start) internal pure returns (bytes23 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -616,7 +618,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes24 value from the specified position in the bytes blob.
    */
-  function slice24(bytes memory data, uint256 start) internal pure returns (bytes24 output) {
+  function getBytes24(bytes memory data, uint256 start) internal pure returns (bytes24 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -628,7 +630,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes24 value from the specified position in the bytes32 value.
    */
-  function slice24(bytes32 data, uint256 start) internal pure returns (bytes24 output) {
+  function getBytes24(bytes32 data, uint256 start) internal pure returns (bytes24 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -640,7 +642,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes25 value from the specified position in the bytes blob.
    */
-  function slice25(bytes memory data, uint256 start) internal pure returns (bytes25 output) {
+  function getBytes25(bytes memory data, uint256 start) internal pure returns (bytes25 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -652,7 +654,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes25 value from the specified position in the bytes32 value.
    */
-  function slice25(bytes32 data, uint256 start) internal pure returns (bytes25 output) {
+  function getBytes25(bytes32 data, uint256 start) internal pure returns (bytes25 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -664,7 +666,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes26 value from the specified position in the bytes blob.
    */
-  function slice26(bytes memory data, uint256 start) internal pure returns (bytes26 output) {
+  function getBytes26(bytes memory data, uint256 start) internal pure returns (bytes26 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -676,7 +678,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes26 value from the specified position in the bytes32 value.
    */
-  function slice26(bytes32 data, uint256 start) internal pure returns (bytes26 output) {
+  function getBytes26(bytes32 data, uint256 start) internal pure returns (bytes26 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -688,7 +690,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes27 value from the specified position in the bytes blob.
    */
-  function slice27(bytes memory data, uint256 start) internal pure returns (bytes27 output) {
+  function getBytes27(bytes memory data, uint256 start) internal pure returns (bytes27 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -700,7 +702,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes27 value from the specified position in the bytes32 value.
    */
-  function slice27(bytes32 data, uint256 start) internal pure returns (bytes27 output) {
+  function getBytes27(bytes32 data, uint256 start) internal pure returns (bytes27 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -712,7 +714,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes28 value from the specified position in the bytes blob.
    */
-  function slice28(bytes memory data, uint256 start) internal pure returns (bytes28 output) {
+  function getBytes28(bytes memory data, uint256 start) internal pure returns (bytes28 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -724,7 +726,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes28 value from the specified position in the bytes32 value.
    */
-  function slice28(bytes32 data, uint256 start) internal pure returns (bytes28 output) {
+  function getBytes28(bytes32 data, uint256 start) internal pure returns (bytes28 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -736,7 +738,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes29 value from the specified position in the bytes blob.
    */
-  function slice29(bytes memory data, uint256 start) internal pure returns (bytes29 output) {
+  function getBytes29(bytes memory data, uint256 start) internal pure returns (bytes29 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -748,7 +750,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes29 value from the specified position in the bytes32 value.
    */
-  function slice29(bytes32 data, uint256 start) internal pure returns (bytes29 output) {
+  function getBytes29(bytes32 data, uint256 start) internal pure returns (bytes29 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -760,7 +762,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes30 value from the specified position in the bytes blob.
    */
-  function slice30(bytes memory data, uint256 start) internal pure returns (bytes30 output) {
+  function getBytes30(bytes memory data, uint256 start) internal pure returns (bytes30 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -772,7 +774,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes30 value from the specified position in the bytes32 value.
    */
-  function slice30(bytes32 data, uint256 start) internal pure returns (bytes30 output) {
+  function getBytes30(bytes32 data, uint256 start) internal pure returns (bytes30 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -784,7 +786,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes31 value from the specified position in the bytes blob.
    */
-  function slice31(bytes memory data, uint256 start) internal pure returns (bytes31 output) {
+  function getBytes31(bytes memory data, uint256 start) internal pure returns (bytes31 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -796,7 +798,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes31 value from the specified position in the bytes32 value.
    */
-  function slice31(bytes32 data, uint256 start) internal pure returns (bytes31 output) {
+  function getBytes31(bytes32 data, uint256 start) internal pure returns (bytes31 output) {
     assembly {
       output := shl(mul(8, start), data)
     }
@@ -808,7 +810,7 @@ library Bytes {
    * @param start The starting position within the bytes blob for extraction.
    * @return output The extracted bytes32 value from the specified position in the bytes blob.
    */
-  function slice32(bytes memory data, uint256 start) internal pure returns (bytes32 output) {
+  function getBytes32(bytes memory data, uint256 start) internal pure returns (bytes32 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
     }
@@ -820,7 +822,7 @@ library Bytes {
    * @param start The starting position within the bytes32 value for extraction.
    * @return output The extracted bytes32 value from the specified position in the bytes32 value.
    */
-  function slice32(bytes32 data, uint256 start) internal pure returns (bytes32 output) {
+  function getBytes32(bytes32 data, uint256 start) internal pure returns (bytes32 output) {
     assembly {
       output := shl(mul(8, start), data)
     }

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -155,6 +155,18 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 12-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 12-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes12 value from the specified position in the bytes blob.
+   */
+  function slice12(bytes memory data, uint256 start) internal pure returns (bytes12 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
    * @dev Extracts a 20-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 20-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.

--- a/packages/store/src/Bytes.sol
+++ b/packages/store/src/Bytes.sol
@@ -107,6 +107,30 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 3-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 3-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes3 value from the specified position in the bytes blob.
+   */
+  function slice3(bytes memory data, uint256 start) internal pure returns (bytes3 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 3-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 3-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes3 value from the specified position in the bytes32 value.
+   */
+  function slice3(bytes32 data, uint256 start) internal pure returns (bytes3 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
    * @dev Extracts a 4-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 4-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.
@@ -115,6 +139,18 @@ library Bytes {
   function slice4(bytes memory data, uint256 start) internal pure returns (bytes4 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 4-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 4-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes4 value from the specified position in the bytes32 value.
+   */
+  function slice4(bytes32 data, uint256 start) internal pure returns (bytes4 output) {
+    assembly {
+      output := shl(mul(8, start), data)
     }
   }
 
@@ -131,6 +167,66 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 5-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 5-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes5 value from the specified position in the bytes32 value.
+   */
+  function slice5(bytes32 data, uint256 start) internal pure returns (bytes5 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 6-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 6-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes6 value from the specified position in the bytes blob.
+   */
+  function slice6(bytes memory data, uint256 start) internal pure returns (bytes6 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 6-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 6-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes6 value from the specified position in the bytes32 value.
+   */
+  function slice6(bytes32 data, uint256 start) internal pure returns (bytes6 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 7-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 7-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes7 value from the specified position in the bytes blob.
+   */
+  function slice7(bytes memory data, uint256 start) internal pure returns (bytes7 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 7-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 7-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes7 value from the specified position in the bytes32 value.
+   */
+  function slice7(bytes32 data, uint256 start) internal pure returns (bytes7 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
    * @dev Extracts a 8-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 8-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.
@@ -143,14 +239,86 @@ library Bytes {
   }
 
   /**
-   * @dev Extracts a 16-byte sequence from a bytes blob starting at a specific position.
-   * @param data The bytes blob from which a 16-byte sequence is to be extracted.
-   * @param start The starting position within the bytes blob for extraction.
-   * @return output The extracted bytes16 value from the specified position in the bytes blob.
+   * @dev Extracts a 8-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 8-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes8 value from the specified position in the bytes32 value.
    */
-  function slice16(bytes memory data, uint256 start) internal pure returns (bytes16 output) {
+  function slice8(bytes32 data, uint256 start) internal pure returns (bytes8 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 9-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 9-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes9 value from the specified position in the bytes blob.
+   */
+  function slice9(bytes memory data, uint256 start) internal pure returns (bytes9 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 9-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 9-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes9 value from the specified position in the bytes32 value.
+   */
+  function slice9(bytes32 data, uint256 start) internal pure returns (bytes9 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 10-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 10-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes10 value from the specified position in the bytes blob.
+   */
+  function slice10(bytes memory data, uint256 start) internal pure returns (bytes10 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 10-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 10-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes10 value from the specified position in the bytes32 value.
+   */
+  function slice10(bytes32 data, uint256 start) internal pure returns (bytes10 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 11-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 11-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes11 value from the specified position in the bytes blob.
+   */
+  function slice11(bytes memory data, uint256 start) internal pure returns (bytes11 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 11-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 11-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes11 value from the specified position in the bytes32 value.
+   */
+  function slice11(bytes32 data, uint256 start) internal pure returns (bytes11 output) {
+    assembly {
+      output := shl(mul(8, start), data)
     }
   }
 
@@ -167,6 +335,186 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 12-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 12-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes12 value from the specified position in the bytes32 value.
+   */
+  function slice12(bytes32 data, uint256 start) internal pure returns (bytes12 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 13-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 13-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes13 value from the specified position in the bytes blob.
+   */
+  function slice13(bytes memory data, uint256 start) internal pure returns (bytes13 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 13-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 13-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes13 value from the specified position in the bytes32 value.
+   */
+  function slice13(bytes32 data, uint256 start) internal pure returns (bytes13 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 14-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 14-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes14 value from the specified position in the bytes blob.
+   */
+  function slice14(bytes memory data, uint256 start) internal pure returns (bytes14 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 14-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 14-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes14 value from the specified position in the bytes32 value.
+   */
+  function slice14(bytes32 data, uint256 start) internal pure returns (bytes14 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 15-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 15-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes15 value from the specified position in the bytes blob.
+   */
+  function slice15(bytes memory data, uint256 start) internal pure returns (bytes15 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 15-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 15-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes15 value from the specified position in the bytes32 value.
+   */
+  function slice15(bytes32 data, uint256 start) internal pure returns (bytes15 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 16-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 16-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes16 value from the specified position in the bytes blob.
+   */
+  function slice16(bytes memory data, uint256 start) internal pure returns (bytes16 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 16-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 16-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes16 value from the specified position in the bytes32 value.
+   */
+  function slice16(bytes32 data, uint256 start) internal pure returns (bytes16 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 17-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 17-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes17 value from the specified position in the bytes blob.
+   */
+  function slice17(bytes memory data, uint256 start) internal pure returns (bytes17 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 17-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 17-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes17 value from the specified position in the bytes32 value.
+   */
+  function slice17(bytes32 data, uint256 start) internal pure returns (bytes17 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 18-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 18-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes18 value from the specified position in the bytes blob.
+   */
+  function slice18(bytes memory data, uint256 start) internal pure returns (bytes18 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 18-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 18-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes18 value from the specified position in the bytes32 value.
+   */
+  function slice18(bytes32 data, uint256 start) internal pure returns (bytes18 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 19-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 19-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes19 value from the specified position in the bytes blob.
+   */
+  function slice19(bytes memory data, uint256 start) internal pure returns (bytes19 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 19-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 19-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes19 value from the specified position in the bytes32 value.
+   */
+  function slice19(bytes32 data, uint256 start) internal pure returns (bytes19 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
    * @dev Extracts a 20-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 20-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.
@@ -179,6 +527,282 @@ library Bytes {
   }
 
   /**
+   * @dev Extracts a 20-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 20-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes20 value from the specified position in the bytes32 value.
+   */
+  function slice20(bytes32 data, uint256 start) internal pure returns (bytes20 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 21-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 21-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes21 value from the specified position in the bytes blob.
+   */
+  function slice21(bytes memory data, uint256 start) internal pure returns (bytes21 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 21-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 21-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes21 value from the specified position in the bytes32 value.
+   */
+  function slice21(bytes32 data, uint256 start) internal pure returns (bytes21 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 22-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 22-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes22 value from the specified position in the bytes blob.
+   */
+  function slice22(bytes memory data, uint256 start) internal pure returns (bytes22 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 22-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 22-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes22 value from the specified position in the bytes32 value.
+   */
+  function slice22(bytes32 data, uint256 start) internal pure returns (bytes22 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 23-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 23-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes23 value from the specified position in the bytes blob.
+   */
+  function slice23(bytes memory data, uint256 start) internal pure returns (bytes23 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 23-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 23-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes23 value from the specified position in the bytes32 value.
+   */
+  function slice23(bytes32 data, uint256 start) internal pure returns (bytes23 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 24-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 24-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes24 value from the specified position in the bytes blob.
+   */
+  function slice24(bytes memory data, uint256 start) internal pure returns (bytes24 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 24-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 24-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes24 value from the specified position in the bytes32 value.
+   */
+  function slice24(bytes32 data, uint256 start) internal pure returns (bytes24 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 25-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 25-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes25 value from the specified position in the bytes blob.
+   */
+  function slice25(bytes memory data, uint256 start) internal pure returns (bytes25 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 25-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 25-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes25 value from the specified position in the bytes32 value.
+   */
+  function slice25(bytes32 data, uint256 start) internal pure returns (bytes25 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 26-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 26-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes26 value from the specified position in the bytes blob.
+   */
+  function slice26(bytes memory data, uint256 start) internal pure returns (bytes26 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 26-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 26-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes26 value from the specified position in the bytes32 value.
+   */
+  function slice26(bytes32 data, uint256 start) internal pure returns (bytes26 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 27-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 27-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes27 value from the specified position in the bytes blob.
+   */
+  function slice27(bytes memory data, uint256 start) internal pure returns (bytes27 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 27-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 27-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes27 value from the specified position in the bytes32 value.
+   */
+  function slice27(bytes32 data, uint256 start) internal pure returns (bytes27 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 28-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 28-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes28 value from the specified position in the bytes blob.
+   */
+  function slice28(bytes memory data, uint256 start) internal pure returns (bytes28 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 28-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 28-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes28 value from the specified position in the bytes32 value.
+   */
+  function slice28(bytes32 data, uint256 start) internal pure returns (bytes28 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 29-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 29-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes29 value from the specified position in the bytes blob.
+   */
+  function slice29(bytes memory data, uint256 start) internal pure returns (bytes29 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 29-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 29-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes29 value from the specified position in the bytes32 value.
+   */
+  function slice29(bytes32 data, uint256 start) internal pure returns (bytes29 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 30-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 30-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes30 value from the specified position in the bytes blob.
+   */
+  function slice30(bytes memory data, uint256 start) internal pure returns (bytes30 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 30-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 30-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes30 value from the specified position in the bytes32 value.
+   */
+  function slice30(bytes32 data, uint256 start) internal pure returns (bytes30 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
+   * @dev Extracts a 31-byte sequence from a bytes blob starting at a specific position.
+   * @param data The bytes blob from which a 31-byte sequence is to be extracted.
+   * @param start The starting position within the bytes blob for extraction.
+   * @return output The extracted bytes31 value from the specified position in the bytes blob.
+   */
+  function slice31(bytes memory data, uint256 start) internal pure returns (bytes31 output) {
+    assembly {
+      output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 31-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 31-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes31 value from the specified position in the bytes32 value.
+   */
+  function slice31(bytes32 data, uint256 start) internal pure returns (bytes31 output) {
+    assembly {
+      output := shl(mul(8, start), data)
+    }
+  }
+
+  /**
    * @dev Extracts a 32-byte sequence from a bytes blob starting at a specific position.
    * @param data The bytes blob from which a 32-byte sequence is to be extracted.
    * @param start The starting position within the bytes blob for extraction.
@@ -187,6 +811,18 @@ library Bytes {
   function slice32(bytes memory data, uint256 start) internal pure returns (bytes32 output) {
     assembly {
       output := mload(add(add(data, 0x20), start))
+    }
+  }
+
+  /**
+   * @dev Extracts a 32-byte sequence from a bytes32 value starting at a specific position.
+   * @param data The bytes32 value from which a 32-byte sequence is to be extracted.
+   * @param start The starting position within the bytes32 value for extraction.
+   * @return output The extracted bytes32 value from the specified position in the bytes32 value.
+   */
+  function slice32(bytes32 data, uint256 start) internal pure returns (bytes32 output) {
+    assembly {
+      output := shl(mul(8, start), data)
     }
   }
 }

--- a/packages/store/src/codegen/tables/Tables.sol
+++ b/packages/store/src/codegen/tables/Tables.sol
@@ -637,11 +637,11 @@ library Tables {
   function decodeStatic(
     bytes memory _blob
   ) internal pure returns (FieldLayout fieldLayout, Schema keySchema, Schema valueSchema) {
-    fieldLayout = FieldLayout.wrap(Bytes.slice32(_blob, 0));
+    fieldLayout = FieldLayout.wrap(Bytes.getBytes32(_blob, 0));
 
-    keySchema = Schema.wrap(Bytes.slice32(_blob, 32));
+    keySchema = Schema.wrap(Bytes.getBytes32(_blob, 32));
 
-    valueSchema = Schema.wrap(Bytes.slice32(_blob, 64));
+    valueSchema = Schema.wrap(Bytes.getBytes32(_blob, 64));
   }
 
   /**

--- a/packages/store/test/Bytes.t.sol
+++ b/packages/store/test/Bytes.t.sol
@@ -6,14 +6,32 @@ import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
 import { Bytes } from "../src/Bytes.sol";
 
 contract BytesTest is Test, GasReporter {
-  // TODO: add tests for other sliceX functions
+  // TODO: add tests for other getBytesX functions
 
-  function testSlice32() public {
+  function testGetBytes3() public {
+    bytes memory a = new bytes(5);
+    a[0] = 0x01;
+    a[1] = 0x02;
+    a[2] = 0x03;
+    a[3] = 0x04;
+    a[4] = 0x05;
+
+    startGasReport("get bytes3 with offset 1");
+    bytes3 b = Bytes.getBytes3(a, 1);
+    endGasReport();
+
+    assertEq(b.length, 3);
+    assertEq(uint256(uint8(b[0])), 0x02);
+    assertEq(uint256(uint8(b[1])), 0x03);
+    assertEq(uint256(uint8(b[2])), 0x04);
+  }
+
+  function testGetBytes32() public {
     bytes32 original = keccak256("some data");
     bytes memory input = abi.encodePacked(bytes10(keccak256("irrelevant data")), original);
 
-    startGasReport("slice bytes32 with offset 10");
-    bytes32 output = Bytes.slice32(input, 10);
+    startGasReport("get bytes32 with offset 10");
+    bytes32 output = Bytes.getBytes32(input, 10);
     endGasReport();
 
     assertEq(output, original);

--- a/packages/store/test/Storage.t.sol
+++ b/packages/store/test/Storage.t.sol
@@ -62,9 +62,9 @@ contract StorageTest is Test, GasReporter {
     bytes memory data = Storage.load({ storagePointer: storagePointer, offset: 31, length: 34 });
     endGasReport();
 
-    assertEq(Bytes.slice1(data, 0), bytes1(0x01));
-    assertEq(Bytes.slice32(data, 1), bytes32(0x0200000000000000000000000000000000000000000000000000000000000003));
-    assertEq(Bytes.slice1(data, 33), bytes1(0x04));
+    assertEq(Bytes.getBytes1(data, 0), bytes1(0x01));
+    assertEq(Bytes.getBytes32(data, 1), bytes32(0x0200000000000000000000000000000000000000000000000000000000000003));
+    assertEq(Bytes.getBytes1(data, 33), bytes1(0x04));
     assertEq(keccak256(data), keccak256(data1));
   }
 

--- a/packages/store/test/StoreCore.t.sol
+++ b/packages/store/test/StoreCore.t.sol
@@ -514,8 +514,8 @@ contract StoreCoreTest is Test, StoreMock {
       .getRecord(_data.tableId, keyTuple, _data.fieldLayout);
     assertEq(IStore(this).getFieldLayout(_data.tableId).staticDataLength(), 48);
     assertEq(IStore(this).getValueSchema(_data.tableId).staticDataLength(), 48);
-    assertEq(Bytes.slice16(loadedStaticData, 0), _data.firstDataBytes);
-    assertEq(Bytes.slice32(loadedStaticData, 16), _data.secondDataBytes);
+    assertEq(Bytes.getBytes16(loadedStaticData, 0), _data.firstDataBytes);
+    assertEq(Bytes.getBytes32(loadedStaticData, 16), _data.secondDataBytes);
     assertEq(
       keccak256(SliceLib.getSubslice(loadedStaticData, 0, 48).toBytes()),
       keccak256(abi.encodePacked(_data.firstDataBytes, _data.secondDataBytes))

--- a/packages/store/test/codegen/tables/Mixed.sol
+++ b/packages/store/test/codegen/tables/Mixed.sol
@@ -572,9 +572,9 @@ library Mixed {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint32 u32, uint128 u128) {
-    u32 = (uint32(Bytes.slice4(_blob, 0)));
+    u32 = (uint32(Bytes.getBytes4(_blob, 0)));
 
-    u128 = (uint128(Bytes.slice16(_blob, 4)));
+    u128 = (uint128(Bytes.getBytes16(_blob, 4)));
   }
 
   /**

--- a/packages/store/test/codegen/tables/Vector2.sol
+++ b/packages/store/test/codegen/tables/Vector2.sol
@@ -244,9 +244,9 @@ library Vector2 {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint32 x, uint32 y) {
-    x = (uint32(Bytes.slice4(_blob, 0)));
+    x = (uint32(Bytes.getBytes4(_blob, 0)));
 
-    y = (uint32(Bytes.slice4(_blob, 4)));
+    y = (uint32(Bytes.getBytes4(_blob, 4)));
   }
 
   /**

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -266,7 +266,7 @@ export function renderEncodeFieldSingle(field: RenderField) {
 export function renderDecodeValueType(field: RenderType, offset: number) {
   const { staticByteLength } = field;
 
-  const innerSlice = `Bytes.slice${staticByteLength}(_blob, ${offset})`;
+  const innerSlice = `Bytes.getBytes${staticByteLength}(_blob, ${offset})`;
 
   return renderCastStaticBytesToType(field, innerSlice);
 }

--- a/packages/world-modules/src/modules/erc20-puppet/tables/ERC20Metadata.sol
+++ b/packages/world-modules/src/modules/erc20-puppet/tables/ERC20Metadata.sol
@@ -486,7 +486,7 @@ library ERC20Metadata {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint8 decimals) {
-    decimals = (uint8(Bytes.slice1(_blob, 0)));
+    decimals = (uint8(Bytes.getBytes1(_blob, 0)));
   }
 
   /**

--- a/packages/world-modules/src/modules/keysintable/tables/UsedKeysIndex.sol
+++ b/packages/world-modules/src/modules/keysintable/tables/UsedKeysIndex.sol
@@ -314,9 +314,9 @@ library UsedKeysIndex {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (bool has, uint40 index) {
-    has = (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    has = (_toBool(uint8(Bytes.getBytes1(_blob, 0))));
 
-    index = (uint40(Bytes.slice5(_blob, 1)));
+    index = (uint40(Bytes.getBytes5(_blob, 1)));
   }
 
   /**

--- a/packages/world/src/WorldResourceId.sol
+++ b/packages/world/src/WorldResourceId.sol
@@ -49,7 +49,7 @@ library WorldResourceIdLib {
    */
   function toTrimmedString(bytes16 paddedString) internal pure returns (string memory) {
     uint256 length;
-    for (; length < 16; length++) if (Bytes.slice1(paddedString, length) == 0) break;
+    for (; length < 16; length++) if (Bytes.getBytes1(paddedString, length) == 0) break;
     bytes memory packedSelector = abi.encodePacked(paddedString);
     return string(Bytes.setLength(packedSelector, length));
   }

--- a/packages/world/src/codegen/tables/FunctionSelectors.sol
+++ b/packages/world/src/codegen/tables/FunctionSelectors.sol
@@ -220,9 +220,9 @@ library FunctionSelectors {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (ResourceId systemId, bytes4 systemFunctionSelector) {
-    systemId = ResourceId.wrap(Bytes.slice32(_blob, 0));
+    systemId = ResourceId.wrap(Bytes.getBytes32(_blob, 0));
 
-    systemFunctionSelector = (Bytes.slice4(_blob, 32));
+    systemFunctionSelector = (Bytes.getBytes4(_blob, 32));
   }
 
   /**

--- a/packages/world/src/codegen/tables/Systems.sol
+++ b/packages/world/src/codegen/tables/Systems.sol
@@ -212,9 +212,9 @@ library Systems {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (address system, bool publicAccess) {
-    system = (address(Bytes.slice20(_blob, 0)));
+    system = (address(Bytes.getBytes20(_blob, 0)));
 
-    publicAccess = (_toBool(uint8(Bytes.slice1(_blob, 20))));
+    publicAccess = (_toBool(uint8(Bytes.getBytes1(_blob, 20))));
   }
 
   /**

--- a/packages/world/src/requireValidNamespace.sol
+++ b/packages/world/src/requireValidNamespace.sol
@@ -24,12 +24,14 @@ function requireValidNamespace(ResourceId resourceId) pure {
   uint256 trimmedNamespaceLength = bytes(trimmedNamespace).length;
 
   if (trimmedNamespaceLength > 0) {
-    if (Bytes.slice1(bytes(trimmedNamespace), trimmedNamespaceLength - 1) == "_") {
+    if (Bytes.getBytes1(bytes(trimmedNamespace), trimmedNamespaceLength - 1) == "_") {
       revert IWorldErrors.World_InvalidNamespace(namespace);
     }
 
     for (uint256 i; i < trimmedNamespaceLength - 1; i++) {
-      if (Bytes.slice1(bytes(trimmedNamespace), i) == "_" && Bytes.slice1(bytes(trimmedNamespace), i + 1) == "_") {
+      if (
+        Bytes.getBytes1(bytes(trimmedNamespace), i) == "_" && Bytes.getBytes1(bytes(trimmedNamespace), i + 1) == "_"
+      ) {
         revert IWorldErrors.World_InvalidNamespace(namespace);
       }
     }

--- a/packages/world/test/codegen/tables/TwoFields.sol
+++ b/packages/world/test/codegen/tables/TwoFields.sol
@@ -226,9 +226,9 @@ library TwoFields {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (bool value1, bool value2) {
-    value1 = (_toBool(uint8(Bytes.slice1(_blob, 0))));
+    value1 = (_toBool(uint8(Bytes.getBytes1(_blob, 0))));
 
-    value2 = (_toBool(uint8(Bytes.slice1(_blob, 1))));
+    value2 = (_toBool(uint8(Bytes.getBytes1(_blob, 1))));
   }
 
   /**

--- a/templates/react/packages/contracts/src/codegen/tables/Tasks.sol
+++ b/templates/react/packages/contracts/src/codegen/tables/Tasks.sol
@@ -408,9 +408,9 @@ library Tasks {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (uint256 createdAt, uint256 completedAt) {
-    createdAt = (uint256(Bytes.slice32(_blob, 0)));
+    createdAt = (uint256(Bytes.getBytes32(_blob, 0)));
 
-    completedAt = (uint256(Bytes.slice32(_blob, 32)));
+    completedAt = (uint256(Bytes.getBytes32(_blob, 32)));
   }
 
   /**

--- a/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
+++ b/templates/threejs/packages/contracts/src/codegen/tables/Position.sol
@@ -288,11 +288,11 @@ library Position {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (int32 x, int32 y, int32 z) {
-    x = (int32(uint32(Bytes.slice4(_blob, 0))));
+    x = (int32(uint32(Bytes.getBytes4(_blob, 0))));
 
-    y = (int32(uint32(Bytes.slice4(_blob, 4))));
+    y = (int32(uint32(Bytes.getBytes4(_blob, 4))));
 
-    z = (int32(uint32(Bytes.slice4(_blob, 8))));
+    z = (int32(uint32(Bytes.getBytes4(_blob, 8))));
   }
 
   /**

--- a/test/mock-game-contracts/src/codegen/tables/Position.sol
+++ b/test/mock-game-contracts/src/codegen/tables/Position.sol
@@ -244,9 +244,9 @@ library Position {
    * @notice Decode the tightly packed blob of static data using this table's field layout.
    */
   function decodeStatic(bytes memory _blob) internal pure returns (int32 x, int32 y) {
-    x = (int32(uint32(Bytes.slice4(_blob, 0))));
+    x = (int32(uint32(Bytes.getBytes4(_blob, 0))));
 
-    y = (int32(uint32(Bytes.slice4(_blob, 4))));
+    y = (int32(uint32(Bytes.getBytes4(_blob, 4))));
   }
 
   /**


### PR DESCRIPTION
These were removed in #2090 as part of audit fixes because they appeared unused, but we missed that they are used by codegen (likely because the function signature is generated by a template string):
https://github.com/latticexyz/mud/blob/1a82c278dd8037155b6449e383b3a00d6453ea3e/packages/store/ts/codegen/field.ts#L269

Shoutout to @transmissions11 for spotting this and kicking this off in #2402

While I was here, I renamed the helpers from `Bytes.sliceN` to `Bytes.getBytesN` to both match the `Bytes.setBytesN` methods and to better differentiate this from `Slice` and `SliceLib` utils.