### PR TITLE
docs(*): update the default `World` address 🏎 

### DIFF
--- a/docs/pages/world/modules/keyswithvalue.mdx
+++ b/docs/pages/world/modules/keyswithvalue.mdx
@@ -29,7 +29,7 @@ import { KeysWithValueModule } from "@latticexyz/world-modules/src/modules/keysw
 contract DeployKeyWithValueModule is Script {
   function run() external {
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
 
     vm.startBroadcast(deployerPrivateKey);
     IWorld world = IWorld(worldAddress);
@@ -108,7 +108,7 @@ import { EncodedLengths, EncodedLengthsLib } from "@latticexyz/store/src/Encoded
 contract UseKeysWithValues is Script {
   function run() external {
     uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
 
     uint createdAt = block.timestamp;
     uint completedAt = 0;
@@ -142,7 +142,7 @@ contract UseKeysWithValues is Script {
 <summary>Explanation</summary>
 
 ```solidity
-import { Tasks, TasksTableId } from "../src/codegen/index.sol";
+import { Tasks } from "../src/codegen/index.sol";
 ```
 
 It is easiest to use `getKeysWithValue` when you have the definition of the source table.

--- a/docs/pages/world/namespaces-access-control.mdx
+++ b/docs/pages/world/namespaces-access-control.mdx
@@ -84,7 +84,7 @@ import { Counter } from "../src/codegen/index.sol";
 
 contract Permissions is Script {
   function run() external {
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
 
     // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
     uint256 namespaceOwnerPrivateKey = vm.envUint("PRIVATE_KEY");

--- a/docs/pages/world/tables.mdx
+++ b/docs/pages/world/tables.mdx
@@ -45,7 +45,7 @@ import { Counter } from "../src/codegen/index.sol";
 
 contract ReadCounter is Script {
   function run() external {
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
     StoreSwitch.setStoreAddress(worldAddress);
     console.log("Counter value:", Counter.get());
   }
@@ -71,7 +71,7 @@ import { Counter } from "../src/codegen/index.sol";
 It is easiest if we import the definitions of the table that were generated using [`mud tablegen`](./cli/tablegen).
 
 ```solidity
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
     StoreSwitch.setStoreAddress(worldAddress);
 ```
 
@@ -106,7 +106,7 @@ import { Counter } from "../src/codegen/index.sol";
 contract ResetCounter is Script {
   function run() external {
     // Specify a store so that you can use tables directly
-    address worldAddress = 0x4F4DDaFBc93Cf8d11a253f21dDbcF836139efdeC;
+    address worldAddress = 0xC14fBdb7808D9e2a37c1a45b635C8C3fF64a1cc1;
     StoreSwitch.setStoreAddress(worldAddress);
 
     // Load the private key from the `PRIVATE_KEY` environment variable (in .env)


### PR DESCRIPTION
Since it's a different value in 2.0.4.

Note: This only updates pages that don't have an active PR on them. I updated the active PRs separately as needed.