### PR TITLE
Revert "chore: ignore test package in changeset flow"

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["mock-game-contracts"],
+  "ignore": [],
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"

--- a/test/mock-game-contracts/CHANGELOG.md
+++ b/test/mock-game-contracts/CHANGELOG.md
@@ -1,0 +1,5 @@
+# mock-game-contracts
+
+## 2.0.0
+
+## 2.0.0-next.18

--- a/test/mock-game-contracts/package.json
+++ b/test/mock-game-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-game-contracts",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Reverts latticexyz/mud#2509

> error ValidationError: Some errors occurred when validating the changesets config:
> error The package "@latticexyz/store-sync" depends on the ignored package "mock-game-contracts", but "@latticexyz/store-sync" is not being ignored. Please add "@latticexyz/store-sync" to the `ignore` option.