### PR TITLE
feat(create-mud): add additional recommended vscode extensions

### DIFF
--- a/.changeset/rich-penguins-film.md
+++ b/.changeset/rich-penguins-film.md
@@ -1,0 +1,5 @@
+---
+"create-mud": patch
+---
+
+Added `dbaeumer.vscode-eslint` and `esbenp.prettier-vscode` to recommended VSCode extensions.

--- a/examples/multiple-accounts/.vscode/extensions.json
+++ b/examples/multiple-accounts/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/templates/phaser/.vscode/extensions.json
+++ b/templates/phaser/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/templates/react-ecs/.vscode/extensions.json
+++ b/templates/react-ecs/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/templates/react/.vscode/extensions.json
+++ b/templates/react/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/templates/threejs/.vscode/extensions.json
+++ b/templates/threejs/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/templates/vanilla/.vscode/extensions.json
+++ b/templates/vanilla/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["NomicFoundation.hardhat-solidity"]
+  "recommendations": ["NomicFoundation.hardhat-solidity", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }


### PR DESCRIPTION
This PR adds additional recommended vscode extensions for the templates and the multi-accounts example.

continued from #2429 