### PR TITLE
fix(cli): remove postdeploy gas setting in favor of script options

### DIFF
--- a/.changeset/plenty-pianos-boil.md
+++ b/.changeset/plenty-pianos-boil.md
@@ -1,0 +1,7 @@
+---
+"@latticexyz/cli": patch
+---
+
+Removed manual gas setting in PostDeploy step of `mud deploy` in favor of `forge script` fetching it from the RPC.
+
+If you still want to manually set gas, you can use `mud deploy --forgeScriptOptions="--with-gas-price 1000000"`.

--- a/packages/cli/src/utils/postDeploy.ts
+++ b/packages/cli/src/utils/postDeploy.ts
@@ -2,8 +2,6 @@ import { existsSync } from "fs";
 import path from "path";
 import chalk from "chalk";
 import { getScriptDirectory, forge } from "@latticexyz/common/foundry";
-import { execSync } from "child_process";
-import { formatGwei } from "viem";
 
 export async function postDeploy(
   postDeployScript: string,
@@ -20,11 +18,7 @@ export async function postDeploy(
     return;
   }
 
-  // TODO: replace this with a viem call
-  const gasPrice = BigInt(execSync(`cast gas-price --rpc-url ${rpc}`, { encoding: "utf-8" }).trim());
-
   console.log(chalk.blue(`Executing post deploy script at ${postDeployPath}`));
-  console.log(chalk.blue(`  using gas price of ${formatGwei(gasPrice)} gwei`));
 
   await forge(
     [
@@ -34,9 +28,6 @@ export async function postDeploy(
       "--sig",
       "run(address)",
       worldAddress,
-      // TODO: also set priority fee?
-      "--with-gas-price",
-      gasPrice.toString(),
       "--rpc-url",
       rpc,
       "-vvv",


### PR DESCRIPTION
reverts #2638

- got a report that postdeploy via `mud deploy` was waiting ~forever for txs, prob due to gas too low
- ran postdeploy script manually with garnet RPC and saw that it set the gas fee appropriately
- if you want to set manually during `mud deploy`, you can now use `mud deploy --forgeScriptOptions` (#2703)