### PR TITLE
refactor(common,cli): kms deployer gets keyId from environment

### DIFF
--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -43,9 +43,9 @@ export const deployOptions = {
     type: "string",
     desc: "The deployment salt to use. Defaults to a random salt.",
   },
-  awsKmsKeyId: {
-    type: "string",
-    desc: "Optional AWS KMS key ID. If set, the World is deployed using a KMS signer instead of local private key.",
+  aws: {
+    type: "boolean",
+    desc: "Deploy the World wtih a KMS signer instead of local private key.",
   },
 } as const satisfies Record<string, Options>;
 
@@ -95,8 +95,7 @@ in your contracts directory to use the default anvil private key.`,
 
   const resolvedConfig = resolveConfig({ config, forgeSourceDir: srcDir, forgeOutDir: outDir });
 
-  const keyId = opts.awsKmsKeyId ?? process.env.AWS_KMS_KEY_ID;
-  const account = keyId ? await kmsKeyToAccount({ keyId }) : privateKeyToAccount(privateKey);
+  const account = opts.aws ? await kmsKeyToAccount() : privateKeyToAccount(privateKey);
 
   const client = createWalletClient({
     transport: http(rpc, {

--- a/packages/common/src/account/kms/kmsKeyToAccount.ts
+++ b/packages/common/src/account/kms/kmsKeyToAccount.ts
@@ -1,11 +1,11 @@
-import { KMSClient } from "@aws-sdk/client-kms";
+import { KMSClient, SignCommandInput } from "@aws-sdk/client-kms";
 import { LocalAccount, hashMessage, hashTypedData, keccak256, serializeTransaction, signatureToHex } from "viem";
 import { toAccount } from "viem/accounts";
 import { signWithKms } from "./signWithKms";
 import { getAddressFromKms } from "./getAddressFromKms";
 
 export type KmsKeyToAccountOptions = {
-  keyId: string;
+  keyId?: SignCommandInput["KeyId"];
   client?: KMSClient;
 };
 


### PR DESCRIPTION
We can declare the KMS Key ID `AWS_KMS_KEY_ID` instead of passing it into to `mud deploy`. This means the flag to enable KMS signing can just be a boolean.