### PR TITLE
fix(store-indexer): transform env var to undefined

### DIFF
--- a/.changeset/afraid-eagles-learn.md
+++ b/.changeset/afraid-eagles-learn.md
@@ -2,6 +2,4 @@
 "@latticexyz/store-indexer": patch
 ---
 
-Added Prometheus metrics at `/metrics` to the Postgres indexer backend and frontend, as well as the SQLite indexer.
-
-Added support for passing in an empty `STORE_ADDRESS=` environment variable.
+Add Prometheus metrics at `/metrics` to the Postgres indexer backend and frontend, as well as the SQLite indexer.

--- a/.changeset/afraid-eagles-learn.md
+++ b/.changeset/afraid-eagles-learn.md
@@ -2,4 +2,6 @@
 "@latticexyz/store-indexer": patch
 ---
 
-Add Prometheus metrics at `/metrics` to the Postgres indexer backend and frontend, as well as the SQLite indexer.
+Added Prometheus metrics at `/metrics` to the Postgres indexer backend and frontend, as well as the SQLite indexer.
+
+Added support for passing in an empty `STORE_ADDRESS=` environment variable.

--- a/.changeset/eighty-actors-live.md
+++ b/.changeset/eighty-actors-live.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-indexer": patch
+---
+
+Added support for passing in an empty `STORE_ADDRESS=` environment variable.

--- a/packages/store-indexer/bin/parseEnv.ts
+++ b/packages/store-indexer/bin/parseEnv.ts
@@ -12,7 +12,11 @@ export const indexerEnvSchema = z.intersection(
     START_BLOCK: z.coerce.bigint().nonnegative().default(0n),
     MAX_BLOCK_RANGE: z.coerce.bigint().positive().default(1000n),
     POLLING_INTERVAL: z.coerce.number().positive().default(1000),
-    STORE_ADDRESS: z.string().refine(isHex).optional(),
+    STORE_ADDRESS: z
+      .string()
+      .transform((input) => (input === "" ? undefined : input))
+      .refine(isHex)
+      .optional(),
   }),
   z.union([
     z.object({


### PR DESCRIPTION
Allow an empty `STORE_ADDRESS=` env variable to be passed in to the store indexer