### PR TITLE
feat(common): allow specifying concurrency in transactionQueue

### DIFF
--- a/.changeset/poor-maps-itch.md
+++ b/.changeset/poor-maps-itch.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+`transactionQueue` now accepts a `queueConcurrency` to allow adjusting the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered and nonces are handled properly. Any number greater than that is likely to see nonce errors and transactions arriving out of order, but this may be an acceptable trade-off for some applications that can safely retry.

--- a/packages/common/src/actions/transactionQueue.ts
+++ b/packages/common/src/actions/transactionQueue.ts
@@ -19,15 +19,15 @@ export type TransactionQueueOptions<chain extends Chain> = {
   queueConcurrency?: number;
 };
 
-export function transactionQueue<chain extends Chain, account extends Account>({
-  publicClient,
-}: TransactionQueueOptions<chain> = {}): (
+export function transactionQueue<chain extends Chain, account extends Account>(
+  opts: TransactionQueueOptions<chain> = {},
+): (
   client: Client<Transport, chain, account>,
 ) => Pick<WalletActions<chain, account>, "writeContract" | "sendTransaction"> {
   return (client) => ({
     // Applies to: `client.writeContract`, `getContract(client, ...).write`
-    writeContract: (args) => mud_writeContract(client, args, publicClient),
+    writeContract: (args) => mud_writeContract(client, args, opts),
     // Applies to: `client.sendTransaction`
-    sendTransaction: (args) => mud_sendTransaction(client, args, publicClient),
+    sendTransaction: (args) => mud_sendTransaction(client, args, opts),
   });
 }

--- a/packages/common/src/actions/transactionQueue.ts
+++ b/packages/common/src/actions/transactionQueue.ts
@@ -12,8 +12,8 @@ export type TransactionQueueOptions<chain extends Chain> = {
   publicClient?: PublicClient<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
-   * and nonces are handled properly. Any number greater than that is likely to see nonce errors, but this may be
-   * an acceptable trade-off for some applications that can safely retry.
+   * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions
+   * arriving out of order, but this may be an acceptable trade-off for some applications that can safely retry.
    * @default 1
    */
   queueConcurrency?: number;

--- a/packages/common/src/actions/transactionQueue.ts
+++ b/packages/common/src/actions/transactionQueue.ts
@@ -3,7 +3,20 @@ import { writeContract as mud_writeContract } from "../writeContract";
 import { sendTransaction as mud_sendTransaction } from "../sendTransaction";
 
 export type TransactionQueueOptions<chain extends Chain> = {
+  /**
+   * `publicClient` can be provided to be used in place of the extended viem client for making public action calls
+   * (`getChainId`, `getTransactionCount`, `simulateContract`, `call`). This helps in cases where the extended
+   * viem client is a smart account client, like in [permissionless.js](https://github.com/pimlicolabs/permissionless.js),
+   * where the transport is the bundler, not an RPC.
+   */
   publicClient?: PublicClient<Transport, chain>;
+  /**
+   * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
+   * and nonces are handled properly. Any number greater than that is likely to see nonce errors, but this may be
+   * an acceptable trade-off for some applications that can safely retry.
+   * @default 1
+   */
+  queueConcurrency?: number;
 };
 
 export function transactionQueue<chain extends Chain, account extends Account>({

--- a/packages/common/src/createNonceManager.ts
+++ b/packages/common/src/createNonceManager.ts
@@ -11,6 +11,7 @@ export type CreateNonceManagerOptions = {
   address: Hex;
   blockTag?: BlockTag;
   broadcastChannelName?: string;
+  queueConcurrency?: number;
 };
 
 export type CreateNonceManagerResult = {
@@ -26,6 +27,7 @@ export function createNonceManager({
   address, // TODO: rename to account?
   blockTag = "pending",
   broadcastChannelName,
+  queueConcurrency = 1,
 }: CreateNonceManagerOptions): CreateNonceManagerResult {
   const nonceRef = { current: -1 };
   let channel: BroadcastChannel | null = null;
@@ -70,7 +72,7 @@ export function createNonceManager({
     );
   }
 
-  const mempoolQueue = new PQueue({ concurrency: 1 });
+  const mempoolQueue = new PQueue({ concurrency: queueConcurrency });
 
   return {
     hasNonce,

--- a/packages/common/src/getContract.ts
+++ b/packages/common/src/getContract.ts
@@ -118,7 +118,7 @@ export function getContract<
               TChain,
               TAccount
             >;
-            const result = writeContract(walletClient, request, publicClient);
+            const result = writeContract(walletClient, request, { publicClient });
 
             const id = `${walletClient.chain.id}:${walletClient.account.address}:${nextWriteId++}`;
             onWrite?.({

--- a/packages/common/src/sendTransaction.ts
+++ b/packages/common/src/sendTransaction.ts
@@ -26,8 +26,8 @@ export type SendTransactionExtraOptions<chain extends Chain | undefined> = {
   publicClient?: PublicClient<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
-   * and nonces are handled properly. Any number greater than that is likely to see nonce errors, but this may be
-   * an acceptable trade-off for some applications that can safely retry.
+   * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions
+   * arriving out of order, but this may be an acceptable trade-off for some applications that can safely retry.
    * @default 1
    */
   queueConcurrency?: number;

--- a/packages/common/src/writeContract.ts
+++ b/packages/common/src/writeContract.ts
@@ -29,8 +29,8 @@ export type WriteContractExtraOptions<chain extends Chain | undefined> = {
   publicClient?: PublicClient<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
-   * and nonces are handled properly. Any number greater than that is likely to see nonce errors, but this may be
-   * an acceptable trade-off for some applications that can safely retry.
+   * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions
+   * arriving out of order, but this may be an acceptable trade-off for some applications that can safely retry.
    * @default 1
    */
   queueConcurrency?: number;

--- a/packages/common/src/writeContract.ts
+++ b/packages/common/src/writeContract.ts
@@ -19,7 +19,22 @@ import { parseAccount } from "viem/accounts";
 
 const debug = parentDebug.extend("writeContract");
 
-// TODO: migrate away from this approach once we can hook into viem's nonce management: https://github.com/wagmi-dev/viem/discussions/1230
+export type WriteContractExtraOptions<chain extends Chain | undefined> = {
+  /**
+   * `publicClient` can be provided to be used in place of the extended viem client for making public action calls
+   * (`getChainId`, `getTransactionCount`, `simulateContract`). This helps in cases where the extended
+   * viem client is a smart account client, like in [permissionless.js](https://github.com/pimlicolabs/permissionless.js),
+   * where the transport is the bundler, not an RPC.
+   */
+  publicClient?: PublicClient<Transport, chain>;
+  /**
+   * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
+   * and nonces are handled properly. Any number greater than that is likely to see nonce errors, but this may be
+   * an acceptable trade-off for some applications that can safely retry.
+   * @default 1
+   */
+  queueConcurrency?: number;
+};
 
 /** @deprecated Use `walletClient.extend(transactionQueue())` instead. */
 export async function writeContract<
@@ -32,7 +47,7 @@ export async function writeContract<
 >(
   client: Client<Transport, chain, account>,
   request: WriteContractParameters<abi, functionName, args, chain, account, chainOverride>,
-  publicClient?: PublicClient<Transport, chain>,
+  opts: WriteContractExtraOptions<chain> = {},
 ): Promise<WriteContractReturnType> {
   const rawAccount = request.account ?? client.account;
   if (!rawAccount) {
@@ -42,9 +57,10 @@ export async function writeContract<
   const account = parseAccount(rawAccount);
 
   const nonceManager = await getNonceManager({
-    client: publicClient ?? client,
+    client: opts.publicClient ?? client,
     address: account.address,
     blockTag: "pending",
+    queueConcurrency: opts.queueConcurrency,
   });
 
   async function prepareWrite(): Promise<
@@ -57,7 +73,7 @@ export async function writeContract<
 
     debug("simulating", request.functionName, "at", request.address);
     const result = await simulateContract<chain, account | undefined, abi, functionName, args, chainOverride>(
-      publicClient ?? client,
+      opts.publicClient ?? client,
       {
         ...request,
         blockTag: "pending",


### PR DESCRIPTION
After hearing from @kooshaba about Sky Strife latency, specifically when playing from Japan, I did a bit of testing with a fresh template deployed to Redstone Holesky to find out where some of the latency was coming from. There's quite a few factors at play:
- each tx requires gas estimation, and viem does two RPC round trips: one to get max priority fee per gas and one to get the gas estimate of the call
  - the former can likely be cached but I am unclear how safe it is to do so (is this a hardcoded chain value? or something that fluctuates based on demand?)
  - the latter can possibly be cached for recurring calls to the same methods with same/similar args (Sky Strife does some variant of this) but would need some thought to get this right, if not just leave this to user land to figure out
- the transaction queue defaults to processing a single item at a time, to ensure no nonce errors, but with all the rpc round trips, that means 1-2s before a tx is even submitted (given Japan latency), then waiting for the next block to be mined, and this is super apparent once you queue up more than a couple txs

Even though increasing the concurrency will lead to nonce errors, it may be an acceptable trade-off for certain games/applications where its safe to retry after nonce failure and its fine to have somewhat out-of-order operations.