### PR TITLE
chore(cli): run prettier on getResourceIds

### DIFF
--- a/packages/cli/src/deploy/getResourceIds.ts
+++ b/packages/cli/src/deploy/getResourceIds.ts
@@ -30,9 +30,7 @@ export async function getResourceIds({
       retries: 3,
       onFailedAttempt: async (error) => {
         const shouldRetry =
-          error instanceof HttpRequestError &&
-          error.status === 400 &&
-          error.message.includes('block is out of range');
+          error instanceof HttpRequestError && error.status === 400 && error.message.includes("block is out of range");
 
         if (!shouldRetry) {
           throw error;


### PR DESCRIPTION
Linting error was caused in https://github.com/latticexyz/mud/pull/2709 but missed because CI wasn't working