### PR TITLE
fix(store,world): minor config validation fixes

### DIFF
--- a/.changeset/dry-toes-lay.md
+++ b/.changeset/dry-toes-lay.md
@@ -1,0 +1,8 @@
+---
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Minor fixes to validations of the new config:
+- `systems.openAccess` incorrectly expected `true` as the only valid input. It now allows `boolean`.
+- `enums` complained if a the enums object was defined `as const` outside the input. This is now possible.

--- a/.changeset/dry-toes-lay.md
+++ b/.changeset/dry-toes-lay.md
@@ -3,6 +3,6 @@
 "@latticexyz/world": patch
 ---
 
-Minor fixes to validations of the new config:
+Minor fixes to config input validations:
 - `systems.openAccess` incorrectly expected `true` as the only valid input. It now allows `boolean`.
 - `enums` complained if a the enums object was defined `as const` outside the input. This is now possible.

--- a/.changeset/dry-toes-lay.md
+++ b/.changeset/dry-toes-lay.md
@@ -4,6 +4,7 @@
 ---
 
 Minor fixes to config input validations:
+
 - `systems.openAccess` incorrectly expected `true` as the only valid input. It now allows `boolean`.
 - The config complained if parts of it were defined `as const` outside the config input. This is now possible.
 - Shorthand inputs are now enabled.

--- a/.changeset/dry-toes-lay.md
+++ b/.changeset/dry-toes-lay.md
@@ -5,4 +5,5 @@
 
 Minor fixes to config input validations:
 - `systems.openAccess` incorrectly expected `true` as the only valid input. It now allows `boolean`.
-- `enums` complained if a the enums object was defined `as const` outside the input. This is now possible.
+- The config complained if parts of it were defined `as const` outside the config input. This is now possible.
+- Shorthand inputs are now enabled.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -59,7 +59,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.25",
+    "@arktype/util": "0.0.27",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/protocol-parser": "workspace:*",

--- a/packages/store/ts/config/v2/input.ts
+++ b/packages/store/ts/config/v2/input.ts
@@ -38,7 +38,7 @@ export type StoreInput = {
 export type TableShorthandInput = SchemaInput | string;
 
 export type TablesWithShorthandsInput = {
-  [key: string]: TableInput | TableShorthandInput;
+  readonly [key: string]: TableInput | TableShorthandInput;
 };
 
 export type StoreWithShorthandsInput = Omit<StoreInput, "tables"> & { tables: TablesWithShorthandsInput };

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -495,4 +495,12 @@ describe("defineStore", () => {
       }),
     ).throwsAndHasTypeError("Overrides of `name` and `namespace` are not allowed for tables in a store config");
   });
+
+  it("should allow const enum as input", () => {
+    const enums = {
+      Example: ["First", "Second"],
+    } as const;
+
+    defineStore({ enums });
+  });
 });

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -503,4 +503,17 @@ describe("defineStore", () => {
 
     attest(defineStore({ enums }).enums).equals(enums);
   });
+
+  it("should allow a const config as input", () => {
+    const config = {
+      tables: {
+        Example: {
+          schema: { id: "address", name: "string", age: "uint256" },
+          key: ["age"],
+        },
+      },
+    } as const;
+
+    defineStore(config);
+  });
 });

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -501,6 +501,6 @@ describe("defineStore", () => {
       Example: ["First", "Second"],
     } as const;
 
-    defineStore({ enums });
+    attest(defineStore({ enums }).enums).equals(enums);
   });
 });

