### PR TITLE
refactor(cli): getWorldContracts

### DIFF
--- a/packages/cli/src/deploy/ensureWorldFactory.ts
+++ b/packages/cli/src/deploy/ensureWorldFactory.ts
@@ -8,16 +8,27 @@ export async function ensureWorldFactory(
   deployerAddress: Hex,
   withWorldProxy?: boolean,
 ): Promise<Address> {
-  const worldFactoryContracts = withWorldProxy
-    ? getWorldProxyFactoryContracts(deployerAddress)
-    : getWorldFactoryContracts(deployerAddress);
+  if (!withWorldProxy) {
+    const contracts = getWorldFactoryContracts(deployerAddress);
 
-  // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
-  await ensureContractsDeployed({
-    client,
-    deployerAddress,
-    contracts: Object.values(worldFactoryContracts),
-  });
+    // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
+    await ensureContractsDeployed({
+      client,
+      deployerAddress,
+      contracts: Object.values(contracts),
+    });
 
-  return worldFactoryContracts["WorldFactory"].address;
+    return contracts.WorldFactory.address;
+  } else {
+    const contracts = getWorldProxyFactoryContracts(deployerAddress);
+
+    // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
+    await ensureContractsDeployed({
+      client,
+      deployerAddress,
+      contracts: Object.values(contracts),
+    });
+
+    return contracts.WorldProxyFactory.address;
+  }
 }

