### PR TITLE
fix(create-mud): add test for threejs template

### DIFF
--- a/templates/threejs/packages/contracts/test/WorldTest.t.sol
+++ b/templates/threejs/packages/contracts/test/WorldTest.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+import "forge-std/Test.sol";
+import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+
+contract WorldTest is MudTest {
+  function testWorldExists() public {
+    uint256 codeSize;
+    address addr = worldAddress;
+    assembly {
+      codeSize := extcodesize(addr)
+    }
+    assertTrue(codeSize > 0);
+  }
+}


### PR DESCRIPTION
something recently changed in foundry to cause CI to start failing for threejs template because there are no tests to run

I didn't wanna remove the `mud test` call because it's useful to make sure the template's world/MUD config can be deployed, so I just added a really basic test instead (copied from other templates)