### PR TITLE
fix: pin CI foundry version

### DIFF
--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -18,4 +18,4 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: nightly-72bc4f4e616c6e2b79ee3582301fbb1d38660857


### PR DESCRIPTION
There is a Foundry issue that only happens in CI: https://github.com/foundry-rs/foundry/issues/7620

So we can pin CI to an old version for now.