--- a/packages/cli/src/deploy/ensureWorldFactory.ts
+++ b/packages/cli/src/deploy/ensureWorldFactory.ts
@@ -8,27 +8,23 @@ export async function ensureWorldFactory(
   deployerAddress: Hex,
   withWorldProxy?: boolean,
 ): Promise<Address> {
-  if (!withWorldProxy) {
-    const contracts = getWorldFactoryContracts(deployerAddress);
-
-    // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
-    await ensureContractsDeployed({
-      client,
-      deployerAddress,
-      contracts: Object.values(contracts),
-    });
-
-    return contracts.WorldFactory.address;
-  } else {
+  if (withWorldProxy) {
     const contracts = getWorldProxyFactoryContracts(deployerAddress);
-
     // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
     await ensureContractsDeployed({
       client,
       deployerAddress,
       contracts: Object.values(contracts),
     });
-
     return contracts.WorldProxyFactory.address;
   }
+  
+  const contracts = getWorldFactoryContracts(deployerAddress);
+  // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
+  await ensureContractsDeployed({
+    client,
+    deployerAddress,
+    contracts: Object.values(contracts),
+  });
+  return contracts.WorldFactory.address;
 }

--- a/packages/cli/src/deploy/ensureWorldFactory.ts
+++ b/packages/cli/src/deploy/ensureWorldFactory.ts
@@ -10,7 +10,7 @@ export async function ensureWorldFactory(
 ): Promise<Address> {
   if (withWorldProxy) {
     const contracts = getWorldProxyFactoryContracts(deployerAddress);
-    // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
+    // We can deploy these contracts in parallel because they do not call each other at this point.
     await ensureContractsDeployed({
       client,
       deployerAddress,
@@ -18,9 +18,9 @@ export async function ensureWorldFactory(
     });
     return contracts.WorldProxyFactory.address;
   }
-  
+
   const contracts = getWorldFactoryContracts(deployerAddress);
-  // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
+  // We can deploy these contracts in parallel because they do not call each other at this point.
   await ensureContractsDeployed({
     client,
     deployerAddress,

--- a/packages/cli/src/deploy/ensureWorldFactory.ts
+++ b/packages/cli/src/deploy/ensureWorldFactory.ts
@@ -1,111 +1,23 @@
-import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
-import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
-import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
-import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
-import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
-import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
-import worldFactoryBuild from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.json" assert { type: "json" };
-import worldFactoryAbi from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.abi.json" assert { type: "json" };
-import worldProxyFactoryBuild from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.json" assert { type: "json" };
-import worldProxyFactoryAbi from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.abi.json" assert { type: "json" };
-import { Client, Transport, Chain, Account, Hex, getCreate2Address, encodeDeployData, size, Address } from "viem";
-import { salt } from "./common";
+import { Client, Transport, Chain, Account, Hex, Address } from "viem";
 import { ensureContractsDeployed } from "./ensureContractsDeployed";
-import { Contract } from "./ensureContract";
+import { getWorldFactoryContracts } from "./getWorldFactoryContracts";
+import { getWorldProxyFactoryContracts } from "./getWorldProxyFactoryContracts";
 
 export async function ensureWorldFactory(
   client: Client<Transport, Chain | undefined, Account>,
   deployerAddress: Hex,
   withWorldProxy?: boolean,
 ): Promise<Address> {
-  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
-  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
-  const accessManagementSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: accessManagementSystemBytecode,
-    salt,
-  });
-
-  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
-  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
-  const balanceTransferSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: balanceTransferSystemBytecode,
-    salt,
-  });
-
-  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
-  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
-  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
-
-  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
-  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
-  const registration = getCreate2Address({
-    from: deployerAddress,
-    bytecode: registrationBytecode,
-    salt,
-  });
-
-  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
-  const initModuleBytecode = encodeDeployData({
-    bytecode: initModuleBuild.bytecode.object as Hex,
-    abi: initModuleAbi,
-    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
-  });
-
-  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
-
-  const build = withWorldProxy ? worldProxyFactoryBuild : worldFactoryBuild;
-  const abi = withWorldProxy ? worldProxyFactoryAbi : worldFactoryAbi;
-
-  const worldFactoryDeployedBytecodeSize = size(build.deployedBytecode.object as Hex);
-  const worldFactoryBytecode = encodeDeployData({
-    bytecode: build.bytecode.object as Hex,
-    abi: abi,
-    args: [initModule],
-  });
-
-  const worldFactory = getCreate2Address({ from: deployerAddress, bytecode: worldFactoryBytecode, salt });
-
-  const worldFactoryContracts: readonly Contract[] = [
-    {
-      bytecode: accessManagementSystemBytecode,
-      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
-      label: "access management system",
-    },
-    {
-      bytecode: balanceTransferSystemBytecode,
-      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
-      label: "balance transfer system",
-    },
-    {
-      bytecode: batchCallSystemBytecode,
-      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
-      label: "batch call system",
-    },
-    {
-      bytecode: registrationBytecode,
-      deployedBytecodeSize: registrationDeployedBytecodeSize,
-      label: "core registration system",
-    },
-    {
-      bytecode: initModuleBytecode,
-      deployedBytecodeSize: initModuleDeployedBytecodeSize,
-      label: "core module",
-    },
-    {
-      bytecode: worldFactoryBytecode,
-      deployedBytecodeSize: worldFactoryDeployedBytecodeSize,
-      label: "world factory",
-    },
-  ];
+  const worldFactoryContracts = withWorldProxy
+    ? getWorldProxyFactoryContracts(deployerAddress)
+    : getWorldFactoryContracts(deployerAddress);
 
   // WorldFactory constructor doesn't call InitModule, only sets its address, so we can do these in parallel since the address is deterministic
   await ensureContractsDeployed({
     client,
     deployerAddress,
-    contracts: worldFactoryContracts,
+    contracts: Object.values(worldFactoryContracts),
   });
 
-  return worldFactory;
+  return worldFactoryContracts["WorldFactory"].address;
 }

--- a/packages/cli/src/deploy/getWorldContracts.ts
+++ b/packages/cli/src/deploy/getWorldContracts.ts
@@ -6,9 +6,8 @@ import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.jso
 import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
 import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
 import { salt } from "./common";
-import { Contract } from "./ensureContract";
 
-export function getWorldContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+export function getWorldContracts(deployerAddress: Hex) {
   const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
   const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
   const accessManagementSystem = getCreate2Address({

--- a/packages/cli/src/deploy/getWorldContracts.ts
+++ b/packages/cli/src/deploy/getWorldContracts.ts
@@ -1,0 +1,80 @@
+import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
+import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
+import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
+import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
+import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
+import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
+import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
+import { salt } from "./common";
+import { Contract } from "./ensureContract";
+
+export function getWorldContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
+  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
+  const accessManagementSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: accessManagementSystemBytecode,
+    salt,
+  });
+
+  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
+  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
+  const balanceTransferSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: balanceTransferSystemBytecode,
+    salt,
+  });
+
+  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
+  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
+  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
+
+  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
+  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
+  const registration = getCreate2Address({
+    from: deployerAddress,
+    bytecode: registrationBytecode,
+    salt,
+  });
+
+  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
+  const initModuleBytecode = encodeDeployData({
+    bytecode: initModuleBuild.bytecode.object as Hex,
+    abi: initModuleAbi,
+    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
+  });
+  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
+
+  return {
+    AccessManagementSystem: {
+      bytecode: accessManagementSystemBytecode,
+      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
+      label: "access management system",
+      address: accessManagementSystem,
+    },
+    BalanceTransferSystem: {
+      bytecode: balanceTransferSystemBytecode,
+      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
+      label: "balance transfer system",
+      address: balanceTransferSystem,
+    },
+    BatchCallSystem: {
+      bytecode: batchCallSystemBytecode,
+      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
+      label: "batch call system",
+      address: batchCallSystem,
+    },
+    RegistrationSystem: {
+      bytecode: registrationBytecode,
+      deployedBytecodeSize: registrationDeployedBytecodeSize,
+      label: "core registration system",
+      address: registration,
+    },
+    InitModule: {
+      bytecode: initModuleBytecode,
+      deployedBytecodeSize: initModuleDeployedBytecodeSize,
+      label: "core module",
+      address: initModule,
+    },
+  };
+}

