### PR TITLE
fix(cli): add retry to getLogs when getting resource ID's

### DIFF
--- a/.changeset/five-pots-switch.md
+++ b/.changeset/five-pots-switch.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Fixed `""block is out of range"` errors in the deployer by adding retry logic to the `getLogs` call in the `getResourceIds` function. Previously, fetching the logs could fail if the RPC was out of sync.

--- a/.changeset/five-pots-switch.md
+++ b/.changeset/five-pots-switch.md
@@ -2,4 +2,4 @@
 "@latticexyz/cli": patch
 ---
 
-Fixed `""block is out of range"` errors in the deployer by adding retry logic to the `getLogs` call in the `getResourceIds` function. Previously, fetching the logs could fail if the RPC was out of sync.
+Deploying now retries on "block is out of range" errors, for cases where the RPC is load balanced and out of sync.

--- a/packages/cli/src/deploy/getResourceIds.ts
+++ b/packages/cli/src/deploy/getResourceIds.ts
@@ -3,6 +3,8 @@ import { getLogs } from "viem/actions";
 import { storeSpliceStaticDataEvent } from "@latticexyz/store";
 import { WorldDeploy, storeTables } from "./common";
 import { debug } from "./debug";
+import pRetry from "p-retry";
+import { wait } from "@latticexyz/common/utils";
 
 export async function getResourceIds({
   client,
@@ -15,15 +17,25 @@ export async function getResourceIds({
   // TODO: PR to viem's getLogs to accept topics array so we can filter on all store events and quickly recreate this table's current state
 
   debug("looking up resource IDs for", worldDeploy.address);
-  const logs = await getLogs(client, {
-    strict: true,
-    address: worldDeploy.address,
-    fromBlock: worldDeploy.deployBlock,
-    toBlock: worldDeploy.stateBlock,
-    event: parseAbiItem(storeSpliceStaticDataEvent),
-    args: { tableId: storeTables.store_ResourceIds.tableId },
-  });
-
+  const logs = await pRetry(
+    () =>
+      getLogs(client, {
+        strict: true,
+        address: worldDeploy.address,
+        fromBlock: worldDeploy.deployBlock,
+        toBlock: worldDeploy.stateBlock,
+        event: parseAbiItem(storeSpliceStaticDataEvent),
+        args: { tableId: storeTables.store_ResourceIds.tableId },
+      }),
+    {
+      retries: 3,
+      onFailedAttempt: async (error) => {
+        const delay = error.attemptNumber * 500;
+        debug(`failed to get logs, retrying in ${delay}ms...`);
+        await wait(delay);
+      },
+    },
+  );
   const resourceIds = logs.map((log) => log.args.keyTuple[0]);
   debug("found", resourceIds.length, "resource IDs for", worldDeploy.address);
 

--- a/packages/cli/src/deploy/getResourceIds.ts
+++ b/packages/cli/src/deploy/getResourceIds.ts
@@ -4,7 +4,6 @@ import { storeSpliceStaticDataEvent } from "@latticexyz/store";
 import { WorldDeploy, storeTables } from "./common";
 import { debug } from "./debug";
 import pRetry from "p-retry";
-import { wait } from "@latticexyz/common/utils";
 
 export async function getResourceIds({
   client,
@@ -29,11 +28,6 @@ export async function getResourceIds({
       }),
     {
       retries: 3,
-      onFailedAttempt: async (error) => {
-        const delay = error.attemptNumber * 500;
-        debug(`failed to get logs, retrying in ${delay}ms...`);
-        await wait(delay);
-      },
     },
   );
   const resourceIds = logs.map((log) => log.args.keyTuple[0]);

--- a/packages/cli/src/deploy/getResourceIds.ts
+++ b/packages/cli/src/deploy/getResourceIds.ts
@@ -32,7 +32,7 @@ export async function getResourceIds({
         const shouldRetry =
           error instanceof HttpRequestError &&
           error.status === 400 &&
-          error.message.includes('"block is out of range"');
+          error.message.includes('block is out of range');
 
         if (!shouldRetry) {
           throw error;


### PR DESCRIPTION
Attempting to fetch invalid logs from an RPC can error with a [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) and `"block is out of range"`. In this case, Viem's `getLogs` does not [retry the query](https://github.com/wevm/viem/blob/main/src/utils/buildRequest.ts#L199-L217). 

However, when using a request router like [proxyd](https://github.com/ethereum-optimism/optimism/tree/develop/proxyd), it is possible that some RPC's are slightly behind and do not have the newer logs. In this case we do actually want to retry the query until the RPC has caught up. 

This PR adds a `pretry` to the `getLogs` call in the `getResourceIds` function which has consistently failed in deployment.