### PR TITLE
refactor(store): make static array length a constant

### DIFF
--- a/.changeset/sixty-queens-brake.md
+++ b/.changeset/sixty-queens-brake.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store": minor
+---
+
+Removed the parameters from static array length getters in table libraries, as they are constant.

--- a/.changeset/sixty-queens-brake.md
+++ b/.changeset/sixty-queens-brake.md
@@ -2,4 +2,4 @@
 "@latticexyz/store": minor
 ---
 
-Removed the parameters from static array length getters in table libraries, as they are constant.
+Replaced the static array length getters in table libraries with constants.

--- a/e2e/packages/contracts/src/codegen/tables/StaticArray.sol
+++ b/e2e/packages/contracts/src/codegen/tables/StaticArray.sol
@@ -135,17 +135,11 @@ library StaticArray {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint256_3(value)));
   }
 
-  // The length of value.
+  // The length of value
   uint256 constant lengthValue = 3;
 
-  // The length of value.
-  uint256 constant _lengthValue = 3;
-
-  // The length of value.
+  // The length of value
   uint256 constant length = 3;
-
-  // The length of value.
-  uint256 constant _length = 3;
 
   /**
    * @notice Get an item of value.

--- a/e2e/packages/contracts/src/codegen/tables/StaticArray.sol
+++ b/e2e/packages/contracts/src/codegen/tables/StaticArray.sol
@@ -135,33 +135,17 @@ library StaticArray {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint256_3(value)));
   }
 
-  /**
-   * @notice Get the length of value.
-   */
-  function lengthValue() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of value.
+  uint256 constant lengthValue = 3;
 
-  /**
-   * @notice Get the length of value.
-   */
-  function _lengthValue() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of value.
+  uint256 constant _lengthValue = 3;
 
-  /**
-   * @notice Get the length of value.
-   */
-  function length() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of value.
+  uint256 constant length = 3;
 
-  /**
-   * @notice Get the length of value.
-   */
-  function _length() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of value.
+  uint256 constant _length = 3;
 
   /**
    * @notice Get an item of value.

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -114,11 +114,8 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
 
-  // The length of staticB32.
+  // The length of staticB32
   uint256 constant lengthStaticB32 = 1;
-
-  // The length of staticB32.
-  uint256 constant _lengthStaticB32 = 1;
 
   /**
    * @notice Get an item of staticB32.
@@ -216,11 +213,8 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
 
-  // The length of staticI32.
+  // The length of staticI32
   uint256 constant lengthStaticI32 = 2;
-
-  // The length of staticI32.
-  uint256 constant _lengthStaticI32 = 2;
 
   /**
    * @notice Get an item of staticI32.
@@ -318,11 +312,8 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
 
-  // The length of staticU128.
+  // The length of staticU128
   uint256 constant lengthStaticU128 = 3;
-
-  // The length of staticU128.
-  uint256 constant _lengthStaticU128 = 3;
 
   /**
    * @notice Get an item of staticU128.
@@ -420,11 +411,8 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
 
-  // The length of staticAddrs.
+  // The length of staticAddrs
   uint256 constant lengthStaticAddrs = 4;
-
-  // The length of staticAddrs.
-  uint256 constant _lengthStaticAddrs = 4;
 
   /**
    * @notice Get an item of staticAddrs.
@@ -522,11 +510,8 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
 
-  // The length of staticBools.
+  // The length of staticBools
   uint256 constant lengthStaticBools = 5;
-
-  // The length of staticBools.
-  uint256 constant _lengthStaticBools = 5;
 
   /**
    * @notice Get an item of staticBools.

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -114,19 +114,11 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_bytes32_1(staticB32)));
   }
 
-  /**
-   * @notice Get the length of staticB32.
-   */
-  function lengthStaticB32() internal pure returns (uint256) {
-    return 1;
-  }
+  // The length of staticB32.
+  uint256 constant lengthStaticB32 = 1;
 
-  /**
-   * @notice Get the length of staticB32.
-   */
-  function _lengthStaticB32() internal pure returns (uint256) {
-    return 1;
-  }
+  // The length of staticB32.
+  uint256 constant _lengthStaticB32 = 1;
 
   /**
    * @notice Get an item of staticB32.
@@ -224,19 +216,11 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_int32_2(staticI32)));
   }
 
-  /**
-   * @notice Get the length of staticI32.
-   */
-  function lengthStaticI32() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of staticI32.
+  uint256 constant lengthStaticI32 = 2;
 
-  /**
-   * @notice Get the length of staticI32.
-   */
-  function _lengthStaticI32() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of staticI32.
+  uint256 constant _lengthStaticI32 = 2;
 
   /**
    * @notice Get an item of staticI32.
@@ -334,19 +318,11 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint128_3(staticU128)));
   }
 
-  /**
-   * @notice Get the length of staticU128.
-   */
-  function lengthStaticU128() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of staticU128.
+  uint256 constant lengthStaticU128 = 3;
 
