### PR TITLE
docs: minor fixes in Emojimon guide

### DIFF
--- a/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
+++ b/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
@@ -1028,7 +1028,7 @@ export function createSystemCalls(
 
 </CollapseCode>
 
-When you click the button, the `EncounterScreen` creates a pending toast and kicks off the transaction by calling our `throwBall` method above. We use `awaitStreamValue` to ensure the transaction went through and MUD has updated the client component data. After that, we can get the result of the catch attempt and return it so that the `EncounterScreen` can render the proper message in the toast.
+When you click the button, the `EncounterScreen` creates a pending toast and kicks off the transaction by calling our `throwBall` method above. We use `waitForTransaction` to ensure the transaction went through and MUD has updated the client component data. After that, we can get the result of the catch attempt and return it so that the `EncounterScreen` can render the proper message in the toast.
 
 ## Flee encounters
 

--- a/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
+++ b/docs/pages/guides/emojimon/5-a-wild-emojimon-appears.mdx
@@ -392,7 +392,7 @@ Let's also add this to our client code for better optimistic rendering.
 
 <CollapseCode>
 
-```ts filename="packages/client/src/mud/createSystemCalls.ts" {37-41} copy showLineNumbers
+```ts filename="packages/client/src/mud/createSystemCalls.ts" {12,37-41} copy showLineNumbers
 import { Has, HasValue, getComponentValue, runQuery } from "@latticexyz/recs";
 import { singletonEntity } from "@latticexyz/store-sync/recs";
 import { uuid } from "@latticexyz/utils";


### PR DESCRIPTION
## In: "A wild Emojimon appears"

1. Highlight an updated line in `createSystemCalls` the same way as the rest of the guide, when some code is added/changed.
2. Remove mention of `awaitStreamValue` in favor of `waitForTransaction` since the flow changed with the new return type of `setupNetwork`. (see [version 2.0.0](https://mud.dev/changelog#version-200-next1))