### PR TITLE
feat(world-modules): string systemId in `callWithSignature` typehash

### DIFF
--- a/.changeset/tender-cherries-hammer.md
+++ b/.changeset/tender-cherries-hammer.md
@@ -1,0 +1,6 @@
+---
+"@latticexyz/world-modules": patch
+"@latticexyz/world": patch
+---
+
+Replaced the `systemId` field in the `Unstable_CallWithSignatureSystem` typehash with individual `systemNamespace` and `systemName` string fields.

--- a/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
+++ b/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
@@ -86,7 +86,7 @@ describe("callWithSignature", async () => {
       primaryType: "Call",
       message: {
         signer: delegator.address,
-        systemId,
+        systemId: "syRegistration",
         callData,
         nonce,
       },

--- a/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
+++ b/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
@@ -86,7 +86,7 @@ describe("callWithSignature", async () => {
       primaryType: "Call",
       message: {
         signer: delegator.address,
-        systemId: "syRegistration",
+        systemId: "sy:<root>:Registration",
         callData,
         nonce,
       },

--- a/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
+++ b/e2e/packages/sync-test/registerDelegationWithSignature.test.ts
@@ -86,7 +86,8 @@ describe("callWithSignature", async () => {
       primaryType: "Call",
       message: {
         signer: delegator.address,
-        systemId: "sy:<root>:Registration",
+        systemNamespace: "",
+        systemName: "Registration",
         callData,
         nonce,
       },

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -9,7 +9,7 @@
     "file": "test/CallWithSignatureModule.t.sol",
     "test": "testRegisterDelegationWithSignature",
     "name": "register an unlimited delegation with signature",
-    "gasUsed": 133659
+    "gasUsed": 136215
   },
   {
     "file": "test/ERC20.t.sol",

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -9,7 +9,7 @@
     "file": "test/CallWithSignatureModule.t.sol",
     "test": "testRegisterDelegationWithSignature",
     "name": "register an unlimited delegation with signature",
-    "gasUsed": 136108
+    "gasUsed": 135913
   },
   {
     "file": "test/ERC20.t.sol",

--- a/packages/world-modules/gas-report.json
+++ b/packages/world-modules/gas-report.json
@@ -9,7 +9,7 @@
     "file": "test/CallWithSignatureModule.t.sol",
     "test": "testRegisterDelegationWithSignature",
     "name": "register an unlimited delegation with signature",
-    "gasUsed": 136215
+    "gasUsed": 136108
   },
   {
     "file": "test/ERC20.t.sol",

--- a/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
+++ b/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.24;
 
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
-import { WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
+import { WorldResourceIdLib, WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
 
 using WorldResourceIdInstance for ResourceId;
 
@@ -10,7 +10,9 @@ using WorldResourceIdInstance for ResourceId;
 // It is not included in `chainId`, to allow cross-chain signing without requiring wallets to switch networks.
 // The value of this field should be the chain on which the world lives, rather than the chain the wallet is connected to.
 bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(address verifyingContract,bytes32 salt)");
-bytes32 constant CALL_TYPEHASH = keccak256("Call(address signer,string systemId,bytes callData,uint256 nonce)");
+bytes32 constant CALL_TYPEHASH = keccak256(
+  "Call(address signer,string systemNamespace,string systemName,bytes callData,uint256 nonce)"
+);
 
 /**
  * @notice Generate the message hash for a given delegation signature.
@@ -41,7 +43,8 @@ function getSignedMessageHash(
           abi.encode(
             CALL_TYPEHASH,
             signer,
-            keccak256(abi.encodePacked(systemId.toString())),
+            keccak256(abi.encodePacked(WorldResourceIdLib.toTrimmedString(systemId.getNamespace()))),
+            keccak256(abi.encodePacked(WorldResourceIdLib.toTrimmedString(systemId.getName()))),
             keccak256(callData),
             nonce
           )

--- a/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
+++ b/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
@@ -38,7 +38,13 @@ function getSignedMessageHash(
         "\x19\x01",
         domainSeperator,
         keccak256(
-          abi.encode(CALL_TYPEHASH, signer, keccak256(abi.encode(systemId.toString())), keccak256(callData), nonce)
+          abi.encode(
+            CALL_TYPEHASH,
+            signer,
+            keccak256(abi.encodePacked(systemId.toString())),
+            keccak256(callData),
+            nonce
+          )
         )
       )
     );

--- a/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
+++ b/packages/world-modules/src/modules/callwithsignature/getSignedMessageHash.sol
@@ -2,12 +2,15 @@
 pragma solidity >=0.8.24;
 
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
+import { WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
+
+using WorldResourceIdInstance for ResourceId;
 
 // Note the intended value of the `salt` field is the chain ID.
 // It is not included in `chainId`, to allow cross-chain signing without requiring wallets to switch networks.
 // The value of this field should be the chain on which the world lives, rather than the chain the wallet is connected to.
 bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(address verifyingContract,bytes32 salt)");
-bytes32 constant CALL_TYPEHASH = keccak256("Call(address signer,bytes32 systemId,bytes callData,uint256 nonce)");
+bytes32 constant CALL_TYPEHASH = keccak256("Call(address signer,string systemId,bytes callData,uint256 nonce)");
 
 /**
  * @notice Generate the message hash for a given delegation signature.
@@ -34,7 +37,9 @@ function getSignedMessageHash(
       abi.encodePacked(
         "\x19\x01",
         domainSeperator,
-        keccak256(abi.encode(CALL_TYPEHASH, signer, systemId, keccak256(callData), nonce))
+        keccak256(
+          abi.encode(CALL_TYPEHASH, signer, keccak256(abi.encode(systemId.toString())), keccak256(callData), nonce)
+        )
       )
     );
 }

--- a/packages/world-modules/test/CallWithSignatureModule.t.sol
+++ b/packages/world-modules/test/CallWithSignatureModule.t.sol
@@ -104,7 +104,7 @@ contract Unstable_CallWithSignatureModuleTest is Test, GasReporter {
     vm.expectRevert(
       abi.encodeWithSelector(
         IUnstable_CallWithSignatureErrors.InvalidSignature.selector,
-        0x5266996Bb73ce3ac0E75D79Db87f4a96063cEe1F
+        0xF6cD939e4Ef31F0916f72c41f8b215f1A029EA00
       )
     );
     Unstable_CallWithSignatureSystem(address(world)).callWithSignature(

--- a/packages/world-modules/test/CallWithSignatureModule.t.sol
+++ b/packages/world-modules/test/CallWithSignatureModule.t.sol
@@ -104,7 +104,7 @@ contract Unstable_CallWithSignatureModuleTest is Test, GasReporter {
     vm.expectRevert(
       abi.encodeWithSelector(
         IUnstable_CallWithSignatureErrors.InvalidSignature.selector,
-        0xB04741cADcfBbB8795A56aC8c69da16DC9173825
+        0x65F0D93280688178Ec3F55bBd6f6088290639Bfb
       )
     );
     Unstable_CallWithSignatureSystem(address(world)).callWithSignature(

--- a/packages/world-modules/test/CallWithSignatureModule.t.sol
+++ b/packages/world-modules/test/CallWithSignatureModule.t.sol
@@ -104,7 +104,7 @@ contract Unstable_CallWithSignatureModuleTest is Test, GasReporter {
     vm.expectRevert(
       abi.encodeWithSelector(
         IUnstable_CallWithSignatureErrors.InvalidSignature.selector,
-        0xF6cD939e4Ef31F0916f72c41f8b215f1A029EA00
+        0xB04741cADcfBbB8795A56aC8c69da16DC9173825
       )
     );
     Unstable_CallWithSignatureSystem(address(world)).callWithSignature(

--- a/packages/world/ts/callWithSignatureTypes.ts
+++ b/packages/world/ts/callWithSignatureTypes.ts
@@ -3,7 +3,7 @@
 export const callWithSignatureTypes = {
   Call: [
     { name: "signer", type: "address" },
-    { name: "systemId", type: "bytes32" },
+    { name: "systemId", type: "string" },
     { name: "callData", type: "bytes" },
     { name: "nonce", type: "uint256" },
   ],

--- a/packages/world/ts/callWithSignatureTypes.ts
+++ b/packages/world/ts/callWithSignatureTypes.ts
@@ -3,7 +3,8 @@
 export const callWithSignatureTypes = {
   Call: [
     { name: "signer", type: "address" },
-    { name: "systemId", type: "string" },
+    { name: "systemNamespace", type: "string" },
+    { name: "systemName", type: "string" },
     { name: "callData", type: "bytes" },
     { name: "nonce", type: "uint256" },
   ],


### PR DESCRIPTION
Making signatures more legible with a `string` systemId
![image](https://github.com/latticexyz/mud/assets/29184158/c0d177ea-7604-4fe2-abe3-40abab8d3c5b)
