### PR TITLE
build: skip docker build/release for now

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,6 +52,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker:
-    uses: ./.github/workflows/docker.yml
-    needs: prerelease
+  # docker:
+  #   uses: ./.github/workflows/docker.yml
+  #   needs: prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker:
-    uses: ./.github/workflows/docker.yml
-    needs: release
+  # docker:
+  #   uses: ./.github/workflows/docker.yml
+  #   needs: release

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -62,9 +62,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  docker:
-    uses: ./.github/workflows/docker.yml
-    needs: release-snapshot
+  # docker:
+  #   uses: ./.github/workflows/docker.yml
+  #   needs: release-snapshot
 
   test-snapshot:
     uses: ./.github/workflows/test-published-packages.yml


### PR DESCRIPTION
> The workflow is not valid. .github/workflows/snapshot.yml (Line: 65, Col: 3): Error calling workflow 'latticexyz/mud/.github/workflows/docker.yml@a9e8a407b5d6f356d7d0a1c1f093de926ffb072f'. The nested job 'docker' is requesting 'packages: write', but is only allowed 'packages: read'.

CI is broken, I think since moving to GitHub Enterprise? I'm not really sure how to fix this but wanna unblock npm releases.
