### PR TITLE
feat(store/world): disable `namespace`/`name` override on store/world table inputs, move validation to define

### DIFF
--- a/packages/store/ts/config/v2/README.md
+++ b/packages/store/ts/config/v2/README.md
@@ -22,15 +22,6 @@ function validateX(x: unknonw): asserts x is X {
 type resolveX<x> = x extends X ? { [key in keyof x]: Resolved } : never;
 
 /**
- * defineX function validates the input types and calls resolveX to resolve it.
- * Note: the runtime validation happens in `resolveX`.
- * This is to take advantage of the type assertion in the function body.
- */
-function defineX<const x>(x: validateX<x>): resolveX<x> {
-  return resolveX(x);
-}
-
-/**
  * resolveX function does not validate the input type, but validates the runtime types.
  * (This is to take advantage of the type assertion in the function body).
  * This function is used by defineX and other higher level resolution functions.
@@ -38,6 +29,15 @@ function defineX<const x>(x: validateX<x>): resolveX<x> {
 function resolveX<const x extends X>(x: x): resolveX<x> {
   validateX(x);
   //
+}
+
+/**
+ * defineX function validates the input types and calls resolveX to resolve it.
+ * Note: the runtime validation happens in `resolveX`.
+ * This is to take advantage of the type assertion in the function body.
+ */
+function defineX<const x>(x: validateX<x>): resolveX<x> {
+  return resolveX(x);
 }
 ```
 

--- a/packages/store/ts/config/v2/README.md
+++ b/packages/store/ts/config/v2/README.md
@@ -22,21 +22,19 @@ function validateX(x: unknonw): asserts x is X {
 type resolveX<x> = x extends X ? { [key in keyof x]: Resolved } : never;
 
 /**
- * resolveX function does not validate the input type, but validates the runtime types.
- * (This is to take advantage of the type assertion in the function body).
+ * resolveX function does not validate the input but expects a resolved input.
  * This function is used by defineX and other higher level resolution functions.
  */
 function resolveX<const x extends X>(x: x): resolveX<x> {
-  validateX(x);
   //
 }
 
 /**
  * defineX function validates the input types and calls resolveX to resolve it.
- * Note: the runtime validation happens in `resolveX`.
- * This is to take advantage of the type assertion in the function body.
+ * Runtime validation also acts as a type assertion to be able to call the resolvers.
  */
 function defineX<const x>(x: validateX<x>): resolveX<x> {
+  validateX(x);
   return resolveX(x);
 }
 ```

--- a/packages/store/ts/config/v2/input.ts
+++ b/packages/store/ts/config/v2/input.ts
@@ -26,7 +26,7 @@ export type TablesInput = {
 
 export type StoreInput = {
   readonly namespace?: string;
-  readonly tables: TablesInput;
+  readonly tables: Omit<TablesInput, "name" | "namespace">;
   readonly userTypes?: UserTypes;
   readonly enums?: Enums;
   readonly codegen?: Partial<Codegen>;

--- a/packages/store/ts/config/v2/input.ts
+++ b/packages/store/ts/config/v2/input.ts
@@ -21,12 +21,12 @@ export type TableInput = {
 };
 
 export type TablesInput = {
-  readonly [key: string]: TableInput;
+  readonly [key: string]: Omit<TableInput, "namespace" | "name">;
 };
 
 export type StoreInput = {
   readonly namespace?: string;
-  readonly tables: Omit<TablesInput, "name" | "namespace">;
+  readonly tables: TablesInput;
   readonly userTypes?: UserTypes;
   readonly enums?: Enums;
   readonly codegen?: Partial<Codegen>;

--- a/packages/store/ts/config/v2/namespaces.ts
+++ b/packages/store/ts/config/v2/namespaces.ts
@@ -1,9 +1,9 @@
 export type namespacedTableKeys<store> = "tables" extends keyof store
-  ? "namespace" extends keyof store
-    ? store["namespace"] extends string
-      ? "" extends store["namespace"]
-        ? keyof store["tables"]
-        : `${store["namespace"] & string}__${keyof store["tables"] & string}`
-      : keyof store["tables"]
-    : keyof store["tables"]
+  ? keyof {
+      [key in keyof store["tables"] as "namespace" extends keyof store
+        ? store["namespace"] extends ""
+          ? key
+          : `${store["namespace"] & string}__${key & string}`
+        : key]: void;
+    }
   : never;

--- a/packages/store/ts/config/v2/namespaces.ts
+++ b/packages/store/ts/config/v2/namespaces.ts
@@ -1,0 +1,9 @@
+export type namespacedTableKeys<store> = "tables" extends keyof store
+  ? "namespace" extends keyof store
+    ? store["namespace"] extends string
+      ? "" extends store["namespace"]
+        ? keyof store["tables"]
+        : `${store["namespace"] & string}__${keyof store["tables"] & string}`
+      : keyof store["tables"]
+    : keyof store["tables"]
+  : never;

--- a/packages/store/ts/config/v2/namespaces.ts
+++ b/packages/store/ts/config/v2/namespaces.ts
@@ -1,9 +1,0 @@
-export type namespacedTableKeys<store> = "tables" extends keyof store
-  ? keyof {
-      [key in keyof store["tables"] as "namespace" extends keyof store
-        ? store["namespace"] extends ""
-          ? key
-          : `${store["namespace"] & string}__${key & string}`
-        : key]: void;
-    }
-  : never;

--- a/packages/store/ts/config/v2/schema.ts
+++ b/packages/store/ts/config/v2/schema.ts
@@ -36,12 +36,10 @@ export type resolveSchema<schema, scope extends Scope> = evaluate<{
   };
 }>;
 
-export function resolveSchema<schema, scope extends Scope = AbiTypeScope>(
+export function resolveSchema<schema extends SchemaInput, scope extends Scope = AbiTypeScope>(
   schema: schema,
   scope: scope = AbiTypeScope as unknown as scope,
 ): resolveSchema<schema, scope> {
-  validateSchema(schema, scope);
-
   return Object.fromEntries(
     Object.entries(schema).map(([key, internalType]) => [
       key,
@@ -59,6 +57,7 @@ export function defineSchema<schema, scope extends AbiTypeScope = AbiTypeScope>(
   schema: validateSchema<schema, scope>,
   scope: scope = AbiTypeScope as scope,
 ): resolveSchema<schema, scope> {
+  validateSchema(schema, scope);
   return resolveSchema(schema, scope) as resolveSchema<schema, scope>;
 }
 

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -584,7 +584,7 @@ describe("defineStore", () => {
     );
   });
 
-  it("should throw if name is overridden in the store/namespace config", () => {
+  it("should throw if name is overridden in the store context", () => {
     attest(() =>
       defineStore({
         namespace: "CustomNamespace",
@@ -600,7 +600,7 @@ describe("defineStore", () => {
     ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
   });
 
-  it("should throw if namespace is overridden in the store/namespace config", () => {
+  it("should throw if namespace is overridden in the store context", () => {
     attest(() =>
       defineStore({
         namespace: "CustomNamespace",

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -1,6 +1,5 @@
 import { describe, it } from "vitest";
 import { defineStore } from "./store";
-import { Config } from "./output";
 import { attest } from "@arktype/attest";
 import { resourceToHex } from "@latticexyz/common";
 import { CODEGEN_DEFAULTS, TABLE_CODEGEN_DEFAULTS } from "./defaults";
@@ -563,8 +562,9 @@ describe("defineStore", () => {
     });
 
     attest<"namespace">(config.namespace).equals("namespace");
-    attest<"namespace">(config.tables.Example.namespace).equals("namespace");
-    attest(config.tables.Example.tableId).equals(
+    attest<"namespace">(config.tables.namespace__Example.namespace).equals("namespace");
+    attest<"Example">(config.tables.namespace__Example.name).equals("Example");
+    attest(config.tables.namespace__Example.tableId).equals(
       resourceToHex({ type: "table", name: "Example", namespace: "namespace" }),
     );
   });

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -3,6 +3,7 @@ import { defineStore } from "./store";
 import { attest } from "@arktype/attest";
 import { resourceToHex } from "@latticexyz/common";
 import { CODEGEN_DEFAULTS, TABLE_CODEGEN_DEFAULTS } from "./defaults";
+import { Store } from "./output";
 
 describe("defineStore", () => {
   it("should return the full config given a full config with one key", () => {
@@ -547,7 +548,7 @@ describe("defineStore", () => {
       userTypes: { CustomType: { type: "address", filePath: "path/to/file" } },
     });
 
-    attest<true, typeof config extends Config ? true : false>();
+    attest<true, typeof config extends Store ? true : false>();
   });
 
   it("should use the global namespace instead for tables", () => {
@@ -581,5 +582,37 @@ describe("defineStore", () => {
     attest(() => defineStore({ tables: { Invalid: { invalidKey: 1 } } })).type.errors(
       "Key `invalidKey` does not exist in TableInput",
     );
+  });
+
+  it("should throw if name is overridden in the store/namespace config", () => {
+    attest(() =>
+      defineStore({
+        namespace: "CustomNamespace",
+        tables: {
+          Example: {
+            schema: { id: "address" },
+            key: ["id"],
+            // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+            name: "NotAllowed",
+          },
+        },
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
+  });
+
+  it("should throw if namespace is overridden in the store/namespace config", () => {
+    attest(() =>
+      defineStore({
+        namespace: "CustomNamespace",
+        tables: {
+          Example: {
+            schema: { id: "address" },
+            key: ["id"],
+            // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+            namespace: "NotAllowed",
+          },
+        },
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
   });
 });

--- a/packages/store/ts/config/v2/store.ts
+++ b/packages/store/ts/config/v2/store.ts
@@ -55,9 +55,7 @@ export type resolveStore<store> = evaluate<{
   readonly codegen: "codegen" extends keyof store ? resolveCodegen<store["codegen"]> : resolveCodegen<{}>;
 }>;
 
-export function resolveStore<const store>(store: store): resolveStore<store> {
-  validateStore(store);
-
+export function resolveStore<const store extends StoreInput>(store: store): resolveStore<store> {
   return {
     tables: resolveTables(
       Object.fromEntries(
@@ -76,5 +74,6 @@ export function resolveStore<const store>(store: store): resolveStore<store> {
 }
 
 export function defineStore<const store>(store: validateStore<store>): resolveStore<store> {
+  validateStore(store);
   return resolveStore(store) as unknown as resolveStore<store>;
 }

--- a/packages/store/ts/config/v2/storeWithShorthands.test.ts
+++ b/packages/store/ts/config/v2/storeWithShorthands.test.ts
@@ -156,6 +156,7 @@ describe("defineStoreWithShorthands", () => {
     const config = defineStoreWithShorthands({
       tables: { Example: { id: "address", name: "string", age: "uint256" } },
     });
+
     const expected = {
       tables: {
         Example: {

--- a/packages/store/ts/config/v2/storeWithShorthands.ts
+++ b/packages/store/ts/config/v2/storeWithShorthands.ts
@@ -28,9 +28,9 @@ export type resolveStoreWithShorthands<store> = resolveStore<{
     : store[key];
 }>;
 
-export function resolveStoreWithShorthands<const store>(store: store): resolveStoreWithShorthands<store> {
-  validateStoreWithShorthands(store);
-
+export function resolveStoreWithShorthands<const store extends StoreWithShorthandsInput>(
+  store: store,
+): resolveStoreWithShorthands<store> {
   const scope = extendedScope(store);
   const fullConfig = {
     ...store,
@@ -39,11 +39,13 @@ export function resolveStoreWithShorthands<const store>(store: store): resolveSt
     }),
   };
 
+  validateStore(fullConfig);
   return resolveStore(fullConfig) as unknown as resolveStoreWithShorthands<store>;
 }
 
 export function defineStoreWithShorthands<const store>(
   store: validateStoreWithShorthands<store>,
 ): resolveStoreWithShorthands<store> {
-  return resolveStoreWithShorthands(store) as resolveStoreWithShorthands<store>;
+  validateStoreWithShorthands(store);
+  return resolveStoreWithShorthands(store) as unknown as resolveStoreWithShorthands<store>;
 }

--- a/packages/store/ts/config/v2/table.ts
+++ b/packages/store/ts/config/v2/table.ts
@@ -37,17 +37,6 @@ export function isValidPrimaryKey<schema extends SchemaInput, scope extends Scop
   );
 }
 
-/** @deprecated */
-export function isTableInput(input: unknown): input is TableInput {
-  return (
-    typeof input === "object" &&
-    input !== null &&
-    hasOwnKey(input, "schema") &&
-    hasOwnKey(input, "key") &&
-    Array.isArray(input["key"])
-  );
-}
-
 export type validateKeys<validKeys extends PropertyKey, keys> = {
   [i in keyof keys]: keys[i] extends validKeys ? keys[i] : validKeys;
 };

--- a/packages/store/ts/config/v2/tables.ts
+++ b/packages/store/ts/config/v2/tables.ts
@@ -37,7 +37,7 @@ export function resolveTables<tables extends TablesInput, scope extends Scope = 
 
   return Object.fromEntries(
     Object.entries(tables).map(([key, table]) => {
-      return [key, resolveTable(mergeIfUndefined(table, { name: key }) as validateTable<typeof table, scope>, scope)];
+      return [key, resolveTable(mergeIfUndefined(table, { name: key }), scope)];
     }),
   ) as unknown as resolveTables<tables, scope>;
 }

--- a/packages/store/ts/config/v2/tables.ts
+++ b/packages/store/ts/config/v2/tables.ts
@@ -6,7 +6,7 @@ import { validateTable, resolveTable } from "./table";
 
 export type validateTables<tables, scope extends Scope = AbiTypeScope> = {
   [key in keyof tables]: tables[key] extends object
-    ? validateTable<tables[key], scope>
+    ? validateTable<tables[key], scope, { inStoreContext: true }>
     : ErrorMessage<`Expected full table config.`>;
 };
 
@@ -16,7 +16,7 @@ export function validateTables<scope extends Scope = AbiTypeScope>(
 ): asserts input is TablesInput {
   if (isObject(input)) {
     for (const table of Object.values(input)) {
-      validateTable(table, scope);
+      validateTable(table, scope, { inStoreContext: true });
     }
     return;
   }
@@ -27,12 +27,10 @@ export type resolveTables<tables, scope extends Scope = AbiTypeScope> = evaluate
   readonly [key in keyof tables]: resolveTable<mergeIfUndefined<tables[key], { name: key }>, scope>;
 }>;
 
-export function resolveTables<tables, scope extends Scope = AbiTypeScope>(
+export function resolveTables<tables extends TablesInput, scope extends Scope = AbiTypeScope>(
   tables: tables,
   scope: scope = AbiTypeScope as unknown as scope,
 ): resolveTables<tables, scope> {
-  validateTables(tables, scope);
-
   if (!isObject(tables)) {
     throw new Error(`Expected tables config, received ${JSON.stringify(tables)}`);
   }

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -792,21 +792,72 @@ describe("defineWorld", () => {
     attest<"CustomNamespace__Example", keyof typeof config.tables>();
   });
 
-  it("should throw if trying to override namespace or name in the store/namespace config", () => {
-    const config = defineWorld({
-      namespace: "CustomNamespace",
-      tables: {
-        Example: {
-          schema: { id: "address" },
-          key: ["id"],
-          // @ts-expect-error Name override not allowed in store context
-          name: "NotAllowed",
-          // @ts-expect-error Namespace override not allowed in store context
-          namespace: "NotAllowed",
+  it("should throw if namespace is overridden in top level tables", () => {
+    attest(() =>
+      defineWorld({
+        namespace: "CustomNamespace",
+        tables: {
+          Example: {
+            schema: { id: "address" },
+            key: ["id"],
+            // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+            namespace: "NotAllowed",
+          },
         },
-      },
-    });
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
+  });
 
-    attest<"CustomNamespace__Example", keyof typeof config.tables>();
+  it("should throw if name is overridden in top level tables", () => {
+    attest(() =>
+      defineWorld({
+        tables: {
+          Example: {
+            schema: { id: "address" },
+            key: ["id"],
+            // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+            name: "NotAllowed",
+          },
+        },
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
+  });
+
+  it("should throw if name is overridden in namespaced tables", () => {
+    attest(() =>
+      defineWorld({
+        namespaces: {
+          MyNamespace: {
+            tables: {
+              Example: {
+                schema: { id: "address" },
+                key: ["id"],
+                // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+                name: "NotAllowed",
+              },
+            },
+          },
+        },
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
+  });
+
+  it("should throw if namespace is overridden in namespaced tables", () => {
+    attest(() =>
+      defineWorld({
+        namespaces: {
+          MyNamespace: {
+            tables: {
+              Example: {
+                schema: { id: "address" },
+                key: ["id"],
+                // @ts-expect-error "Overrides of `name` and `namespace` are not allowed for tables in a store config"
+                namespace: "NotAllowed",
+              },
+            },
+          },
+        },
+      }),
+    ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
   });
 });

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -799,7 +799,9 @@ describe("defineWorld", () => {
         Example: {
           schema: { id: "address" },
           key: ["id"],
+          // @ts-expect-error Name override not allowed in store context
           name: "NotAllowed",
+          // @ts-expect-error Namespace override not allowed in store context
           namespace: "NotAllowed",
         },
       },

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -777,4 +777,19 @@ describe("defineWorld", () => {
       );
     });
   });
+
+  it("should use the custom name and namespace as table index", () => {
+    const config = defineWorld({
+      namespace: "CustomNamespace",
+      tables: {
+        Example: {
+          schema: { id: "address" },
+          key: ["id"],
+          name: "CustomName",
+        },
+      },
+    });
+
+    attest<"CustomNamespace__CustomName", keyof typeof config.tables>();
+  });
 });

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -771,8 +771,8 @@ describe("defineWorld", () => {
       });
 
       attest<"namespace">(config.namespace).equals("namespace");
-      attest<"namespace">(config.tables.Example.namespace).equals("namespace");
-      attest(config.tables.Example.tableId).equals(
+      attest<"namespace">(config.tables.namespace__Example.namespace).equals("namespace");
+      attest(config.tables.namespace__Example.tableId).equals(
         resourceToHex({ type: "table", name: "Example", namespace: "namespace" }),
       );
     });
@@ -785,11 +785,26 @@ describe("defineWorld", () => {
         Example: {
           schema: { id: "address" },
           key: ["id"],
-          name: "CustomName",
         },
       },
     });
 
-    attest<"CustomNamespace__CustomName", keyof typeof config.tables>();
+    attest<"CustomNamespace__Example", keyof typeof config.tables>();
+  });
+
+  it("should throw if trying to override namespace or name in the store/namespace config", () => {
+    const config = defineWorld({
+      namespace: "CustomNamespace",
+      tables: {
+        Example: {
+          schema: { id: "address" },
+          key: ["id"],
+          name: "NotAllowed",
+          namespace: "NotAllowed",
+        },
+      },
+    });
+
+    attest<"CustomNamespace__Example", keyof typeof config.tables>();
   });
 });

--- a/packages/world/ts/config/v2/world.ts
+++ b/packages/world/ts/config/v2/world.ts
@@ -1,16 +1,13 @@
 import { conform, evaluate, narrow } from "@arktype/util";
-import { mapObject } from "@latticexyz/common/utils";
 import {
   UserTypes,
   extendedScope,
   get,
   resolveTable,
   validateTable,
-  resolveCodegen as resolveStoreCodegen,
   mergeIfUndefined,
   validateTables,
   resolveStore,
-  resolveTables,
   Store,
   hasOwnKey,
   validateStore,
@@ -77,7 +74,6 @@ export function resolveWorld<const world>(world: world): resolveWorld<world> {
   validateWorld(world);
 
   const scope = extendedScope(world);
-  const namespace = get(world, "namespace") ?? "";
 
   const namespaces = get(world, "namespaces") ?? {};
   validateNamespaces(namespaces, scope);
@@ -99,18 +95,13 @@ export function resolveWorld<const world>(world: world): resolveWorld<world> {
       .flat(),
   ) as Tables;
 
-  const resolvedRootTables = resolveTables(
-    mapObject(rootTables, (table) => mergeIfUndefined(table, { namespace })),
-    scope,
-  );
+  const resolvedStore = resolveStore(world);
 
   return mergeIfUndefined(
     {
-      tables: { ...resolvedRootTables, ...resolvedNamespacedTables },
-      userTypes: world.userTypes ?? {},
-      enums: world.enums ?? {},
-      namespace,
-      codegen: mergeIfUndefined(resolveStoreCodegen(world.codegen), resolveCodegen(world.codegen)),
+      ...resolvedStore,
+      tables: { ...resolvedStore.tables, ...resolvedNamespacedTables },
+      codegen: mergeIfUndefined(resolvedStore.codegen, resolveCodegen(world.codegen)),
       deployment: resolveDeployment(world.deployment),
       systems: resolveSystems(world.systems ?? CONFIG_DEFAULTS.systems),
       excludeSystems: get(world, "excludeSystems"),

--- a/packages/world/ts/config/v2/world.ts
+++ b/packages/world/ts/config/v2/world.ts
@@ -70,16 +70,9 @@ export type resolveWorld<world> = evaluate<
     >
 >;
 
-export function resolveWorld<const world>(world: world): resolveWorld<world> {
-  validateWorld(world);
-
+export function resolveWorld<const world extends WorldInput>(world: world): resolveWorld<world> {
   const scope = extendedScope(world);
-
-  const namespaces = get(world, "namespaces") ?? {};
-  validateNamespaces(namespaces, scope);
-
-  const rootTables = get(world, "tables") ?? {};
-  validateTables(rootTables, scope);
+  const namespaces = world.namespaces ?? {};
 
   const resolvedNamespacedTables = Object.fromEntries(
     Object.entries(namespaces)
@@ -112,5 +105,6 @@ export function resolveWorld<const world>(world: world): resolveWorld<world> {
 }
 
 export function defineWorld<const world>(world: validateWorld<world>): resolveWorld<world> {
+  validateWorld(world);
   return resolveWorld(world) as unknown as resolveWorld<world>;
 }

--- a/packages/world/ts/config/v2/worldWithShorthands.ts
+++ b/packages/world/ts/config/v2/worldWithShorthands.ts
@@ -8,7 +8,6 @@ import {
   resolveTableShorthand,
   resolveTablesWithShorthands,
   validateTablesWithShorthands,
-  validateTableShorthand,
   Scope,
 } from "@latticexyz/store/config/v2";
 import { mapObject } from "@latticexyz/common/utils";
@@ -64,16 +63,12 @@ export function resolveWorldWithShorthands<world>(world: world): resolveWorldWit
 
   const scope = extendedScope(world);
   const tables = mapObject(world.tables ?? {}, (table) => {
-    return isTableShorthandInput(table)
-      ? resolveTableShorthand(table as validateTableShorthand<typeof table, typeof scope>, scope)
-      : table;
+    return isTableShorthandInput(table) ? resolveTableShorthand(table, scope) : table;
   });
   const namespaces = mapObject(world.namespaces ?? {}, (namespace) => ({
     ...namespace,
     tables: mapObject(namespace.tables ?? {}, (table) => {
-      return isTableShorthandInput(table)
-        ? resolveTableShorthand(table as validateTableShorthand<typeof table, typeof scope>, scope)
-        : table;
+      return isTableShorthandInput(table) ? resolveTableShorthand(table, scope) : table;
     }),
   }));
 

--- a/packages/world/ts/config/v2/worldWithShorthands.ts
+++ b/packages/world/ts/config/v2/worldWithShorthands.ts
@@ -58,9 +58,9 @@ export type validateNamespacesWithShorthands<namespaces, scope extends Scope = A
   };
 };
 
-export function resolveWorldWithShorthands<world>(world: world): resolveWorldWithShorthands<world> {
-  validateWorldWithShorthands(world);
-
+export function resolveWorldWithShorthands<world extends WorldWithShorthandsInput>(
+  world: world,
+): resolveWorldWithShorthands<world> {
   const scope = extendedScope(world);
   const tables = mapObject(world.tables ?? {}, (table) => {
     return isTableShorthandInput(table) ? resolveTableShorthand(table, scope) : table;
@@ -73,6 +73,7 @@ export function resolveWorldWithShorthands<world>(world: world): resolveWorldWit
   }));
 
   const fullConfig = { ...world, tables, namespaces };
+  validateWorld(fullConfig);
 
   return resolveWorld(fullConfig) as unknown as resolveWorldWithShorthands<world>;
 }
@@ -80,5 +81,6 @@ export function resolveWorldWithShorthands<world>(world: world): resolveWorldWit
 export function defineWorldWithShorthands<world>(
   world: validateWorldWithShorthands<world>,
 ): resolveWorldWithShorthands<world> {
-  return resolveWorldWithShorthands(world) as resolveWorldWithShorthands<world>;
+  validateWorldWithShorthands(world);
+  return resolveWorldWithShorthands(world) as unknown as resolveWorldWithShorthands<world>;
 }


### PR DESCRIPTION
- Adds an explicit type error to validators when trying to override `namespace` or `name` when defining tables in a store/world config. `name`/`namespace` is still on the `TableInput` type so we can use it internally.
- Slightly refactored the validator pattern to move runtime validation to `defineX` and expect a fully validated input in `resolveX`
- Updates the store resolver to map tables to a prefixed key if a `namespace` option is provided in the config