### PR TITLE
refactor(store,world): refactor types, remove redundant casts

### DIFF
--- a/.changeset/late-bats-smash.md
+++ b/.changeset/late-bats-smash.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/store": patch
+"@latticexyz/world": patch
+---
+
+Internal type improvements.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -59,7 +59,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.27",
+    "@arktype/util": "0.0.29",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/protocol-parser": "workspace:*",

--- a/packages/store/ts/config/defaults.ts
+++ b/packages/store/ts/config/defaults.ts
@@ -5,11 +5,15 @@ export const PATH_DEFAULTS = {
   codegenIndexFilename: "index.sol",
 } as const;
 
+export type PATH_DEFAULTS = typeof PATH_DEFAULTS;
+
 export const DEFAULTS = {
   namespace: "",
   enums: {} as Record<string, never>,
   userTypes: {} as Record<string, never>,
 } as const;
+
+export type DEFAULTS = typeof DEFAULTS;
 
 export const TABLE_DEFAULTS = {
   directory: "tables",
@@ -18,3 +22,5 @@ export const TABLE_DEFAULTS = {
   storeArgument: false,
   offchainOnly: false,
 } as const;
+
+export type TABLE_DEFAULTS = typeof TABLE_DEFAULTS;

--- a/packages/store/ts/config/defaults.ts
+++ b/packages/store/ts/config/defaults.ts
@@ -9,8 +9,8 @@ export type PATH_DEFAULTS = typeof PATH_DEFAULTS;
 
 export const DEFAULTS = {
   namespace: "",
-  enums: {} as Record<string, never>,
-  userTypes: {} as Record<string, never>,
+  enums: {},
+  userTypes: {},
 } as const;
 
 export type DEFAULTS = typeof DEFAULTS;

--- a/packages/store/ts/config/v2/codegen.ts
+++ b/packages/store/ts/config/v2/codegen.ts
@@ -2,8 +2,8 @@ import { CODEGEN_DEFAULTS } from "./defaults";
 import { isObject, mergeIfUndefined } from "./generics";
 
 export type resolveCodegen<codegen> = codegen extends {}
-  ? mergeIfUndefined<codegen, typeof CODEGEN_DEFAULTS>
-  : typeof CODEGEN_DEFAULTS;
+  ? mergeIfUndefined<codegen, CODEGEN_DEFAULTS>
+  : CODEGEN_DEFAULTS;
 
 export function resolveCodegen<codegen>(codegen: codegen): resolveCodegen<codegen> {
   return (

--- a/packages/store/ts/config/v2/compat.ts
+++ b/packages/store/ts/config/v2/compat.ts
@@ -71,5 +71,5 @@ export function storeToV1<store>(store: conform<store, Store>): storeToV1<store>
     codegenIndexFilename: store.codegen.indexFilename,
     tables: resolvedTables,
     v2: store,
-  } as unknown as storeToV1<store>;
+  } as never;
 }

--- a/packages/store/ts/config/v2/defaults.ts
+++ b/packages/store/ts/config/v2/defaults.ts
@@ -5,21 +5,31 @@ export const CODEGEN_DEFAULTS = {
   indexFilename: "index.sol",
 } as const;
 
+export type CODEGEN_DEFAULTS = typeof CODEGEN_DEFAULTS;
+
 export const TABLE_CODEGEN_DEFAULTS = {
   outputDirectory: "tables",
   tableIdArgument: false,
   storeArgument: false,
 } as const;
 
+export type TABLE_CODEGEN_DEFAULTS = typeof TABLE_CODEGEN_DEFAULTS;
+
 export const TABLE_DEPLOY_DEFAULTS = {
   disabled: false,
 } as const;
+
+export type TABLE_DEPLOY_DEFAULTS = typeof TABLE_DEPLOY_DEFAULTS;
 
 export const TABLE_DEFAULTS = {
   namespace: "",
   type: "table",
 } as const;
 
+export type TABLE_DEFAULTS = typeof TABLE_DEFAULTS;
+
 export const CONFIG_DEFAULTS = {
   namespace: "",
 } as const;