-  /**
-   * @notice Get the length of staticU128.
-   */
-  function _lengthStaticU128() internal pure returns (uint256) {
-    return 3;
-  }
+  // The length of staticU128.
+  uint256 constant _lengthStaticU128 = 3;
 
   /**
    * @notice Get an item of staticU128.
@@ -444,19 +420,11 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 3, EncodeArray.encode(fromStaticArray_address_4(staticAddrs)));
   }
 
-  /**
-   * @notice Get the length of staticAddrs.
-   */
-  function lengthStaticAddrs() internal pure returns (uint256) {
-    return 4;
-  }
+  // The length of staticAddrs.
+  uint256 constant lengthStaticAddrs = 4;
 
-  /**
-   * @notice Get the length of staticAddrs.
-   */
-  function _lengthStaticAddrs() internal pure returns (uint256) {
-    return 4;
-  }
+  // The length of staticAddrs.
+  uint256 constant _lengthStaticAddrs = 4;
 
   /**
    * @notice Get an item of staticAddrs.
@@ -554,19 +522,11 @@ library Dynamics1 {
     StoreCore.setDynamicField(_tableId, _keyTuple, 4, EncodeArray.encode(fromStaticArray_bool_5(staticBools)));
   }
 
-  /**
-   * @notice Get the length of staticBools.
-   */
-  function lengthStaticBools() internal pure returns (uint256) {
-    return 5;
-  }
+  // The length of staticBools.
+  uint256 constant lengthStaticBools = 5;
 
-  /**
-   * @notice Get the length of staticBools.
-   */
-  function _lengthStaticBools() internal pure returns (uint256) {
-    return 5;
-  }
+  // The length of staticBools.
+  uint256 constant _lengthStaticBools = 5;
 
   /**
    * @notice Get an item of staticBools.

--- a/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
+++ b/packages/cli/contracts/src/codegen/tables/Dynamics1.sol
@@ -117,14 +117,14 @@ library Dynamics1 {
   /**
    * @notice Get the length of staticB32.
    */
