### PR TITLE
test(store-sync): skip flaky query cache tests

### DIFF
--- a/packages/store-sync/src/query-cache/createStorageAdapter.test.ts
+++ b/packages/store-sync/src/query-cache/createStorageAdapter.test.ts
@@ -8,7 +8,7 @@ import { testClient } from "../../test/common";
 import { getBlockNumber } from "viem/actions";
 import { Address } from "viem";
 
-describe("createStorageAdapter", async () => {
+describe.skip("createStorageAdapter", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let worldAddress: Address;
   beforeAll(async () => {

--- a/packages/store-sync/src/query-cache/query.test.ts
+++ b/packages/store-sync/src/query-cache/query.test.ts
@@ -4,7 +4,7 @@ import { query } from "./query";
 import { deployMockGame } from "../../test/mockGame";
 import { Address } from "viem";
 
-describe("query", async () => {
+describe.skip("query", async () => {
   let worldAddress: Address;
   beforeAll(async () => {
     worldAddress = await deployMockGame();

--- a/packages/store-sync/src/query-cache/subscribeToQuery.test.ts
+++ b/packages/store-sync/src/query-cache/subscribeToQuery.test.ts
@@ -12,7 +12,7 @@ import { SubjectEvent, SubjectRecord } from "@latticexyz/query";
 
 const henryAccount = privateKeyToAccount(keccak256(stringToHex("henry")));
 
-describe("subscribeToQuery", async () => {
+describe.skip("subscribeToQuery", async () => {
   let worldAddress: Address;
   beforeAll(async () => {
     await testClient.setBalance({ address: henryAccount.address, value: parseEther("1") });


### PR DESCRIPTION
see https://github.com/latticexyz/mud/issues/2671

since we're not using querying yet and it's on pause, going to disable these tests for now to keep CI happy