--- a/packages/cli/src/deploy/getWorldFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldFactoryContracts.ts
@@ -1,0 +1,96 @@
+import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
+import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
+import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
+import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
+import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
+import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
+import worldFactoryBuild from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.json" assert { type: "json" };
+import worldFactoryAbi from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.abi.json" assert { type: "json" };
+import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
+import { salt } from "./common";
+import { Contract } from "./ensureContract";
+
+export function getWorldFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
+  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
+  const accessManagementSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: accessManagementSystemBytecode,
+    salt,
+  });
+
+  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
+  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
+  const balanceTransferSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: balanceTransferSystemBytecode,
+    salt,
+  });
+
+  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
+  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
+  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
+
+  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
+  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
+  const registration = getCreate2Address({
+    from: deployerAddress,
+    bytecode: registrationBytecode,
+    salt,
+  });
+
+  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
+  const initModuleBytecode = encodeDeployData({
+    bytecode: initModuleBuild.bytecode.object as Hex,
+    abi: initModuleAbi,
+    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
+  });
+  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
+
+  const worldFactoryDeployedBytecodeSize = size(worldFactoryBuild.deployedBytecode.object as Hex);
+  const worldFactoryBytecode = encodeDeployData({
+    bytecode: worldFactoryBuild.bytecode.object as Hex,
+    abi: worldFactoryAbi,
+    args: [initModule],
+  });
+  const worldFactory = getCreate2Address({ from: deployerAddress, bytecode: worldFactoryBytecode, salt });
+
+  return {
+    AccessManagementSystem: {
+      bytecode: accessManagementSystemBytecode,
+      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
+      label: "access management system",
+      address: accessManagementSystem,
+    },
+    BalanceTransferSystem: {
+      bytecode: balanceTransferSystemBytecode,
+      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
+      label: "balance transfer system",
+      address: balanceTransferSystem,
+    },
+    BatchCallSystem: {
+      bytecode: batchCallSystemBytecode,
+      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
+      label: "batch call system",
+      address: batchCallSystem,
+    },
+    RegistrationSystem: {
+      bytecode: registrationBytecode,
+      deployedBytecodeSize: registrationDeployedBytecodeSize,
+      label: "core registration system",
+      address: registration,
+    },
+    InitModule: {
+      bytecode: initModuleBytecode,
+      deployedBytecodeSize: initModuleDeployedBytecodeSize,
+      label: "core module",
+      address: initModule,
+    },
+    WorldFactory: {
+      bytecode: worldFactoryBytecode,
+      deployedBytecodeSize: worldFactoryDeployedBytecodeSize,
+      label: "world factory",
+      address: worldFactory,
+    },
+  };
+}

