### PR TITLE
feat(world): make World Initializable

### DIFF
--- a/docs/pages/world/reference/world-external.mdx
+++ b/docs/pages/world/reference/world-external.mdx
@@ -740,6 +740,12 @@ function creator() external view returns (address);
 | -------- | --------- | ----------------------------------- |
 | `<none>` | `address` | The address of the World's creator. |
 
+#### \_\_World_init
+
+```solidity
+function __World_init() external;
+```
+
 #### initialize
 
 Initializes the World.

--- a/docs/pages/world/reference/world.mdx
+++ b/docs/pages/world/reference/world.mdx
@@ -19,7 +19,7 @@ _World doesn't inherit `Store` because the `IStoreRegistration` methods are adde
 Address of the contract's creator.
 
 ```solidity
-address public immutable creator;
+address public creator;
 ```
 
 ### Functions
@@ -36,12 +36,10 @@ function worldVersion() public pure returns (bytes32);
 | -------- | --------- | ------------------------------------------ |
 | `<none>` | `bytes32` | The current version of the world contract. |
 
-#### constructor
-
-_Event emitted when the World contract is created._
+#### \_\_World_init
 
 ```solidity
-constructor();
+function __World_init() public initializer;
 ```
 
 #### prohibitDirectCallback

--- a/packages/store/gas-report.json
+++ b/packages/store/gas-report.json
@@ -357,7 +357,7 @@
     "file": "test/KeyEncoding.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register KeyEncoding table",
