### PR TITLE
fix(store-indexer): allow empty env variable

### DIFF
--- a/.changeset/eighty-actors-live.md
+++ b/.changeset/eighty-actors-live.md
@@ -2,4 +2,5 @@
 "@latticexyz/store-indexer": patch
 ---
 
-Added support for passing in an empty `STORE_ADDRESS=` environment variable.
+Added support for an empty `STORE_ADDRESS=` environment variable.
+This previously would fail the input validation, now it behaves the same way as not setting the `STORE_ADDRESS` variable at all.

--- a/packages/store-indexer/bin/parseEnv.ts
+++ b/packages/store-indexer/bin/parseEnv.ts
@@ -14,8 +14,7 @@ export const indexerEnvSchema = z.intersection(
     POLLING_INTERVAL: z.coerce.number().positive().default(1000),
     STORE_ADDRESS: z
       .string()
-      .transform((input) => (input === "" ? undefined : input))
-      .refine(isHex)
+      .refine((value) => value === "" || isHex(value))
       .optional(),
   }),
   z.union([


### PR DESCRIPTION
Followup to #2741, which didn't actually fixed the issue (merged too quickly). This does.