--- a/packages/cli/src/deploy/getWorldFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldFactoryContracts.ts
@@ -1,91 +1,23 @@
-import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
-import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
-import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
-import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
-import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
-import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
 import worldFactoryBuild from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.json" assert { type: "json" };
 import worldFactoryAbi from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.abi.json" assert { type: "json" };
 import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
 import { salt } from "./common";
 import { Contract } from "./ensureContract";
+import { getWorldContracts } from "./getWorldContracts";
 
 export function getWorldFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
-  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
-  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
-  const accessManagementSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: accessManagementSystemBytecode,
-    salt,
-  });
-
-  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
-  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
-  const balanceTransferSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: balanceTransferSystemBytecode,
-    salt,
-  });
-
-  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
-  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
-  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
-
-  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
-  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
-  const registration = getCreate2Address({
-    from: deployerAddress,
-    bytecode: registrationBytecode,
-    salt,
-  });
-
-  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
-  const initModuleBytecode = encodeDeployData({
-    bytecode: initModuleBuild.bytecode.object as Hex,
-    abi: initModuleAbi,
-    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
-  });
-  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
+  const worldContracts = getWorldContracts(deployerAddress);
 
   const worldFactoryDeployedBytecodeSize = size(worldFactoryBuild.deployedBytecode.object as Hex);
   const worldFactoryBytecode = encodeDeployData({
     bytecode: worldFactoryBuild.bytecode.object as Hex,
     abi: worldFactoryAbi,
-    args: [initModule],
+    args: [worldContracts.InitModule.address],
   });
   const worldFactory = getCreate2Address({ from: deployerAddress, bytecode: worldFactoryBytecode, salt });
 
   return {
-    AccessManagementSystem: {
-      bytecode: accessManagementSystemBytecode,
-      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
-      label: "access management system",
-      address: accessManagementSystem,
-    },
-    BalanceTransferSystem: {
-      bytecode: balanceTransferSystemBytecode,
-      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
-      label: "balance transfer system",
-      address: balanceTransferSystem,
-    },
-    BatchCallSystem: {
-      bytecode: batchCallSystemBytecode,
-      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
-      label: "batch call system",
-      address: batchCallSystem,
-    },
-    RegistrationSystem: {
-      bytecode: registrationBytecode,
-      deployedBytecodeSize: registrationDeployedBytecodeSize,
-      label: "core registration system",
-      address: registration,
-    },
-    InitModule: {
-      bytecode: initModuleBytecode,
-      deployedBytecodeSize: initModuleDeployedBytecodeSize,
-      label: "core module",
-      address: initModule,
-    },
+    ...worldContracts,
     WorldFactory: {
       bytecode: worldFactoryBytecode,
       deployedBytecodeSize: worldFactoryDeployedBytecodeSize,

--- a/packages/cli/src/deploy/getWorldFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldFactoryContracts.ts
@@ -2,10 +2,9 @@ import worldFactoryBuild from "@latticexyz/world/out/WorldFactory.sol/WorldFacto
 import worldFactoryAbi from "@latticexyz/world/out/WorldFactory.sol/WorldFactory.abi.json" assert { type: "json" };
 import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
 import { salt } from "./common";
-import { Contract } from "./ensureContract";
 import { getWorldContracts } from "./getWorldContracts";
 
-export function getWorldFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+export function getWorldFactoryContracts(deployerAddress: Hex) {
   const worldContracts = getWorldContracts(deployerAddress);
 
   const worldFactoryDeployedBytecodeSize = size(worldFactoryBuild.deployedBytecode.object as Hex);

--- a/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
@@ -2,10 +2,9 @@ import worldProxyFactoryBuild from "@latticexyz/world/out/WorldProxyFactory.sol/
 import worldProxyFactoryAbi from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.abi.json" assert { type: "json" };
 import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
 import { salt } from "./common";
-import { Contract } from "./ensureContract";
 import { getWorldContracts } from "./getWorldContracts";
 
-export function getWorldProxyFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+export function getWorldProxyFactoryContracts(deployerAddress: Hex) {
   const worldContracts = getWorldContracts(deployerAddress);
 
   const worldProxyFactoryDeployedBytecodeSize = size(worldProxyFactoryBuild.deployedBytecode.object as Hex);

--- a/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
@@ -1,91 +1,23 @@
-import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
-import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
-import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
-import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
-import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
-import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
 import worldProxyFactoryBuild from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.json" assert { type: "json" };
 import worldProxyFactoryAbi from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.abi.json" assert { type: "json" };
 import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
 import { salt } from "./common";
 import { Contract } from "./ensureContract";
+import { getWorldContracts } from "./getWorldContracts";
 
 export function getWorldProxyFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
-  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
-  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
-  const accessManagementSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: accessManagementSystemBytecode,
-    salt,
-  });
-
-  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
-  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
-  const balanceTransferSystem = getCreate2Address({
-    from: deployerAddress,
-    bytecode: balanceTransferSystemBytecode,
-    salt,
-  });
-
-  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
-  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
-  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
-
-  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
-  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
-  const registration = getCreate2Address({
-    from: deployerAddress,
-    bytecode: registrationBytecode,
-    salt,
-  });
-
-  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
-  const initModuleBytecode = encodeDeployData({
-    bytecode: initModuleBuild.bytecode.object as Hex,
-    abi: initModuleAbi,
-    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
-  });
-  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
+  const worldContracts = getWorldContracts(deployerAddress);
 
   const worldProxyFactoryDeployedBytecodeSize = size(worldProxyFactoryBuild.deployedBytecode.object as Hex);
   const worldProxyFactoryBytecode = encodeDeployData({
     bytecode: worldProxyFactoryBuild.bytecode.object as Hex,
     abi: worldProxyFactoryAbi,
-    args: [initModule],
+    args: [worldContracts.InitModule.address],
   });
   const worldProxyFactory = getCreate2Address({ from: deployerAddress, bytecode: worldProxyFactoryBytecode, salt });
 
   return {
-    AccessManagementSystem: {
-      bytecode: accessManagementSystemBytecode,
-      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
-      label: "access management system",
-      address: accessManagementSystem,
-    },
-    BalanceTransferSystem: {
-      bytecode: balanceTransferSystemBytecode,
-      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
-      label: "balance transfer system",
-      address: balanceTransferSystem,
-    },
-    BatchCallSystem: {
-      bytecode: batchCallSystemBytecode,
-      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
-      label: "batch call system",
-      address: batchCallSystem,
-    },
-    RegistrationSystem: {
-      bytecode: registrationBytecode,
-      deployedBytecodeSize: registrationDeployedBytecodeSize,
-      label: "core registration system",
-      address: registration,
-    },
-    InitModule: {
-      bytecode: initModuleBytecode,
-      deployedBytecodeSize: initModuleDeployedBytecodeSize,
-      label: "core module",
-      address: initModule,
-    },
+    ...worldContracts,
     WorldFactory: {
       bytecode: worldProxyFactoryBytecode,
       deployedBytecodeSize: worldProxyFactoryDeployedBytecodeSize,

--- a/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
@@ -1,0 +1,96 @@
+import accessManagementSystemBuild from "@latticexyz/world/out/AccessManagementSystem.sol/AccessManagementSystem.json" assert { type: "json" };
+import balanceTransferSystemBuild from "@latticexyz/world/out/BalanceTransferSystem.sol/BalanceTransferSystem.json" assert { type: "json" };
+import batchCallSystemBuild from "@latticexyz/world/out/BatchCallSystem.sol/BatchCallSystem.json" assert { type: "json" };
+import registrationSystemBuild from "@latticexyz/world/out/RegistrationSystem.sol/RegistrationSystem.json" assert { type: "json" };
+import initModuleBuild from "@latticexyz/world/out/InitModule.sol/InitModule.json" assert { type: "json" };
+import initModuleAbi from "@latticexyz/world/out/InitModule.sol/InitModule.abi.json" assert { type: "json" };
+import worldProxyFactoryBuild from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.json" assert { type: "json" };
+import worldProxyFactoryAbi from "@latticexyz/world/out/WorldProxyFactory.sol/WorldProxyFactory.abi.json" assert { type: "json" };
+import { Hex, getCreate2Address, encodeDeployData, size } from "viem";
+import { salt } from "./common";
+import { Contract } from "./ensureContract";
+
+export function getWorldProxyFactoryContracts(deployerAddress: Hex): Record<string, Contract & { address: Hex }> {
+  const accessManagementSystemDeployedBytecodeSize = size(accessManagementSystemBuild.deployedBytecode.object as Hex);
+  const accessManagementSystemBytecode = accessManagementSystemBuild.bytecode.object as Hex;
+  const accessManagementSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: accessManagementSystemBytecode,
+    salt,
+  });
+
+  const balanceTransferSystemDeployedBytecodeSize = size(balanceTransferSystemBuild.deployedBytecode.object as Hex);
+  const balanceTransferSystemBytecode = balanceTransferSystemBuild.bytecode.object as Hex;
+  const balanceTransferSystem = getCreate2Address({
+    from: deployerAddress,
+    bytecode: balanceTransferSystemBytecode,
+    salt,
+  });
+
+  const batchCallSystemDeployedBytecodeSize = size(batchCallSystemBuild.deployedBytecode.object as Hex);
+  const batchCallSystemBytecode = batchCallSystemBuild.bytecode.object as Hex;
+  const batchCallSystem = getCreate2Address({ from: deployerAddress, bytecode: batchCallSystemBytecode, salt });
+
+  const registrationDeployedBytecodeSize = size(registrationSystemBuild.deployedBytecode.object as Hex);
+  const registrationBytecode = registrationSystemBuild.bytecode.object as Hex;
+  const registration = getCreate2Address({
+    from: deployerAddress,
+    bytecode: registrationBytecode,
+    salt,
+  });
+
+  const initModuleDeployedBytecodeSize = size(initModuleBuild.deployedBytecode.object as Hex);
+  const initModuleBytecode = encodeDeployData({
+    bytecode: initModuleBuild.bytecode.object as Hex,
+    abi: initModuleAbi,
+    args: [accessManagementSystem, balanceTransferSystem, batchCallSystem, registration],
+  });
+  const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
+
+  const worldFactoryDeployedBytecodeSize = size(worldProxyFactoryBuild.deployedBytecode.object as Hex);
+  const worldFactoryBytecode = encodeDeployData({
+    bytecode: worldProxyFactoryBuild.bytecode.object as Hex,
+    abi: worldProxyFactoryAbi,
+    args: [initModule],
+  });
+  const worldFactory = getCreate2Address({ from: deployerAddress, bytecode: worldFactoryBytecode, salt });
+
+  return {
+    AccessManagementSystem: {
+      bytecode: accessManagementSystemBytecode,
+      deployedBytecodeSize: accessManagementSystemDeployedBytecodeSize,
+      label: "access management system",
+      address: accessManagementSystem,
+    },
+    BalanceTransferSystem: {
+      bytecode: balanceTransferSystemBytecode,
+      deployedBytecodeSize: balanceTransferSystemDeployedBytecodeSize,
+      label: "balance transfer system",
+      address: balanceTransferSystem,
+    },
+    BatchCallSystem: {
+      bytecode: batchCallSystemBytecode,
+      deployedBytecodeSize: batchCallSystemDeployedBytecodeSize,
+      label: "batch call system",
+      address: batchCallSystem,
+    },
+    RegistrationSystem: {
+      bytecode: registrationBytecode,
+      deployedBytecodeSize: registrationDeployedBytecodeSize,
+      label: "core registration system",
+      address: registration,
+    },
+    InitModule: {
+      bytecode: initModuleBytecode,
+      deployedBytecodeSize: initModuleDeployedBytecodeSize,
+      label: "core module",
+      address: initModule,
+    },
+    WorldFactory: {
+      bytecode: worldFactoryBytecode,
+      deployedBytecodeSize: worldFactoryDeployedBytecodeSize,
+      label: "world factory",
+      address: worldFactory,
+    },
+  };
+}

--- a/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
@@ -47,13 +47,13 @@ export function getWorldProxyFactoryContracts(deployerAddress: Hex): Record<stri
   });
   const initModule = getCreate2Address({ from: deployerAddress, bytecode: initModuleBytecode, salt });
 
