### PR TITLE
test(common): kms test uses sdk environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.check_changes.outputs.changes_outside_docs
         env:
           DATABASE_URL: "postgres://postgres@localhost:5432/postgres"
-          KMS_ENDPOINT: "http://localhost:8080"
+          AWS_ENDPOINT_URL: "http://localhost:8080"
         run: pnpm test:ci
 
       - name: Generate gas reports

--- a/packages/common/src/account/kms/kmsKeyToAccount.test.ts
+++ b/packages/common/src/account/kms/kmsKeyToAccount.test.ts
@@ -13,7 +13,6 @@ describe("kmsKeyToAccount", () => {
 
   beforeAll(async () => {
     const client = new KMSClient({
-      endpoint: process.env.KMS_ENDPOINT,
       region: "local",
       credentials: {
         accessKeyId: "AKIAXTTRUF7NU7KDMIED",


### PR DESCRIPTION
This test does not need a custom environment variable, we can set [`AWS_ENDPOINT_URL`](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) and the AWS SDK will pick it up.