### PR TITLE
feat(templates): add the foundry path if necessary

### DIFF
--- a/docs/pages/templates/typescript/getting-started.mdx
+++ b/docs/pages/templates/typescript/getting-started.mdx
@@ -8,7 +8,6 @@ To install the TypeScript templates you need:
 
 - [Node.js v18](https://nodejs.org/en/download/package-manager)
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Foundry](https://book.getfoundry.sh/getting-started/installation)
 - [pnpm](https://pnpm.io/)
   ```sh copy
   sudo npm install -g pnpm

--- a/templates/phaser/package.json
+++ b/templates/phaser/package.json
@@ -2,14 +2,14 @@
   "name": "mud-template-phaser",
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run build",
-    "dev": "mprocs",
+    "build": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run build",
+    "dev": "forge || export PATH=$PATH:~/.foundry/bin; mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
-    "test": "pnpm recursive run test"
+    "test": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",

--- a/templates/react-ecs/package.json
+++ b/templates/react-ecs/package.json
@@ -2,14 +2,14 @@
   "name": "mud-template-react-ecs",
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run build",
-    "dev": "mprocs",
+    "build": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run build",
+    "dev": "forge || export PATH=$PATH:~/.foundry/bin; mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
-    "test": "pnpm recursive run test"
+    "test": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -2,14 +2,14 @@
   "name": "mud-template-react",
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run build",
-    "dev": "mprocs",
+    "build": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run build",
+    "dev": "forge || export PATH=$PATH:~/.foundry/bin; mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
-    "test": "pnpm recursive run test"
+    "test": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",

--- a/templates/threejs/package.json
+++ b/templates/threejs/package.json
@@ -2,14 +2,14 @@
   "name": "mud-template-threejs",
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run build",
-    "dev": "mprocs",
+    "build": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run build",
+    "dev": "forge || export PATH=$PATH:~/.foundry/bin; mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
-    "test": "pnpm recursive run test"
+    "test": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -2,14 +2,14 @@
   "name": "mud-template-vanilla",
   "private": true,
   "scripts": {
-    "build": "pnpm recursive run build",
-    "dev": "mprocs",
+    "build": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run build",
+    "dev": "forge || export PATH=$PATH:~/.foundry/bin; mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",
     "mud:up": "pnpm mud set-version --tag main && pnpm install",
     "prepare": "(forge --version || pnpm foundry:up)",
-    "test": "pnpm recursive run test"
+    "test": "forge || export PATH=$PATH:~/.foundry/bin; pnpm recursive run test"
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",


### PR DESCRIPTION
`pnpm create` now installs foundry if necessary. That is great, but we can improve usability even more if we make sure it's in the path when we need it.