--- a/packages/store/ts/config/v2/table.test.ts
+++ b/packages/store/ts/config/v2/table.test.ts
@@ -9,7 +9,7 @@ import { getKeySchema, getValueSchema } from "@latticexyz/protocol-parser/intern
 describe("validateKeys", () => {
   it("should return a tuple of valid keys", () => {
     attest<
-      ["static"],
+      readonly ["static"],
       validateKeys<getStaticAbiTypeKeys<{ static: "uint256"; dynamic: "string" }, AbiTypeScope>, ["static"]>
     >();
   });
@@ -18,7 +18,7 @@ describe("validateKeys", () => {
     const scope = extendScope(AbiTypeScope, { static: "address", dynamic: "string" });
 
     attest<
-      ["static", "customStatic"],
+      readonly ["static", "customStatic"],
       validateKeys<
         getStaticAbiTypeKeys<
           { static: "uint256"; dynamic: "string"; customStatic: "static"; customDynamic: "dynamic" },
@@ -33,7 +33,7 @@ describe("validateKeys", () => {
     const scope = extendScope(AbiTypeScope, { static: "address", dynamic: "string" });
 
     attest<
-      ["static", "customStatic"],
+      readonly ["static", "customStatic"],
       validateKeys<
         getStaticAbiTypeKeys<
           { static: "uint256"; dynamic: "string"; customStatic: "static"; customDynamic: "dynamic" },
@@ -218,13 +218,13 @@ describe("resolveTable", () => {
     attest(() =>
       defineTable({
         schema: { id: "address" },
-        // @ts-expect-error Type 'string' is not assignable to type 'string[]'
+        // @ts-expect-error Type 'string' is not assignable to type 'readonly string[]'
         key: "",
         name: "",
       }),
     )
       .throws('Invalid key. Expected `("id")[]`, received ``')
-      .type.errors("Type 'string' is not assignable to type 'string[]'");
+      .type.errors("Type 'string' is not assignable to type 'readonly string[]'");
   });
 
   it("should throw if a string is provided as schema", () => {

--- a/packages/store/ts/config/v2/table.ts
+++ b/packages/store/ts/config/v2/table.ts
@@ -37,11 +37,11 @@ export function isValidPrimaryKey<schema extends SchemaInput, scope extends Scop
   );
 }
 
-export type validateKeys<validKeys extends PropertyKey, keys> = keys extends string[]
+export type validateKeys<validKeys extends PropertyKey, keys> = keys extends readonly string[]
   ? {
-      [i in keyof keys]: keys[i] extends validKeys ? keys[i] : validKeys;
+      readonly [i in keyof keys]: keys[i] extends validKeys ? keys[i] : validKeys;
     }
-  : string[];
+  : readonly string[];
 
 export type ValidateTableOptions = { inStoreContext: boolean };
 

--- a/packages/store/ts/exports/index.ts
+++ b/packages/store/ts/exports/index.ts
@@ -16,5 +16,5 @@ export {
 export { storeEventsAbi } from "../storeEventsAbi";
 export type { StoreEventsAbi, StoreEventsAbiItem } from "../storeEventsAbi";
 
-export { defineStore } from "../config/v2/store";
+export { defineStoreWithShorthands as defineStore } from "../config/v2/storeWithShorthands";
 export type { Store } from "../config/v2/output";

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -54,7 +54,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.25",
+    "@arktype/util": "0.0.27",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/schema-type": "workspace:*",

--- a/packages/world/ts/config/v2/input.ts
+++ b/packages/world/ts/config/v2/input.ts
@@ -14,7 +14,7 @@ export type SystemInput = {
    */
   registerFunctionSelectors?: boolean;
   /** If openAccess is true, any address can call the system */
-  openAccess?: true;
+  openAccess?: boolean;
   /** An array of addresses or system names that can access the system */
   accessList?: string[];
 };

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -739,4 +739,17 @@ describe("defineWorld", () => {
 
     attest<false>(config.systems.Example.openAccess).equals(false);
   });
+
+  it("should allow a const config as input", () => {
+    const config = {
+      tables: {
+        Example: {
+          schema: { id: "address", name: "string", age: "uint256" },
+          key: ["age"],
+        },
+      },
+    } as const;
+
+    defineWorld(config);
+  });
 });

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -729,12 +729,14 @@ describe("defineWorld", () => {
   });
 
   it("should allow setting openAccess of a system to false", () => {
-    defineWorld({
+    const config = defineWorld({
       systems: {
         Example: {
           openAccess: false,
         },
       },
     });
+
+    attest<false>(config.systems.Example.openAccess).equals(false);
   });
 });

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -727,4 +727,14 @@ describe("defineWorld", () => {
       }),
     ).type.errors("Namespaces config will be enabled soon.");
   });
+
+  it("should allow setting openAccess of a system to false", () => {
+    defineWorld({
+      systems: {
+        Example: {
+          openAccess: false,
+        },
+      },
+    });
+  });
 });