-  function lengthStaticB32(bytes32 key) internal pure returns (uint256) {
+  function lengthStaticB32() internal pure returns (uint256) {
     return 1;
   }
 
   /**
    * @notice Get the length of staticB32.
    */
-  function _lengthStaticB32(bytes32 key) internal pure returns (uint256) {
+  function _lengthStaticB32() internal pure returns (uint256) {
     return 1;
   }
 
@@ -227,14 +227,14 @@ library Dynamics1 {
   /**
    * @notice Get the length of staticI32.
    */
-  function lengthStaticI32(bytes32 key) internal pure returns (uint256) {
+  function lengthStaticI32() internal pure returns (uint256) {
     return 2;
   }
 
   /**
    * @notice Get the length of staticI32.
    */
-  function _lengthStaticI32(bytes32 key) internal pure returns (uint256) {
+  function _lengthStaticI32() internal pure returns (uint256) {
     return 2;
   }
 
@@ -337,14 +337,14 @@ library Dynamics1 {
   /**
    * @notice Get the length of staticU128.
    */
-  function lengthStaticU128(bytes32 key) internal pure returns (uint256) {
+  function lengthStaticU128() internal pure returns (uint256) {
     return 3;
   }
 
   /**
    * @notice Get the length of staticU128.
    */
-  function _lengthStaticU128(bytes32 key) internal pure returns (uint256) {
+  function _lengthStaticU128() internal pure returns (uint256) {
     return 3;
   }
 
@@ -447,14 +447,14 @@ library Dynamics1 {
   /**
    * @notice Get the length of staticAddrs.
    */
-  function lengthStaticAddrs(bytes32 key) internal pure returns (uint256) {
+  function lengthStaticAddrs() internal pure returns (uint256) {
     return 4;
   }
 
   /**
    * @notice Get the length of staticAddrs.
    */
-  function _lengthStaticAddrs(bytes32 key) internal pure returns (uint256) {
+  function _lengthStaticAddrs() internal pure returns (uint256) {
     return 4;
   }
 
@@ -557,14 +557,14 @@ library Dynamics1 {
   /**
    * @notice Get the length of staticBools.
    */
-  function lengthStaticBools(bytes32 key) internal pure returns (uint256) {
+  function lengthStaticBools() internal pure returns (uint256) {
     return 5;
   }
 
   /**
    * @notice Get the length of staticBools.
    */
-  function _lengthStaticBools(bytes32 key) internal pure returns (uint256) {
+  function _lengthStaticBools() internal pure returns (uint256) {
     return 5;
   }
 

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -138,19 +138,11 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
-  /**
-   * @notice Get the length of v2.
-   */
-  function lengthV2() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of v2.
+  uint256 constant lengthV2 = 2;
 
-  /**
-   * @notice Get the length of v2.
-   */
-  function _lengthV2() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of v2.
+  uint256 constant _lengthV2 = 2;
 
   /**
    * @notice Get an item of v2.
@@ -240,19 +232,11 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
-  /**
-   * @notice Get the length of v3.
-   */
-  function lengthV3() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of v3.
+  uint256 constant lengthV3 = 2;
 
-  /**
-   * @notice Get the length of v3.
-   */
-  function _lengthV3() internal pure returns (uint256) {
-    return 2;
-  }
+  // The length of v3.
+  uint256 constant _lengthV3 = 2;
 
   /**
    * @notice Get an item of v3.
@@ -342,19 +326,11 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
-  /**
-   * @notice Get the length of v4.
-   */
-  function lengthV4() internal pure returns (uint256) {
-    return 1;
-  }
+  // The length of v4.
+  uint256 constant lengthV4 = 1;
 
-  /**
-   * @notice Get the length of v4.
-   */
-  function _lengthV4() internal pure returns (uint256) {
-    return 1;
-  }
+  // The length of v4.
+  uint256 constant _lengthV4 = 1;
 
   /**
    * @notice Get an item of v4.

--- a/packages/cli/contracts/src/codegen/tables/Singleton.sol
+++ b/packages/cli/contracts/src/codegen/tables/Singleton.sol
@@ -138,11 +138,8 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode(fromStaticArray_uint32_2(v2)));
   }
 
-  // The length of v2.
+  // The length of v2
   uint256 constant lengthV2 = 2;
-
-  // The length of v2.
-  uint256 constant _lengthV2 = 2;
 
   /**
    * @notice Get an item of v2.
@@ -232,11 +229,8 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 1, EncodeArray.encode(fromStaticArray_uint32_2(v3)));
   }
 
-  // The length of v3.
+  // The length of v3
   uint256 constant lengthV3 = 2;
-
-  // The length of v3.
-  uint256 constant _lengthV3 = 2;
 
   /**
    * @notice Get an item of v3.
@@ -326,11 +320,8 @@ library Singleton {
     StoreCore.setDynamicField(_tableId, _keyTuple, 2, EncodeArray.encode(fromStaticArray_uint32_1(v4)));
   }
 
-  // The length of v4.
+  // The length of v4
   uint256 constant lengthV4 = 1;
-
-  // The length of v4.
-  uint256 constant _lengthV4 = 1;
 
   /**
    * @notice Get an item of v4.

--- a/packages/cli/contracts/test/Tablegen.t.sol
+++ b/packages/cli/contracts/test/Tablegen.t.sol
@@ -67,14 +67,14 @@ contract TablegenTest is Test, StoreMock {
     assertEq(abi.encode(Dynamics2.get(key)), abi.encode(data2));
 
     // test length getters
-    assertEq(Dynamics1.lengthStaticB32(key), staticB32.length);
-    assertEq(Dynamics1.lengthStaticI32(key), staticI32.length);
-    assertEq(Dynamics1.lengthStaticU128(key), staticU128.length);
-    assertEq(Dynamics1.lengthStaticAddrs(key), staticAddrs.length);
-    assertEq(Dynamics1.lengthStaticBools(key), staticBools.length);
-    assertEq(Dynamics2.lengthU64(key), u64.length);
-    assertEq(Dynamics2.lengthStr(key), bytes(str).length);
-    assertEq(Dynamics2.lengthB(key), b.length);
+    assertEq(Dynamics1.lengthStaticB32, staticB32.length);
+    assertEq(Dynamics1.lengthStaticI32, staticI32.length);
+    assertEq(Dynamics1.lengthStaticU128, staticU128.length);
+    assertEq(Dynamics1.lengthStaticAddrs, staticAddrs.length);
+    assertEq(Dynamics1.lengthStaticBools, staticBools.length);
+    assertEq(Dynamics2.lengthU64, u64.length);
+    assertEq(Dynamics2.lengthStr, bytes(str).length);
+    assertEq(Dynamics2.lengthB, b.length);
 
     // test item getters
     assertEq(Dynamics1.getItemStaticB32(key, 0), staticB32[0]);

--- a/packages/cli/contracts/test/Tablegen.t.sol
+++ b/packages/cli/contracts/test/Tablegen.t.sol
@@ -72,9 +72,9 @@ contract TablegenTest is Test, StoreMock {
     assertEq(Dynamics1.lengthStaticU128, staticU128.length);
     assertEq(Dynamics1.lengthStaticAddrs, staticAddrs.length);
     assertEq(Dynamics1.lengthStaticBools, staticBools.length);
-    assertEq(Dynamics2.lengthU64, u64.length);
-    assertEq(Dynamics2.lengthStr, bytes(str).length);
-    assertEq(Dynamics2.lengthB, b.length);
+    assertEq(Dynamics2.lengthU64(key), u64.length);
+    assertEq(Dynamics2.lengthStr(key), bytes(str).length);
+    assertEq(Dynamics2.lengthB(key), b.length);
 
     // test item getters
     assertEq(Dynamics1.getItemStaticB32(key, 0), staticB32[0]);
@@ -131,17 +131,17 @@ contract TablegenTest is Test, StoreMock {
     assertEq(Singleton.getV1(), -10);
 
     assertEq(abi.encode(Singleton.getV2()), abi.encode([uint32(1), 2]));
-    assertEq(Singleton.lengthV2(), 2);
+    assertEq(Singleton.lengthV2, 2);
     assertEq(Singleton.getItemV2(0), 1);
     assertEq(Singleton.getItemV2(1), 2);
 
     assertEq(abi.encode(Singleton.getV3()), abi.encode([uint32(3), 4]));
-    assertEq(Singleton.lengthV3(), 2);
+    assertEq(Singleton.lengthV3, 2);
     assertEq(Singleton.getItemV3(0), 3);
     assertEq(Singleton.getItemV3(1), 4);
 
     assertEq(abi.encode(Singleton.getV4()), abi.encode([uint32(5)]));
-    assertEq(Singleton.lengthV4(), 1);
+    assertEq(Singleton.lengthV4, 1);
     assertEq(Singleton.getItemV4(0), 5);
     vm.expectRevert(abi.encodeWithSelector(IStoreErrors.Store_IndexOutOfBounds.selector, 4, 4));
     assertEq(Singleton.getItemV4(1), 0);

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -92,15 +92,11 @@ export function renderFieldMethods(options: RenderTableOptions): string {
           result += renderWithFieldSuffix(options.withSuffixlessFieldMethods, field.name, (_methodNameSuffix) =>
             renderWithStore(
               storeArgument,
-              ({ _typedStore, _commentSuffix, _methodNamePrefix }) => `
+              ({ _commentSuffix, _methodNamePrefix }) => `
                 /**
                  * @notice Get the length of ${field.name}${_commentSuffix}.
                  */
-                function ${_methodNamePrefix}length${_methodNameSuffix}(${renderArguments([
-                  _typedStore,
-                  _typedTableId,
-                  _typedKeyArgs,
-                ])}) internal pure returns (uint256) {
+                function ${_methodNamePrefix}length${_methodNameSuffix}() internal pure returns (uint256) {
                   return ${typeWrappingData.staticLength};
                 }
               `,

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -89,14 +89,14 @@ export function renderFieldMethods(options: RenderTableOptions): string {
 
       if (options.withGetters) {
         if (typeWrappingData && typeWrappingData.kind === "staticArray") {
-          result += renderWithFieldSuffix(options.withSuffixlessFieldMethods, field.name, (_methodNameSuffix) =>
-            renderWithStore(
-              storeArgument,
-              ({ _commentSuffix, _methodNamePrefix }) => `
-                // The length of ${field.name}${_commentSuffix}.                 
-                uint256 constant ${_methodNamePrefix}length${_methodNameSuffix} = ${typeWrappingData.staticLength};
+          result += renderWithFieldSuffix(
+            options.withSuffixlessFieldMethods,
+            field.name,
+            (_methodNameSuffix) =>
+              `
+                // The length of ${field.name}
+                uint256 constant length${_methodNameSuffix} = ${typeWrappingData.staticLength};
               `,
-            ),
           );
         } else {
           result += renderWithFieldSuffix(options.withSuffixlessFieldMethods, field.name, (_methodNameSuffix) =>

--- a/packages/store/ts/codegen/field.ts
+++ b/packages/store/ts/codegen/field.ts
@@ -93,12 +93,8 @@ export function renderFieldMethods(options: RenderTableOptions): string {
             renderWithStore(
               storeArgument,
               ({ _commentSuffix, _methodNamePrefix }) => `
-                /**
-                 * @notice Get the length of ${field.name}${_commentSuffix}.
-                 */
-                function ${_methodNamePrefix}length${_methodNameSuffix}() internal pure returns (uint256) {
-                  return ${typeWrappingData.staticLength};
-                }
+                // The length of ${field.name}${_commentSuffix}.                 
+                uint256 constant ${_methodNamePrefix}length${_methodNameSuffix} = ${typeWrappingData.staticLength};
               `,
             ),
           );


### PR DESCRIPTION
The static array length getters return a constant, so the unused args were causing build errors:

![image](https://github.com/latticexyz/mud/assets/29184158/32b4b031-996d-458e-9352-c86c7d70d05b)


