### PR TITLE
fix(store-sync): await fetchAndStoreLogs

### DIFF
--- a/.changeset/few-glasses-rhyme.md
+++ b/.changeset/few-glasses-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Partially revert [#2665](https://github.com/latticexyz/mud/pull/2665) to guarantee logs are stored in order.

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -26,7 +26,6 @@ import {
   shareReplay,
   combineLatest,
   scan,
-  identity,
   mergeMap,
 } from "rxjs";
 import { debug as parentDebug } from "./debug";
@@ -199,9 +198,7 @@ export async function createStoreSync<config extends StoreConfig = StoreConfig>(
       startBlock = range.startBlock;
       endBlock = range.endBlock;
     }),
-    // We use `map` instead of `concatMap` here to send the fetch request immediately when a new block range appears,
-    // instead of sending the next request only when the previous one completed.
-    map((range) => {
+    concatMap((range) => {
       const storedBlocks = fetchAndStoreLogs({
         publicClient,
         address,
@@ -217,8 +214,6 @@ export async function createStoreSync<config extends StoreConfig = StoreConfig>(
 
       return from(storedBlocks);
     }),
-    // `concatMap` turns the stream of promises into their awaited values
-    concatMap(identity),
     tap(({ blockNumber, logs }) => {
       debug("stored", logs.length, "logs for block", blockNumber);
       lastBlockNumberProcessed = blockNumber;


### PR DESCRIPTION
This change was introduced by https://github.com/latticexyz/mud/pull/2665/files but @dhvanipa found a bug with the new approach (we actually want to await the storing of logs, which might get out of order with just `map`)