-    "gasUsed": 717787
+    "gasUsed": 717799
   },
   {
     "file": "test/Mixed.t.sol",
@@ -723,7 +723,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooks",
     "name": "set static field on table with subscriber",
-    "gasUsed": 52904
+    "gasUsed": 52882
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -747,7 +747,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testHooksDynamicData",
     "name": "set (dynamic) field on table with subscriber",
-    "gasUsed": 60374
+    "gasUsed": 60419
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -771,7 +771,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: register table",
-    "gasUsed": 647841
+    "gasUsed": 647847
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -783,13 +783,13 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get value schema (warm)",
-    "gasUsed": 1441
+    "gasUsed": 1447
   },
   {
     "file": "test/StoreCoreGas.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "StoreCore: get key schema (warm)",
-    "gasUsed": 2313
+    "gasUsed": 2319
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -807,7 +807,7 @@
     "file": "test/StoreCoreGas.t.sol",
     "test": "testSetAndGetDynamicData",
     "name": "compare: Set complex record with dynamic data using native solidity",
-    "gasUsed": 116845
+    "gasUsed": 116821
   },
   {
     "file": "test/StoreCoreGas.t.sol",
@@ -1113,7 +1113,7 @@
     "file": "test/Vector2.t.sol",
     "test": "testRegisterAndGetFieldLayout",
     "name": "register Vector2 field layout",
-    "gasUsed": 443849
+    "gasUsed": 443861
   },
   {
     "file": "test/Vector2.t.sol",

--- a/packages/store/src/StoreKernel.sol
+++ b/packages/store/src/StoreKernel.sol
@@ -21,7 +21,7 @@ abstract contract StoreKernel is IStoreKernel, StoreRead, Initializable {
    * @notice Initializes the StoreKernel contract and StoreCore.
    * @dev Emits a HelloStore event upon creation.
    */
-  function initialize() public initializer {
+  function __StoreKernel_init() public onlyInitializing {
     StoreCore.initialize();
     emit IStoreEvents.HelloStore(STORE_VERSION);
   }

--- a/packages/store/test/StoreMock.sol
+++ b/packages/store/test/StoreMock.sol
@@ -11,15 +11,22 @@ import { Schema } from "../src/Schema.sol";
 import { FieldLayout } from "../src/FieldLayout.sol";
 import { StoreRead } from "../src/StoreRead.sol";
 import { ResourceId } from "../src/ResourceId.sol";
+import { StoreKernel } from "../src/StoreKernel.sol";
+
+import { Initializable } from "../src/Initializable.sol";
 
 /**
  * StoreMock is a contract wrapper around the StoreCore library for testing purposes.
  */
-contract StoreMock is Store {
+contract StoreMock is Initializable, Store {
   constructor() {
-    StoreCore.initialize();
+    __StoreMock_init();
+  }
+
+  function __StoreMock_init() public initializer {
+    __StoreKernel_init();
+
     StoreCore.registerInternalTables();
-    StoreSwitch.setStoreAddress(address(this));
   }
 
   // Set full record (including full dynamic data)

--- a/packages/store/test/StoreMock.t.sol
+++ b/packages/store/test/StoreMock.t.sol
@@ -12,13 +12,8 @@ import { Initializable } from "../src/Initializable.sol";
 
 contract StoreMockTest is Test {
   function testStoreMockInitialize() public {
-    StoreMock store = new StoreMock();
-
     vm.expectEmit(true, true, true, true);
     emit IStoreEvents.HelloStore(STORE_VERSION);
-    store.initialize();
-
-    vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
-    store.initialize();
+    new StoreMock();
   }
 }

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -87,13 +87,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallComposite",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456859
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456859
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -105,13 +105,13 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testInstallSingleton",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456859
   },
   {
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookCompositeGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456859
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -129,7 +129,7 @@
     "file": "test/KeysInTableModule.t.sol",
     "test": "testSetAndDeleteRecordHookGas",
     "name": "install keys in table module",
-    "gasUsed": 1456815
+    "gasUsed": 1456859
   },
   {
     "file": "test/KeysInTableModule.t.sol",
@@ -147,7 +147,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testGetKeysWithValueGas",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715784
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -165,7 +165,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testInstall",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715784
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -177,7 +177,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetAndDeleteRecordHook",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715784
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -195,7 +195,7 @@
     "file": "test/KeysWithValueModule.t.sol",
     "test": "testSetField",
     "name": "install keys with value module",
-    "gasUsed": 715762
+    "gasUsed": 715784
   },
   {
     "file": "test/KeysWithValueModule.t.sol",
@@ -315,7 +315,7 @@
     "file": "test/UniqueEntityModule.t.sol",
     "test": "testInstall",
     "name": "install unique entity module",
-    "gasUsed": 715539
+    "gasUsed": 715561
   },
   {
     "file": "test/UniqueEntityModule.t.sol",

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -57,13 +57,13 @@
     "file": "test/Factories.t.sol",
     "test": "testCreate2Factory",
     "name": "deploy contract via Create2",
-    "gasUsed": 5144624
+    "gasUsed": 5212920
   },
   {
     "file": "test/Factories.t.sol",
     "test": "testWorldFactoryGas",
     "name": "deploy world via WorldFactory",
-    "gasUsed": 12931159
+    "gasUsed": 12997538
   },
   {
     "file": "test/World.t.sol",
@@ -129,7 +129,7 @@
     "file": "test/World.t.sol",
     "test": "testRegisterTable",
     "name": "Register a new table in the namespace",
-    "gasUsed": 569676
+    "gasUsed": 569698
   },
   {
     "file": "test/World.t.sol",

--- a/packages/world/gas-report.json
+++ b/packages/world/gas-report.json
@@ -57,13 +57,13 @@
     "file": "test/Factories.t.sol",
     "test": "testCreate2Factory",
     "name": "deploy contract via Create2",
-    "gasUsed": 5212920
+    "gasUsed": 5110739
   },
   {
     "file": "test/Factories.t.sol",
     "test": "testWorldFactoryGas",
     "name": "deploy world via WorldFactory",
-    "gasUsed": 12997538
+    "gasUsed": 12997691
   },
   {
     "file": "test/World.t.sol",

--- a/packages/world/src/IWorldKernel.sol
+++ b/packages/world/src/IWorldKernel.sol
@@ -76,6 +76,8 @@ interface IWorldKernel is IWorldModuleInstallation, IWorldCall, IWorldErrors, IW
    */
   function creator() external view returns (address);
 
+  function __World_init() external;
+
   /**
    * @notice Initializes the World.
    * @dev Can only be called once by the creator.

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -40,7 +40,7 @@ contract World is StoreKernel, IWorldKernel {
   using WorldResourceIdInstance for ResourceId;
 
   /// @notice Address of the contract's creator.
-  address public immutable creator;
+  address public creator;
 
   /// @return The current version of the world contract.
   function worldVersion() public pure returns (bytes32) {
@@ -49,7 +49,11 @@ contract World is StoreKernel, IWorldKernel {
 
   /// @dev Event emitted when the World contract is created.
   constructor() {
-    initialize();
+    __World_init();
+  }
+
+  function __World_init() public initializer {
+    __StoreKernel_init();
 
     creator = msg.sender;
     emit IWorldEvents.HelloWorld(WORLD_VERSION);

--- a/packages/world/src/World.sol
+++ b/packages/world/src/World.sol
@@ -47,11 +47,6 @@ contract World is StoreKernel, IWorldKernel {
     return WORLD_VERSION;
   }
 
-  /// @dev Event emitted when the World contract is created.
-  constructor() {
-    __World_init();
-  }
-
   function __World_init() public initializer {
     __StoreKernel_init();
 

--- a/packages/world/src/WorldFactory.sol
+++ b/packages/world/src/WorldFactory.sol
@@ -35,6 +35,7 @@ contract WorldFactory is IWorldFactory {
     uint256 _salt = uint256(keccak256(abi.encode(msg.sender, salt)));
     worldAddress = Create2.deploy(bytecode, _salt);
     IBaseWorld world = IBaseWorld(worldAddress);
+    world.__World_init();
 
     // Initialize the World and transfer ownership to the caller
     world.initialize(initModule);

--- a/packages/world/test/World.t.sol
+++ b/packages/world/test/World.t.sol
@@ -198,10 +198,12 @@ contract WorldTest is Test, GasReporter {
 
   function testConstructorAndInitialize() public {
     InitModule initModule = createInitModule();
+    IBaseWorld newWorld = IBaseWorld(address(new World()));
 
     vm.expectEmit(true, true, true, true);
     emit IWorldEvents.HelloWorld(WORLD_VERSION);
-    IBaseWorld newWorld = IBaseWorld(address(new World()));
+    newWorld.__World_init();
+
     StoreSwitch.setStoreAddress(address(newWorld));
 
     // Expect the creator to be the original deployer

--- a/packages/world/test/createWorld.sol
+++ b/packages/world/test/createWorld.sol
@@ -7,5 +7,6 @@ import { createInitModule } from "./createInitModule.sol";
 
 function createWorld() returns (IBaseWorld world) {
   world = IBaseWorld(address(new World()));
+  world.__World_init();
   world.initialize(createInitModule());
 }

--- a/packages/world/ts/protocol-snapshots/2.0.0.snap
+++ b/packages/world/ts/protocol-snapshots/2.0.0.snap
@@ -47,6 +47,7 @@
   "event Store_SetRecord(bytes32 indexed tableId, bytes32[] keyTuple, bytes staticData, bytes32 encodedLengths, bytes dynamicData)",
   "event Store_SpliceDynamicData(bytes32 indexed tableId, bytes32[] keyTuple, uint8 dynamicFieldIndex, uint48 start, uint40 deleteCount, bytes32 encodedLengths, bytes data)",
   "event Store_SpliceStaticData(bytes32 indexed tableId, bytes32[] keyTuple, uint48 start, bytes data)",
+  "function __World_init()",
   "function batchCall((bytes32 systemId, bytes callData)[] systemCalls) returns (bytes[] returnDatas)",
   "function batchCallFrom((address from, bytes32 systemId, bytes callData)[] systemCalls) returns (bytes[] returnDatas)",
   "function call(bytes32 systemId, bytes callData) payable returns (bytes)",


### PR DESCRIPTION
Moves the logic from the World constructor to a `__World_init` function that can only be called once. 