--- a/packages/world/ts/config/v2/worldWithShorthands.test.ts
+++ b/packages/world/ts/config/v2/worldWithShorthands.test.ts
@@ -321,4 +321,17 @@ describe("defineWorldWithShorthands", () => {
       "Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option.",
     );
   });
+
+  it("should allow a const config as input", () => {
+    const config = {
+      tables: {
+        Example: {
+          schema: { id: "address", name: "string", age: "uint256" },
+          key: ["age"],
+        },
+      },
+    } as const;
+
+    defineWorldWithShorthands(config);
+  });
 });

--- a/packages/world/ts/exports/index.ts
+++ b/packages/world/ts/exports/index.ts
@@ -6,5 +6,5 @@
 
 export { helloWorldEvent, worldDeployedEvent } from "../worldEvents";
 
-export { defineWorld } from "../config/v2/world";
+export { defineWorldWithShorthands as defineWorld } from "../config/v2/worldWithShorthands";
 export type { World } from "../config/v2/output";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,8 +430,6 @@ importers:
         specifier: 0.34.6
         version: 0.34.6(jsdom@22.1.0)
 
-  packages/ecs-browser: {}
-
   packages/faucet:
     dependencies:
       '@fastify/compress':
@@ -523,12 +521,6 @@ importers:
       vitest:
         specifier: 0.34.6
         version: 0.34.6(jsdom@22.1.0)
-
-  packages/network: {}
-
-  packages/noise: {}
-
-  packages/phaserx: {}
 
   packages/protocol-parser:
     dependencies:
@@ -713,8 +705,6 @@ importers:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.23)(typescript@5.4.2)
 
-  packages/solecs: {}
-
   packages/solhint-config-mud:
     devDependencies:
       tsup:
@@ -734,15 +724,11 @@ importers:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.23)(typescript@5.4.2)
 
-  packages/std-client: {}
-
-  packages/std-contracts: {}
-
   packages/store:
     dependencies:
       '@arktype/util':
-        specifier: 0.0.25
-        version: 0.0.25
+        specifier: 0.0.27
+        version: 0.0.27
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -804,8 +790,6 @@ importers:
       vitest:
         specifier: 0.34.6
         version: 0.34.6(jsdom@22.1.0)
-
-  packages/store-cache: {}
 
   packages/store-indexer:
     dependencies:
@@ -1038,8 +1022,8 @@ importers:
   packages/world:
     dependencies:
       '@arktype/util':
-        specifier: 0.0.25
-        version: 0.0.25
+        specifier: 0.0.27
+        version: 0.0.27
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -1253,8 +1237,8 @@ packages:
     resolution: {integrity: sha512-MwtDGjbgfXWxlExjIL78HvPlWOma1XFEcDd3VWuCPMt/f+3TR7fXyiGFNlIYZGOYdOIU7qgjaE8dmbd6jdJa3Q==}
     dev: true
 
-  /@arktype/util@0.0.25:
-    resolution: {integrity: sha512-rcUpLkSNC6mA9qSesSL2WvSLzEbyh2VvzeLcywE6i6bp9TPLpB6G3k5cpVjM3bCE6bpZmTR2SR3ybZuQ+tCvbw==}
+  /@arktype/util@0.0.27:
+    resolution: {integrity: sha512-ZkPuSU8Q56YVgPInFhojLTujejM+VPfaZx6Guop41CvnozWFOTlC0uAHuDqvY4nYq3zXsMkRwm8LmaRZ3mslMg==}
     dev: false
 
   /@babel/code-frame@7.21.4:


### PR DESCRIPTION
Minor fixes to config input validations:
- `systems.openAccess` incorrectly expected `true` as the only valid input. It now allows `boolean`.
- The config complained if parts of it were defined `as const` outside the config input. This is now possible.
- Shorthand inputs are now enabled.