### PR TITLE
fix(common): use feeRef for sendTransaction calls

### DIFF
--- a/.changeset/angry-ties-travel.md
+++ b/.changeset/angry-ties-travel.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Added asynchronous polling for current fees to `sendTransaction`.

--- a/packages/common/src/sendTransaction.ts
+++ b/packages/common/src/sendTransaction.ts
@@ -94,8 +94,8 @@ export async function sendTransaction<
           const nonce = nonceManager.nextNonce();
           debug("sending tx with nonce", nonce, "to", preparedRequest.to);
           const parameters: SendTransactionParameters<chain, account, chainOverride> = {
-            nonce,
             ...preparedRequest,
+            nonce,
             ...feeRef.fees,
           };
           return await viem_sendTransaction(client, parameters);

--- a/packages/common/src/sendTransaction.ts
+++ b/packages/common/src/sendTransaction.ts
@@ -13,6 +13,7 @@ import pRetry from "p-retry";
 import { debug as parentDebug } from "./debug";
 import { getNonceManager } from "./getNonceManager";
 import { parseAccount } from "viem/accounts";
+import { getFeeRef } from "./getFeeRef";
 
 const debug = parentDebug.extend("sendTransaction");
 
@@ -49,12 +50,19 @@ export async function sendTransaction<
     throw new Error("No account provided");
   }
   const account = parseAccount(rawAccount);
+  const chain = client.chain;
 
   const nonceManager = await getNonceManager({
     client: opts.publicClient ?? client,
     address: account.address,
     blockTag: "pending",
     queueConcurrency: opts.queueConcurrency,
+  });
+
+  const feeRef = await getFeeRef({
+    client: opts.publicClient ?? client,
+    refreshInterval: 10000,
+    args: { chain },
   });
 
   async function prepare(): Promise<SendTransactionParameters<chain, account, chainOverride>> {
@@ -85,7 +93,11 @@ export async function sendTransaction<
 
           const nonce = nonceManager.nextNonce();
           debug("sending tx with nonce", nonce, "to", preparedRequest.to);
-          const parameters: SendTransactionParameters<chain, account, chainOverride> = { nonce, ...preparedRequest };
+          const parameters: SendTransactionParameters<chain, account, chainOverride> = {
+            nonce,
+            ...preparedRequest,
+            ...feeRef.fees,
+          };
           return await viem_sendTransaction(client, parameters);
         },
         {


### PR DESCRIPTION
- if we don't use the fee ref here, we don't get the "site recommended" fee to show up in Metamask
- also doesn't seem to hurt, just makes submission a bit faster
- i believe this is what was causing nonce gap issues during the last playtest. players could improperly set their fee and get a tx stuck in the mempool indefinitely