+
+export type CONFIG_DEFAULTS = typeof CONFIG_DEFAULTS;

--- a/packages/store/ts/config/v2/enums.ts
+++ b/packages/store/ts/config/v2/enums.ts
@@ -21,9 +21,9 @@ export function scopeWithEnums<enums, scope extends AbiTypeScope = AbiTypeScope>
 ): scopeWithEnums<enums, scope> {
   if (isEnums(enums)) {
     const enumScope = Object.fromEntries(Object.keys(enums).map((key) => [key, "uint8" as const]));
-    return extendScope(scope, enumScope) as scopeWithEnums<enums, scope>;
+    return extendScope(scope, enumScope) as never;
   }
-  return scope as scopeWithEnums<enums, scope>;
+  return scope as never;
 }
 
 export type resolveEnums<enums> = { readonly [key in keyof enums]: Readonly<enums[key]> };

--- a/packages/store/ts/config/v2/generics.ts
+++ b/packages/store/ts/config/v2/generics.ts
@@ -3,10 +3,20 @@ import { merge } from "@arktype/util";
 export type get<input, key> = key extends keyof input ? input[key] : undefined;
 
 export function get<input, key extends PropertyKey>(input: input, key: key): get<input, key> {
-  return (typeof input === "object" && input != null && hasOwnKey(input, key) ? input[key] : undefined) as get<
-    input,
-    key
-  >;
+  return (typeof input === "object" && input != null && hasOwnKey(input, key) ? input[key] : undefined) as never;
+}
+
+export type getPath<input, path extends readonly PropertyKey[]> = path extends readonly [
+  infer head,
+  ...infer tail extends PropertyKey[],
+]
+  ? head extends keyof input
+    ? getPath<input[head], tail>
+    : undefined
+  : input;
+
+export function getPath<input, path extends readonly PropertyKey[]>(input: input, path: path): getPath<input, path> {
+  return path.length ? (getPath(get(input, path[0]), path.slice(1)) as never) : (input as never);
 }
 
 export function hasOwnKey<obj, const key extends PropertyKey>(
@@ -39,5 +49,5 @@ export function mergeIfUndefined<base extends object, merged extends object>(
   const allKeys = [...new Set([...Object.keys(base), ...Object.keys(merged)])];
   return Object.fromEntries(
     allKeys.map((key) => [key, base[key as keyof base] ?? merged[key as keyof merged]]),
-  ) as mergeIfUndefined<base, merged>;
+  ) as never;
 }

--- a/packages/store/ts/config/v2/input.ts
+++ b/packages/store/ts/config/v2/input.ts
@@ -1,6 +1,7 @@
 import { Hex } from "viem";
 import { Codegen, Enums, TableCodegen, TableDeploy, UserTypes } from "./output";
 import { Scope } from "./scope";