-  const worldFactoryDeployedBytecodeSize = size(worldProxyFactoryBuild.deployedBytecode.object as Hex);
-  const worldFactoryBytecode = encodeDeployData({
+  const worldProxyFactoryDeployedBytecodeSize = size(worldProxyFactoryBuild.deployedBytecode.object as Hex);
+  const worldProxyFactoryBytecode = encodeDeployData({
     bytecode: worldProxyFactoryBuild.bytecode.object as Hex,
     abi: worldProxyFactoryAbi,
     args: [initModule],
   });
-  const worldFactory = getCreate2Address({ from: deployerAddress, bytecode: worldFactoryBytecode, salt });
+  const worldProxyFactory = getCreate2Address({ from: deployerAddress, bytecode: worldProxyFactoryBytecode, salt });
 
   return {
     AccessManagementSystem: {
@@ -87,10 +87,10 @@ export function getWorldProxyFactoryContracts(deployerAddress: Hex): Record<stri
       address: initModule,
     },
     WorldFactory: {
-      bytecode: worldFactoryBytecode,
-      deployedBytecodeSize: worldFactoryDeployedBytecodeSize,
-      label: "world factory",
-      address: worldFactory,
+      bytecode: worldProxyFactoryBytecode,
+      deployedBytecodeSize: worldProxyFactoryDeployedBytecodeSize,
+      label: "world proxy factory",
+      address: worldProxyFactory,
     },
   };
 }

--- a/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
+++ b/packages/cli/src/deploy/getWorldProxyFactoryContracts.ts
@@ -17,7 +17,7 @@ export function getWorldProxyFactoryContracts(deployerAddress: Hex) {
 
   return {
     ...worldContracts,
-    WorldFactory: {
+    WorldProxyFactory: {
       bytecode: worldProxyFactoryBytecode,
       deployedBytecodeSize: worldProxyFactoryDeployedBytecodeSize,
       label: "world proxy factory",


### PR DESCRIPTION
In https://github.com/latticexyz/mud/pull/2662 (contract verification) it is useful to have a list of the names and bytecode for the standard contracts deployed by MUD (`InitModule`, `World` etc.)

As pointed out in https://github.com/latticexyz/mud/pull/2662#discussion_r1577697220 we can split this into a seperate PR and rework the approach too.