### PR TITLE
fix(store,world,world-modules): publish `solidity-files-cache.json` on npm

### DIFF
--- a/packages/schema-type/.npmignore
+++ b/packages/schema-type/.npmignore
@@ -4,3 +4,9 @@
 !src/**
 !package.json
 !README.md
+
+!out/**/*.json
+!out/**/*.abi.json
+!out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
+!foundry.toml

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !ts/**
 !mud.config.ts

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -3,10 +3,10 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !ts/**
 !mud.config.ts
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -9,3 +9,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !ts/**
 !package.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -8,3 +8,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -3,9 +3,9 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !ts/**
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !test/MudTest.t.sol
 !ts/**

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -3,6 +3,7 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !test/MudTest.t.sol
 !ts/**
@@ -10,4 +11,3 @@
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -10,3 +10,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json


### PR DESCRIPTION
Publishing this file with NPM enables `forge verify-contract` to find MUD contract files when they are installed as a dependency.