### PR TITLE
refactor(e2e): fix sync-test types

### DIFF
--- a/e2e/packages/sync-test/data/getWorld.ts
+++ b/e2e/packages/sync-test/data/getWorld.ts
@@ -1,10 +1,10 @@
 import { Page } from "@playwright/test";
 import IWorldAbi from "../../contracts/out/IWorld.sol/IWorld.abi.json";
-import { GetContractReturnType, PublicClient, WalletClient } from "viem";
+import { GetContractReturnType, PublicClient } from "viem";
 
 type WorldAbi = typeof IWorldAbi;
 
-type WorldContract = GetContractReturnType<WorldAbi, PublicClient, WalletClient>;
+type WorldContract = GetContractReturnType<WorldAbi, PublicClient>;
 
 export function getWorld(page: Page) {
   return page.evaluate(() => {


### PR DESCRIPTION
These files have a few type errors (particularly since the viem update) that makes it hard to debug 
<img width="1043" alt="image" src="https://github.com/latticexyz/mud/assets/29184158/f090a210-c913-43c0-b1de-540ff4c2c302">
