### PR TITLE
fix(cli): fix verify with sourcify for dependencies

### DIFF
--- a/.changeset/sour-otters-warn.md
+++ b/.changeset/sour-otters-warn.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Patched `mud verify` to properly verify store, world, and world-modules contracts. Currently only `sourcify` is fully supported and is the default verifier.

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -25,7 +25,7 @@ const verifyOptions = {
     desc: "Enable batch processing of RPC requests in viem client (defaults to batch size of 100 and wait of 1s)",
   },
   srcDir: { type: "string", desc: "Source directory. Defaults to foundry src directory." },
-  verifier: { type: "string", desc: "The verifier to use" },
+  verifier: { type: "string", desc: "The verifier to use. Default to sourcify", default: "sourcify" },
   verifierUrl: {
     type: "string",
     desc: "The verification provider.",

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -97,7 +97,6 @@ const commandModule: CommandModule<Options, Options> = {
     await verify({
       client,
       rpc,
-      foundryProfile: profile,
       systems,
       modules,
       deployerAddress: opts.deployerAddress as Hex | undefined,

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -74,11 +74,17 @@ export async function verify({
     ),
   );
 
-  {
-    const cwd = "node_modules/@latticexyz/world";
-
+  // If the verifier is Sourcify, attempt to verify MUD core contracts
+  if (verifier === "sourcify") {
+    // Install subdependencies so contracts can compile
     await execa("npm", ["install"], {
-      cwd,
+      cwd: "node_modules/@latticexyz/store",
+    });
+    await execa("npm", ["install"], {
+      cwd: "node_modules/@latticexyz/world",
+    });
+    await execa("npm", ["install"], {
+      cwd: "node_modules/@latticexyz/world-modules",
     });
 
     Object.entries(
@@ -99,21 +105,13 @@ export async function verify({
           },
           {
             profile: foundryProfile,
-            cwd,
+            cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
           console.error(`Error verifying world factory contract ${name}:`, error);
         }),
       ),
     );
-  }
-
-  {
-    const cwd = "node_modules/@latticexyz/world-modules";
-
-    await execa("npm", ["install"], {
-      cwd,
-    });
 
     modules.map(({ name, bytecode }) =>
       verifyQueue.add(() =>
@@ -131,17 +129,13 @@ export async function verify({
           },
           {
             profile: foundryProfile,
-            cwd,
+            cwd: "node_modules/@latticexyz/world-modules",
           },
         ).catch((error) => {
           console.error(`Error verifying module contract ${name}:`, error);
         }),
       ),
     );
-  }
-
-  {
-    const cwd = "node_modules/@latticexyz/world";
 
     // If the world was deployed as a Proxy, verify the proxy and implementation.
     if (usesProxy) {
@@ -152,7 +146,7 @@ export async function verify({
           { name: "WorldProxy", rpc, verifier, verifierUrl, address: worldAddress },
           {
             profile: foundryProfile,
-            cwd,
+            cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
           console.error(`Error verifying WorldProxy contract:`, error);
@@ -164,7 +158,7 @@ export async function verify({
           { name: "World", rpc, verifier, verifierUrl, address: implementationAddress },
           {
             profile: foundryProfile,
-            cwd,
+            cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
           console.error(`Error verifying World contract:`, error);

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -49,7 +49,7 @@ export async function verify({
   });
   const usesProxy = implementationStorage && implementationStorage !== zeroHash;
 
-  const verifyQueue = new PQueue({ concurrency: 1 });
+  const verifyQueue = new PQueue({ concurrency: 4 });
 
   systems.map(({ name, bytecode }) =>
     verifyQueue.add(() =>

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -107,12 +107,14 @@ export async function verify({
       ),
     );
   }
+
   {
     const cwd = "node_modules/@latticexyz/world-modules";
 
     await execa("npm", ["install"], {
       cwd,
     });
+
     modules.map(({ name, bytecode }) =>
       verifyQueue.add(() =>
         verifyContract(
@@ -140,10 +142,6 @@ export async function verify({
 
   {
     const cwd = "node_modules/@latticexyz/world";
-
-    await execa("npm", ["install"], {
-      cwd,
-    });
 
     // If the world was deployed as a Proxy, verify the proxy and implementation.
     if (usesProxy) {

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -168,7 +168,9 @@ export async function verify({
     }
   } else {
     console.log("");
-    console.log(`MUD is unable to verify dependent contracts for ${verifier}`);
+    console.log(
+      `Note: MUD is currently unable to verify store, world, and world-modules contracts with ${verifier}. We are planning to expand support in a future version.`,
+    );
     console.log("");
   }
 }

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -104,7 +104,6 @@ export async function verify({
             }),
           },
           {
-            profile: foundryProfile,
             cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
@@ -128,7 +127,6 @@ export async function verify({
             }),
           },
           {
-            profile: foundryProfile,
             cwd: "node_modules/@latticexyz/world-modules",
           },
         ).catch((error) => {
@@ -145,7 +143,6 @@ export async function verify({
         verifyContract(
           { name: "WorldProxy", rpc, verifier, verifierUrl, address: worldAddress },
           {
-            profile: foundryProfile,
             cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
@@ -157,7 +154,6 @@ export async function verify({
         verifyContract(
           { name: "World", rpc, verifier, verifierUrl, address: implementationAddress },
           {
-            profile: foundryProfile,
             cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {
@@ -169,7 +165,6 @@ export async function verify({
         verifyContract(
           { name: "World", rpc, verifier, verifierUrl, address: worldAddress },
           {
-            profile: foundryProfile,
             cwd: "node_modules/@latticexyz/world",
           },
         ).catch((error) => {

--- a/packages/cli/src/verify.ts
+++ b/packages/cli/src/verify.ts
@@ -12,7 +12,7 @@ import { execa } from "execa";
 type VerifyOptions = {
   client: Client<Transport, Chain | undefined>;
   rpc: string;
-  verifier?: string;
+  verifier: string;
   verifierUrl?: string;
   systems: { name: string; bytecode: Hex }[];
   modules: { name: string; bytecode: Hex }[];
@@ -166,5 +166,9 @@ export async function verify({
         }),
       );
     }
+  } else {
+    console.log("");
+    console.log(`MUD is unable to verify dependent contracts for ${verifier}`);
+    console.log("");
   }
 }

--- a/packages/cli/src/verify/verifyContract.ts
+++ b/packages/cli/src/verify/verifyContract.ts
@@ -7,11 +7,10 @@ type VerifyContractOptions = {
   verifier?: string;
   verifierUrl?: string;
   address: Address;
+  cwd?: string;
 };
 
-type ForgeOptions = { profile?: string; silent?: boolean; env?: NodeJS.ProcessEnv; cwd?: string };
-
-export async function verifyContract(options: VerifyContractOptions, forgeOptions?: ForgeOptions) {
+export async function verifyContract(options: VerifyContractOptions) {
   const args = ["verify-contract", options.address, options.name, "--rpc-url", options.rpc];
 
   if (options.verifier) {
@@ -20,5 +19,5 @@ export async function verifyContract(options: VerifyContractOptions, forgeOption
   if (options.verifierUrl) {
     args.push("--verifier-url", options.verifierUrl);
   }
-  await forge(args, forgeOptions);
+  await forge(args, { cwd: options.cwd });
 }

--- a/packages/schema-type/.npmignore
+++ b/packages/schema-type/.npmignore
@@ -4,3 +4,9 @@
 !src/**
 !package.json
 !README.md
+
+!out/**/*.json
+!out/**/*.abi.json
+!out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
+!foundry.toml

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !ts/**
 !mud.config.ts

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -3,10 +3,10 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !ts/**
 !mud.config.ts
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -9,3 +9,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !ts/**
 !package.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -8,3 +8,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json

--- a/packages/world-modules/.npmignore
+++ b/packages/world-modules/.npmignore
@@ -3,9 +3,9 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !ts/**
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -4,6 +4,7 @@
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
 !cache/solidity-files-cache.json
+!foundry.toml
 !src/**
 !test/MudTest.t.sol
 !ts/**

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -3,6 +3,7 @@
 !out/**/*.json
 !out/**/*.abi.json
 !out/**/*.abi.json.d.ts
+!cache/solidity-files-cache.json
 !src/**
 !test/MudTest.t.sol
 !ts/**
@@ -10,4 +11,3 @@
 !package.json
 !README.md
 !dist/**
-!cache/solidity-files-cache.json

--- a/packages/world/.npmignore
+++ b/packages/world/.npmignore
@@ -10,3 +10,4 @@
 !package.json
 !README.md
 !dist/**
+!cache/solidity-files-cache.json


### PR DESCRIPTION
`mud verify` attempts to verify external contracts (`InitModule`, `World`, etc.) by changing the working directory to the relevant dependency (eg. `cd node_module@latticexyz/world`) and running `forge verify-contract`. 

However these dependencies on NPM are incomplete, causing issues when attempting to compile the source files:

1) Without `solidity-files-cache.json`, Forge cannot locate the contract by name alone (eg. `World`), and requires the full path. We fix this by publishing the cache on NPM.
2) The sub-dependencies of each dependency are not installed, so for example, if `world.sol` imports `schema-type`, `world.sol` cannot be compiled. We fix this by running `npm install` in each dependency during verification.