### PR TITLE
feat(store-sync): query subjects$ and subjectEvents$

### DIFF
--- a/packages/store-sync/src/query-cache/subscribeToQuery.test.ts
+++ b/packages/store-sync/src/query-cache/subscribeToQuery.test.ts
@@ -8,7 +8,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { testClient } from "../../test/common";
 import { combineLatest, filter, firstValueFrom, map, scan, shareReplay } from "rxjs";
 import { waitForTransaction } from "./test/waitForTransaction";
-import { SubjectEvent } from "@latticexyz/query";
+import { SubjectEvent, SubjectRecord } from "@latticexyz/query";
 
 const henryAccount = privateKeyToAccount(keccak256(stringToHex("henry")));
 
@@ -22,7 +22,7 @@ describe("subscribeToQuery", async () => {
   it("can get players with a position", async () => {
     const { store, fetchLatestLogs } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -30,6 +30,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -37,7 +41,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -122,6 +126,87 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                  "x": 1,
+                  "y": -1,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0xdBa86119a787422C593ceF119E40887f396024E2",
+                  "x": 100,
+                  "y": 100,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000dba86119a787422c593cef119e40887f396024e2",
+                ],
+                "primaryKey": [
+                  "0xdBa86119a787422C593ceF119E40887f396024E2",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0xdBa86119a787422C593ceF119E40887f396024E2",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -139,7 +224,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 2,
           "value": [
             {
@@ -164,6 +249,106 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 2,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                  "x": 1,
+                  "y": -1,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0xdBa86119a787422C593ceF119E40887f396024E2",
+                  "x": 100,
+                  "y": 100,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000dba86119a787422c593cef119e40887f396024e2",
+                ],
+                "primaryKey": [
+                  "0xdBa86119a787422C593ceF119E40887f396024E2",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0xdBa86119a787422C593ceF119E40887f396024E2",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                  "x": 1,
+                  "y": 2,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000005f2cc8fb10299751348e1b10f5f1ba47820b1cb8",
+                ],
+                "primaryKey": [
+                  "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -171,7 +356,7 @@ describe("subscribeToQuery", async () => {
   it("can get players at position (3, 5)", async () => {
     const { store, fetchLatestLogs } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -183,6 +368,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -190,7 +379,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -235,6 +424,49 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -252,7 +484,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 2,
           "value": [
             {
@@ -277,6 +509,68 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 2,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000005f2cc8fb10299751348e1b10f5f1ba47820b1cb8",
+                ],
+                "primaryKey": [
+                  "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -294,7 +588,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 3,
           "value": [
             {
@@ -319,6 +613,49 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 3,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -326,7 +663,7 @@ describe("subscribeToQuery", async () => {
   it("can get players within the bounds of (-5, -5) and (5, 5)", async () => {
     const { store, fetchLatestLogs } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -340,6 +677,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -347,7 +688,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -412,6 +753,68 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                  "x": 1,
+                  "y": -1,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -429,7 +832,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 2,
           "value": [
             {
@@ -454,6 +857,87 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 2,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                  "x": 1,
+                  "y": -1,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000005f2cc8fb10299751348e1b10f5f1ba47820b1cb8",
+                ],
+                "primaryKey": [
+                  "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -471,7 +955,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 3,
           "value": [
             {
@@ -496,6 +980,68 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 3,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                  "x": 1,
+                  "y": -1,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -503,7 +1049,7 @@ describe("subscribeToQuery", async () => {
   it("can get players that are still alive", async () => {
     const { store } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
         Health: ["player"],
@@ -513,6 +1059,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -520,7 +1070,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -563,6 +1113,47 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "health": 5n,
+                  "player": "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000001d96f2f6bef1202e4ce1ff6dad0c2cb002861d3e",
+                ],
+                "primaryKey": [
+                  "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+                ],
+                "tableId": "0x746200000000000000000000000000004865616c746800000000000000000000",
+              },
+              "subject": [
+                "0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "health": 5n,
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x746200000000000000000000000000004865616c746800000000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -570,7 +1161,7 @@ describe("subscribeToQuery", async () => {
   it("can get all players in grassland", async () => {
     const { store } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Terrain: ["x", "y"],
       },
@@ -579,6 +1170,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -586,7 +1181,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -614,6 +1209,33 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "terrainType": 2,
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000000000000000000000000000000000000000000003",
+                  "0x0000000000000000000000000000000000000000000000000000000000000005",
+                ],
+                "primaryKey": [
+                  3,
+                  5,
+                ],
+                "tableId": "0x746200000000000000000000000000005465727261696e000000000000000000",
+              },
+              "subject": [
+                3,
+                5,
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -621,7 +1243,7 @@ describe("subscribeToQuery", async () => {
   it("can get all players without health (e.g. spectator)", async () => {
     const { store } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -632,6 +1254,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -639,7 +1265,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 1,
           "value": [
             {
@@ -664,6 +1290,30 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 1,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0xdBa86119a787422C593ceF119E40887f396024E2",
+                  "x": 100,
+                  "y": 100,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000dba86119a787422c593cef119e40887f396024e2",
+                ],
+                "primaryKey": [
+                  "0xdBa86119a787422C593ceF119E40887f396024E2",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0xdBa86119a787422C593ceF119E40887f396024E2",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -671,7 +1321,7 @@ describe("subscribeToQuery", async () => {
   it("emits new subjects when initial matching set is empty", async () => {
     const { store, fetchLatestLogs } = await createHydratedStore(worldAddress);
 
-    const { subjects$ } = subscribeToQuery(store, {
+    const { subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -683,6 +1333,10 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
@@ -690,6 +1344,10 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
+        "subjectEvents$": {
+          "count": 1,
+          "value": [],
+        },
         "subjects$": {
           "count": 1,
           "value": [],
@@ -711,7 +1369,7 @@ describe("subscribeToQuery", async () => {
 
     expect(await firstValueFrom(latest$)).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 2,
           "value": [
             {
@@ -736,6 +1394,30 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 2,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                  "x": 999,
+                  "y": 999,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000005f2cc8fb10299751348e1b10f5f1ba47820b1cb8",
+                ],
+                "primaryKey": [
+                  "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+              ],
+            },
+          ],
+        },
       }
     `);
   });
@@ -743,7 +1425,7 @@ describe("subscribeToQuery", async () => {
   it("emits changed subjects when subscribing some time after initial query", async () => {
     const { store, fetchLatestLogs } = await createHydratedStore(worldAddress);
 
-    const { subjects, subjects$ } = subscribeToQuery(store, {
+    const { subjects, subjects$, subjectEvents$ } = subscribeToQuery(store, {
       from: {
         Position: ["player"],
       },
@@ -814,15 +1496,23 @@ describe("subscribeToQuery", async () => {
 
     const latest$ = combineLatest({
       subjects$: subjects$.pipe(
+        scan((values, value) => [...values, value], [] as readonly (readonly SubjectRecord[])[]),
+        map((values) => ({ count: values.length, value: values.at(-1) })),
+      ),
+      subjectEvents$: subjectEvents$.pipe(
         scan((values, value) => [...values, value], [] as readonly (readonly SubjectEvent[])[]),
         map((values) => ({ count: values.length, value: values.at(-1) })),
       ),
     }).pipe(shareReplay(1));
 
     // we expect two emissions for by this point: initial subjects + subjects changed since starting the subscriptions
-    expect(await firstValueFrom(latest$.pipe(filter((latest) => latest.subjects$.count === 2)))).toMatchInlineSnapshot(`
+    expect(
+      await firstValueFrom(
+        latest$.pipe(filter((latest) => latest.subjects$.count === 2 && latest.subjectEvents$.count === 2)),
+      ),
+    ).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 2,
           "value": [
             {
@@ -847,6 +1537,68 @@ describe("subscribeToQuery", async () => {
             },
           ],
         },
+        "subjects$": {
+          "count": 2,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x0000000000000000000000005f2cc8fb10299751348e1b10f5f1ba47820b1cb8",
+                ],
+                "primaryKey": [
+                  "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
+              ],
+            },
+          ],
+        },
       }
     `);
 
@@ -862,9 +1614,13 @@ describe("subscribeToQuery", async () => {
     );
     await fetchLatestLogs();
 
-    expect(await firstValueFrom(latest$.pipe(filter((latest) => latest.subjects$.count === 3)))).toMatchInlineSnapshot(`
+    expect(
+      await firstValueFrom(
+        latest$.pipe(filter((latest) => latest.subjects$.count === 3 && latest.subjectEvents$.count === 3)),
+      ),
+    ).toMatchInlineSnapshot(`
       {
-        "subjects$": {
+        "subjectEvents$": {
           "count": 3,
           "value": [
             {
@@ -886,6 +1642,49 @@ describe("subscribeToQuery", async () => {
                 "0x5f2cC8fb10299751348e1b10f5F1Ba47820B1cB8",
               ],
               "type": "exit",
+            },
+          ],
+        },
+        "subjects$": {
+          "count": 3,
+          "value": [
+            {
+              "record": {
+                "fields": {
+                  "player": "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000328809bc894f92807417d2dad6b7c998c1afdac6",
+                ],
+                "primaryKey": [
+                  "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x328809Bc894f92807417D2dAD6b7C998c1aFdac6",
+              ],
+            },
+            {
+              "record": {
+                "fields": {
+                  "player": "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                  "x": 3,
+                  "y": 5,
+                },
+                "keyTuple": [
+                  "0x000000000000000000000000078cf0753dd50f7c56f20b3ae02719ea199be2eb",
+                ],
+                "primaryKey": [
+                  "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+                ],
+                "tableId": "0x74620000000000000000000000000000506f736974696f6e0000000000000000",
+              },
+              "subject": [
+                "0x078cf0753dd50f7C56F20B3Ae02719EA199BE2eb",
+              ],
             },
           ],
         },


### PR DESCRIPTION
I removed the original `subjects$` in favor of just `subjectEvents$` but we need `subjects$` for RECS compat