+import { evaluate } from "@arktype/util";
 
 export type SchemaInput = {
   readonly [key: string]: string;
@@ -41,4 +42,4 @@ export type TablesWithShorthandsInput = {
   readonly [key: string]: TableInput | TableShorthandInput;
 };
 
-export type StoreWithShorthandsInput = Omit<StoreInput, "tables"> & { tables: TablesWithShorthandsInput };
+export type StoreWithShorthandsInput = evaluate<Omit<StoreInput, "tables"> & { tables: TablesWithShorthandsInput }>;

--- a/packages/store/ts/config/v2/output.ts
+++ b/packages/store/ts/config/v2/output.ts
@@ -1,3 +1,4 @@
+import { evaluate } from "@arktype/util";
 import { AbiType, Schema, Table as BaseTable } from "@latticexyz/config";
 
 export type { AbiType, Schema };
@@ -21,10 +22,12 @@ export type TableDeploy = {
   readonly disabled: boolean;
 };
 
-export type Table = BaseTable & {
-  readonly codegen: TableCodegen;
-  readonly deploy: TableDeploy;
-};
+export type Table = evaluate<
+  BaseTable & {
+    readonly codegen: TableCodegen;
+    readonly deploy: TableDeploy;
+  }
+>;
 
 export type Codegen = {
   readonly storeImportPath: string;

--- a/packages/store/ts/config/v2/schema.ts
+++ b/packages/store/ts/config/v2/schema.ts
@@ -28,7 +28,7 @@ export function validateSchema<scope extends Scope = AbiTypeScope>(
 }
 
 export type resolveSchema<schema, scope extends Scope> = evaluate<{
-  [key in keyof schema]: {
+  readonly [key in keyof schema]: {
     /** the Solidity primitive ABI type */
     readonly type: schema[key] extends FixedArrayAbiType
       ? fixedArrayToArray<schema[key]>

--- a/packages/store/ts/config/v2/schema.ts
+++ b/packages/store/ts/config/v2/schema.ts
@@ -14,7 +14,7 @@ export type validateSchema<schema, scope extends Scope = AbiTypeScope> = schema 
 
 export function validateSchema<scope extends Scope = AbiTypeScope>(
   schema: unknown,
-  scope: scope = AbiTypeScope as unknown as scope,
+  scope: scope = AbiTypeScope as never,
 ): asserts schema is SchemaInput {
   if (!isObject(schema)) {
     throw new Error(`Expected schema, received ${JSON.stringify(schema)}`);
@@ -28,7 +28,7 @@ export function validateSchema<scope extends Scope = AbiTypeScope>(
 }
 
 export type resolveSchema<schema, scope extends Scope> = evaluate<{
-  readonly [key in keyof schema]: {
+  [key in keyof schema]: {
     /** the Solidity primitive ABI type */
     readonly type: schema[key] extends FixedArrayAbiType
       ? fixedArrayToArray<schema[key]>
@@ -46,13 +46,11 @@ export function resolveSchema<schema extends SchemaInput, scope extends Scope = 
     Object.entries(schema).map(([key, internalType]) => [
       key,
       {
-        type: isFixedArrayAbiType(internalType)
-          ? fixedArrayToArray(internalType)
-          : scope.types[internalType as keyof typeof scope.types],
+        type: isFixedArrayAbiType(internalType) ? fixedArrayToArray(internalType) : scope.types[internalType as never],
         internalType,
       },
     ]),
-  ) as unknown as resolveSchema<schema, scope>;
+  ) as never;
 }
 
 export function defineSchema<schema, scope extends AbiTypeScope = AbiTypeScope>(
@@ -60,12 +58,12 @@ export function defineSchema<schema, scope extends AbiTypeScope = AbiTypeScope>(
   scope: scope = AbiTypeScope as scope,
 ): resolveSchema<schema, scope> {
   validateSchema(schema, scope);
-  return resolveSchema(schema, scope) as resolveSchema<schema, scope>;
+  return resolveSchema(schema, scope) as never;
 }
 
 export function isSchemaInput<scope extends Scope = AbiTypeScope>(
   input: unknown,
-  scope: scope = AbiTypeScope as unknown as scope,
+  scope: scope = AbiTypeScope as never,
 ): input is SchemaInput {
   return (
     typeof input === "object" &&

--- a/packages/store/ts/config/v2/scope.ts
+++ b/packages/store/ts/config/v2/scope.ts
@@ -21,7 +21,7 @@ export type getStaticAbiTypeKeys<
 > = SchemaInput extends schema
   ? string
   : {
-      [key in keyof schema]: scope["types"][schema[key] & keyof scope["types"]] extends StaticAbiType ? key : never;
+      [key in keyof schema]: scope["types"] extends { [_ in schema[key]]: StaticAbiType } ? key : never;
     }[keyof schema];
 
 export type extendScope<scope extends ScopeOptions, additionalTypes extends Dict<string, AbiType>> = evaluate<

--- a/packages/store/ts/config/v2/storeWithShorthands.ts
+++ b/packages/store/ts/config/v2/storeWithShorthands.ts
@@ -40,12 +40,12 @@ export function resolveStoreWithShorthands<const store extends StoreWithShorthan
   };
 
   validateStore(fullConfig);
-  return resolveStore(fullConfig) as unknown as resolveStoreWithShorthands<store>;
+  return resolveStore(fullConfig) as never;
 }
 
 export function defineStoreWithShorthands<const store>(
   store: validateStoreWithShorthands<store>,
 ): resolveStoreWithShorthands<store> {
   validateStoreWithShorthands(store);
-  return resolveStoreWithShorthands(store) as unknown as resolveStoreWithShorthands<store>;
+  return resolveStoreWithShorthands(store) as never;
 }

--- a/packages/store/ts/config/v2/tableShorthand.test.ts
+++ b/packages/store/ts/config/v2/tableShorthand.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import { attest } from "@arktype/attest";
 import { AbiTypeScope, extendScope } from "./scope";
-import { defineTableShorthand } from "./tableShorthand";
+import { defineTableShorthand, NoStaticKeyFieldError } from "./tableShorthand";
 
 describe("defineTableShorthand", () => {
   it("should expand a single ABI type into a id/value schema", () => {
@@ -146,8 +146,6 @@ describe("defineTableShorthand", () => {
     attest(() =>
       // @ts-expect-error "Error: Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option."
       defineTableShorthand({ id: "CustomType", name: "string", age: "uint256" }, scope),
-    ).throwsAndHasTypeError(
-      "Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option.",
-    );
+    ).throwsAndHasTypeError(NoStaticKeyFieldError);
   });
 });

--- a/packages/store/ts/config/v2/tableShorthand.ts
+++ b/packages/store/ts/config/v2/tableShorthand.ts
@@ -7,8 +7,10 @@ import { SchemaInput, ScopedSchemaInput, TablesWithShorthandsInput } from "./inp
 import { TableShorthandInput } from "./input";
 import { ValidateTableOptions, validateTable } from "./table";
 
-export type NoStaticKeyFieldError =
-  ErrorMessage<"Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option.">;
+export const NoStaticKeyFieldError =
+  "Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option.";
+
+export type NoStaticKeyFieldError = ErrorMessage<typeof NoStaticKeyFieldError>;
 
 export function isTableShorthandInput(shorthand: unknown): shorthand is TableShorthandInput {
   return (
@@ -43,7 +45,7 @@ export type validateTableShorthand<input, scope extends Scope = AbiTypeScope> = 
 
 export function validateTableShorthand<scope extends Scope = AbiTypeScope>(
   shorthand: unknown,
-  scope: scope = AbiTypeScope as unknown as scope,
+  scope: scope = AbiTypeScope as never,
 ): asserts shorthand is TableShorthandInput {
   if (typeof shorthand === "string") {
     if (isFixedArrayAbiType(shorthand) || hasOwnKey(scope.types, shorthand)) {
@@ -76,13 +78,13 @@ export type resolveTableShorthand<shorthand, scope extends Scope = AbiTypeScope>
 
 export function resolveTableShorthand<shorthand extends TableShorthandInput, scope extends Scope = AbiTypeScope>(
   shorthand: shorthand,
-  scope: scope = AbiTypeScope as unknown as scope,
+  scope: scope = AbiTypeScope as never,
 ): resolveTableShorthand<shorthand, scope> {
   if (isSchemaInput(shorthand, scope)) {
     return {
       schema: shorthand,
       key: ["id"],
-    } as unknown as resolveTableShorthand<shorthand, scope>;
+    } as never;
   }
 
   return {
@@ -91,15 +93,15 @@ export function resolveTableShorthand<shorthand extends TableShorthandInput, sco
       value: shorthand,
     },
     key: ["id"],
-  } as unknown as resolveTableShorthand<shorthand, scope>;
+  } as never;
 }
 
 export function defineTableShorthand<shorthand, scope extends Scope = AbiTypeScope>(
   shorthand: validateTableShorthand<shorthand, scope>,
-  scope: scope = AbiTypeScope as unknown as scope,
+  scope: scope = AbiTypeScope as never,
 ): resolveTableShorthand<shorthand, scope> {
   validateTableShorthand(shorthand, scope);
-  return resolveTableShorthand(shorthand, scope) as resolveTableShorthand<shorthand, scope>;
+  return resolveTableShorthand(shorthand, scope) as never;
 }
 
 /**

--- a/packages/store/ts/config/v2/tables.ts
+++ b/packages/store/ts/config/v2/tables.ts
@@ -39,5 +39,5 @@ export function resolveTables<tables extends TablesInput, scope extends Scope = 
     Object.entries(tables).map(([key, table]) => {
       return [key, resolveTable(mergeIfUndefined(table, { name: key }), scope)];
     }),
-  ) as unknown as resolveTables<tables, scope>;
+  ) as never;
 }

--- a/packages/store/ts/config/v2/userTypes.ts
+++ b/packages/store/ts/config/v2/userTypes.ts
@@ -24,10 +24,7 @@ export function scopeWithUserTypes<userTypes, scope extends AbiTypeScope = AbiTy
   userTypes: userTypes,
   scope: scope = AbiTypeScope as scope,
 ): scopeWithUserTypes<userTypes, scope> {
-  return (isUserTypes(userTypes) ? extendScope(scope, extractInternalType(userTypes)) : scope) as scopeWithUserTypes<
-    userTypes,
-    scope
-  >;
+  return (isUserTypes(userTypes) ? extendScope(scope, extractInternalType(userTypes)) : scope) as never;
 }
 
 export function validateUserTypes(userTypes: unknown): asserts userTypes is UserTypes {

--- a/packages/store/ts/register/typeExtensions.ts
+++ b/packages/store/ts/register/typeExtensions.ts
@@ -20,18 +20,6 @@ declare module "@latticexyz/config/library" {
 }
 
 // store-specific helper to preserve strong types, depends on store's type extensions to the core config
-export interface ExpandMUDUserConfig<T extends MUDCoreUserConfig>
-  extends OrDefaults<
-    T,
-    {
-      enums: typeof DEFAULTS.enums;
-      userTypes: typeof DEFAULTS.userTypes;
-      namespace: typeof DEFAULTS.namespace;
-      storeImportPath: typeof PATH_DEFAULTS.storeImportPath;
-      userTypesFilename: typeof PATH_DEFAULTS.userTypesFilename;
-      codegenDirectory: typeof PATH_DEFAULTS.codegenDirectory;
-      codegenIndexFilename: typeof PATH_DEFAULTS.codegenIndexFilename;
-    }
-  > {
+export interface ExpandMUDUserConfig<T extends MUDCoreUserConfig> extends OrDefaults<T, DEFAULTS & PATH_DEFAULTS> {
   tables: ExpandTablesConfig<T["tables"]>;
 }

--- a/packages/store/ts/register/typeExtensions.ts
+++ b/packages/store/ts/register/typeExtensions.ts
@@ -20,6 +20,9 @@ declare module "@latticexyz/config/library" {
 }
 
 // store-specific helper to preserve strong types, depends on store's type extensions to the core config
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore this doesn't cause an error I can reproduce in-editor but fails on TSC with a complaint
+// about a systems prop that is not being extended
 export interface ExpandMUDUserConfig<T extends MUDCoreUserConfig> extends OrDefaults<T, DEFAULTS & PATH_DEFAULTS> {
   tables: ExpandTablesConfig<T["tables"]>;
 }

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -54,7 +54,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.27",
+    "@arktype/util": "0.0.29",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/protocol-parser": "workspace:*",

--- a/packages/world/ts/config/defaults.ts
+++ b/packages/world/ts/config/defaults.ts
@@ -4,6 +4,8 @@ export const SYSTEM_DEFAULTS = {
   accessList: [] as string[],
 } as const;
 
+export type SYSTEM_DEFAULTS = typeof SYSTEM_DEFAULTS;
+
 export const WORLD_DEFAULTS = {
   worldContractName: undefined,
   worldInterfaceName: "IWorld",
@@ -16,3 +18,5 @@ export const WORLD_DEFAULTS = {
   worldImportPath: "@latticexyz/world/src/",
   modules: [] as [],
 } as const;
+
+export type WORLD_DEFAULTS = typeof WORLD_DEFAULTS;

--- a/packages/world/ts/config/types.ts
+++ b/packages/world/ts/config/types.ts
@@ -34,11 +34,11 @@ export interface ExpandSystemConfig<T extends SystemUserConfig, SystemName exten
     T,
     {
       name: SystemName;
-      registerFunctionSelectors: typeof SYSTEM_DEFAULTS.registerFunctionSelector;
-      openAccess: typeof SYSTEM_DEFAULTS.openAccess;
+      registerFunctionSelectors: SYSTEM_DEFAULTS["registerFunctionSelector"];
+      openAccess: SYSTEM_DEFAULTS["openAccess"];
     }
   > {
-  accessList: T extends { accessList: string[] } ? T["accessList"] : typeof SYSTEM_DEFAULTS.accessList;
+  accessList: T extends { accessList: string[] } ? T["accessList"] : SYSTEM_DEFAULTS["accessList"];
 }
 
 export type SystemsUserConfig = Record<string, SystemUserConfig>;

--- a/packages/world/ts/config/v2/codegen.ts
+++ b/packages/world/ts/config/v2/codegen.ts
@@ -2,11 +2,9 @@ import { isObject, mergeIfUndefined } from "@latticexyz/store/config/v2";
 import { CODEGEN_DEFAULTS } from "./defaults";
 
 export type resolveCodegen<codegen> = codegen extends {}
-  ? mergeIfUndefined<codegen, typeof CODEGEN_DEFAULTS>
-  : typeof CODEGEN_DEFAULTS;
+  ? mergeIfUndefined<codegen, CODEGEN_DEFAULTS>
+  : CODEGEN_DEFAULTS;
 
 export function resolveCodegen<codegen>(codegen: codegen): resolveCodegen<codegen> {
-  return (
-    isObject(codegen) ? mergeIfUndefined(codegen, CODEGEN_DEFAULTS) : CODEGEN_DEFAULTS
-  ) as resolveCodegen<codegen>;
+  return (isObject(codegen) ? mergeIfUndefined(codegen, CODEGEN_DEFAULTS) : CODEGEN_DEFAULTS) as never;
 }

--- a/packages/world/ts/config/v2/compat.ts
+++ b/packages/world/ts/config/v2/compat.ts
@@ -12,7 +12,7 @@ function modulesToV1<modules extends readonly Module[]>(modules: modules): modul
     name: module.name,
     root: module.root ?? false,
     args: module.args ?? [],
-  })) as modulesToV1<modules>;
+  })) as never;
 }
 
 type systemsToV1<systems extends Systems> = {
@@ -56,5 +56,5 @@ export function worldToV1<world>(world: conform<world, World>): worldToV1<world>
     worldImportPath: world.codegen.worldImportPath,
   };
 
-  return { ...storeToV1(world as Store), ...v1WorldConfig, v2: world } as worldToV1<world>;
+  return { ...storeToV1(world as Store), ...v1WorldConfig, v2: world } as never;
 }

--- a/packages/world/ts/config/v2/defaults.ts
+++ b/packages/world/ts/config/v2/defaults.ts
@@ -4,11 +4,15 @@ export const SYSTEM_DEFAULTS = {
   accessList: [] as string[],
 } as const;
 
+export type SYSTEM_DEFAULTS = typeof SYSTEM_DEFAULTS;
+
 export const CODEGEN_DEFAULTS = {
   worldInterfaceName: "IWorld",
   worldgenDirectory: "world",
   worldImportPath: "@latticexyz/world/src/",
 } as const;
+
+export type CODEGEN_DEFAULTS = typeof CODEGEN_DEFAULTS;
 
 export const DEPLOY_DEFAULTS = {
   customWorldContract: undefined,
@@ -16,6 +20,8 @@ export const DEPLOY_DEFAULTS = {
   deploysDirectory: "./deploys",
   worldsFile: "./worlds.json",
 } as const;
+
+export type DEPLOY_DEFAULTS = typeof DEPLOY_DEFAULTS;
 
 export const CONFIG_DEFAULTS = {
   systems: {},
@@ -25,3 +31,5 @@ export const CONFIG_DEFAULTS = {
   codegen: CODEGEN_DEFAULTS,
   deploy: DEPLOY_DEFAULTS,
 } as const;
+
+export type CONFIG_DEFAULTS = typeof CONFIG_DEFAULTS;

--- a/packages/world/ts/config/v2/deploy.ts
+++ b/packages/world/ts/config/v2/deploy.ts
@@ -1,10 +1,8 @@
 import { mergeIfUndefined, isObject } from "@latticexyz/store/config/v2";
 import { DEPLOY_DEFAULTS } from "./defaults";
 
-export type resolveDeploy<deploy> = deploy extends {}
-  ? mergeIfUndefined<deploy, typeof DEPLOY_DEFAULTS>
-  : typeof DEPLOY_DEFAULTS;
+export type resolveDeploy<deploy> = deploy extends {} ? mergeIfUndefined<deploy, DEPLOY_DEFAULTS> : DEPLOY_DEFAULTS;
 
 export function resolveDeploy<deploy>(deploy: deploy): resolveDeploy<deploy> {
-  return (isObject(deploy) ? mergeIfUndefined(deploy, DEPLOY_DEFAULTS) : DEPLOY_DEFAULTS) as resolveDeploy<deploy>;
+  return (isObject(deploy) ? mergeIfUndefined(deploy, DEPLOY_DEFAULTS) : DEPLOY_DEFAULTS) as never;
 }

--- a/packages/world/ts/config/v2/world.ts
+++ b/packages/world/ts/config/v2/world.ts
@@ -67,7 +67,7 @@ export type resolveWorld<world> = evaluate<
         },
         "namespaces" | keyof Store
       >,
-      typeof CONFIG_DEFAULTS
+      CONFIG_DEFAULTS
     >
 >;
 
@@ -102,10 +102,10 @@ export function resolveWorld<const world extends WorldInput>(world: world): reso
       modules: world.modules,
     },
     CONFIG_DEFAULTS,
-  ) as unknown as resolveWorld<world>;
+  ) as never;
 }
 
 export function defineWorld<const world>(world: validateWorld<world>): resolveWorld<world> {
   validateWorld(world);
-  return resolveWorld(world) as unknown as resolveWorld<world>;
+  return resolveWorld(world) as never;
 }

--- a/packages/world/ts/config/v2/worldWithShorthands.ts
+++ b/packages/world/ts/config/v2/worldWithShorthands.ts
@@ -1,19 +1,19 @@
+import { mapObject } from "@latticexyz/common/utils";
 import {
   AbiTypeScope,
+  Scope,
   extendedScope,
-  get,
+  getPath,
   hasOwnKey,
   isObject,
   isTableShorthandInput,
   resolveTableShorthand,
   resolveTablesWithShorthands,
   validateTablesWithShorthands,
-  Scope,
 } from "@latticexyz/store/config/v2";
-import { mapObject } from "@latticexyz/common/utils";
-import { resolveWorld, validateWorld } from "./world";
 import { WorldWithShorthandsInput } from "./input";
 import { validateNamespaces } from "./namespaces";
+import { resolveWorld, validateWorld } from "./world";
 
 export type resolveWorldWithShorthands<world> = resolveWorld<{
   [key in keyof world]: key extends "tables"
@@ -45,7 +45,7 @@ function validateWorldWithShorthands(world: unknown): asserts world is WorldWith
 
   if (hasOwnKey(world, "namespaces") && isObject(world.namespaces)) {
     for (const namespaceKey of Object.keys(world.namespaces)) {
-      validateTablesWithShorthands(get(get(world.namespaces, namespaceKey), "tables") ?? {}, scope);
+      validateTablesWithShorthands(getPath(world.namespaces, [namespaceKey, "tables"]) ?? {}, scope);
     }
   }
 }
@@ -75,12 +75,12 @@ export function resolveWorldWithShorthands<world extends WorldWithShorthandsInpu
   const fullConfig = { ...world, tables, namespaces };
   validateWorld(fullConfig);
 
-  return resolveWorld(fullConfig) as unknown as resolveWorldWithShorthands<world>;
+  return resolveWorld(fullConfig) as never;
 }
 
 export function defineWorldWithShorthands<world>(
   world: validateWorldWithShorthands<world>,
 ): resolveWorldWithShorthands<world> {
   validateWorldWithShorthands(world);
-  return resolveWorldWithShorthands(world) as unknown as resolveWorldWithShorthands<world>;
+  return resolveWorldWithShorthands(world) as never;
 }

--- a/packages/world/ts/register/typeExtensions.ts
+++ b/packages/world/ts/register/typeExtensions.ts
@@ -22,21 +22,7 @@ declare module "@latticexyz/config/library" {
 }
 
 declare module "@latticexyz/store/register" {
-  export interface ExpandMUDUserConfig<T extends MUDCoreUserConfig>
-    extends OrDefaults<
-      T,
-      {
-        worldContractName: typeof WORLD_DEFAULTS.worldContractName;
-        worldInterfaceName: typeof WORLD_DEFAULTS.worldInterfaceName;
-        excludeSystems: typeof WORLD_DEFAULTS.excludeSystems;
-        postDeployScript: typeof WORLD_DEFAULTS.postDeployScript;
-        deploysDirectory: typeof WORLD_DEFAULTS.deploysDirectory;
-        worldsFile: typeof WORLD_DEFAULTS.worldsFile;
-        worldgenDirectory: typeof WORLD_DEFAULTS.worldgenDirectory;
-        worldImportPath: typeof WORLD_DEFAULTS.worldImportPath;
-        modules: typeof WORLD_DEFAULTS.modules;
-      }
-    > {
+  export interface ExpandMUDUserConfig<T extends MUDCoreUserConfig> extends OrDefaults<T, WORLD_DEFAULTS> {
     systems: ExpandSystemsConfig<T["systems"] extends Record<string, unknown> ? T["systems"] : Record<string, never>>;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,8 +1028,8 @@ importers:
   packages/world:
     dependencies:
       '@arktype/util':
-        specifier: 0.0.27
-        version: 0.0.27
+        specifier: 0.0.29
+        version: 0.0.29
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -1245,10 +1245,6 @@ packages:
   /@arktype/util@0.0.23:
     resolution: {integrity: sha512-MwtDGjbgfXWxlExjIL78HvPlWOma1XFEcDd3VWuCPMt/f+3TR7fXyiGFNlIYZGOYdOIU7qgjaE8dmbd6jdJa3Q==}
     dev: true
-
-  /@arktype/util@0.0.27:
-    resolution: {integrity: sha512-ZkPuSU8Q56YVgPInFhojLTujejM+VPfaZx6Guop41CvnozWFOTlC0uAHuDqvY4nYq3zXsMkRwm8LmaRZ3mslMg==}
-    dev: false
 
   /@arktype/util@0.0.29:
     resolution: {integrity: sha512-fDTBSVzxLj9k1ZjinkawmaQdcXFKMBVK8c+vqMPxwoa94mPMZxBo84yQcqyFVcIcWIkg6qQQmH1ozyT4nqFT/g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,8 +733,8 @@ importers:
   packages/store:
     dependencies:
       '@arktype/util':
-        specifier: 0.0.27
-        version: 0.0.27
+        specifier: 0.0.29
+        version: 0.0.29
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -1248,6 +1248,10 @@ packages:
 
   /@arktype/util@0.0.27:
     resolution: {integrity: sha512-ZkPuSU8Q56YVgPInFhojLTujejM+VPfaZx6Guop41CvnozWFOTlC0uAHuDqvY4nYq3zXsMkRwm8LmaRZ3mslMg==}
+    dev: false
+
+  /@arktype/util@0.0.29:
+    resolution: {integrity: sha512-fDTBSVzxLj9k1ZjinkawmaQdcXFKMBVK8c+vqMPxwoa94mPMZxBo84yQcqyFVcIcWIkg6qQQmH1ozyT4nqFT/g==}
     dev: false
 
   /@babel/code-frame@7.21.4:


### PR DESCRIPTION
This refactors some existing types in world and store, adding some useful patterns for sharing logic between types and values and removing redundant casts.

I plan to review with @alvrs and @holic on a call if possible so we can cover some of the changes as efficiently as possible. There should not be any impact on the type or value-level behavior.