### PR TITLE
refactor(cli): add getDeployer

### DIFF
--- a/packages/cli/src/deploy/ensureDeployer.ts
+++ b/packages/cli/src/deploy/ensureDeployer.ts
@@ -1,21 +1,15 @@
-import { Account, Address, Chain, Client, Transport, sliceHex } from "viem";
-import { getBalance, getBytecode, sendRawTransaction, sendTransaction, waitForTransactionReceipt } from "viem/actions";
+import { Account, Address, Chain, Client, Transport } from "viem";
+import { getBalance, sendRawTransaction, sendTransaction, waitForTransactionReceipt } from "viem/actions";
 import deployment from "./create2/deployment.json";
 import { debug } from "./debug";
+import { getDeployer } from "./getDeployer";
 
 const deployer = `0x${deployment.address}` as const;
 
 export async function ensureDeployer(client: Client<Transport, Chain | undefined, Account>): Promise<Address> {
-  const bytecode = await getBytecode(client, { address: deployer });
-  if (bytecode) {
-    debug("found CREATE2 deployer at", deployer);
-    // check if deployed bytecode is the same as the expected bytecode (minus 14-bytes creation code prefix)
-    if (bytecode !== sliceHex(`0x${deployment.creationCode}`, 14)) {
-      console.warn(
-        `\n  ⚠️ Bytecode for deployer at ${deployer} did not match the expected CREATE2 bytecode. You may have unexpected results.\n`,
-      );
-    }
-    return deployer;
+  const existingDeployer = await getDeployer(client);
+  if (existingDeployer !== undefined) {
+    return existingDeployer;
   }
 
   // There's not really a way to simulate a pre-EIP-155 (no chain ID) transaction,

--- a/packages/cli/src/deploy/getDeployer.ts
+++ b/packages/cli/src/deploy/getDeployer.ts
@@ -1,0 +1,20 @@
+import { Address, Chain, Client, Transport, sliceHex } from "viem";
+import { getBytecode } from "viem/actions";
+import deployment from "./create2/deployment.json";
+import { debug } from "./debug";
+
+const deployer = `0x${deployment.address}` as const;
+
+export async function getDeployer(client: Client<Transport, Chain | undefined>): Promise<Address | undefined> {
+  const bytecode = await getBytecode(client, { address: deployer });
+  if (bytecode) {
+    debug("found CREATE2 deployer at", deployer);
+    // check if deployed bytecode is the same as the expected bytecode (minus 14-bytes creation code prefix)
+    if (bytecode !== sliceHex(`0x${deployment.creationCode}`, 14)) {
+      console.warn(
+        `\n  ⚠️ Bytecode for deployer at ${deployer} did not match the expected CREATE2 bytecode. You may have unexpected results.\n`,
+      );
+    }
+    return deployer;
+  }
+}


### PR DESCRIPTION
As noted in https://github.com/latticexyz/mud/pull/2662#discussion_r1577694925, it is useful to get the address of the CREATE2 deployer, but we should not export it directly in case the deployer contract does not exist.

This adds a `getDeployer() => Promise<Address | undefined>` function.