### PR TITLE
refactor(cli): run postdeploy with private_key flag

### DIFF
--- a/e2e/packages/contracts/script/PostDeploy.s.sol
+++ b/e2e/packages/contracts/script/PostDeploy.s.sol
@@ -12,8 +12,7 @@ contract PostDeploy is Script {
   function run(address worldAddress) external {
     StoreSwitch.setStoreAddress(worldAddress);
 
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
     // Set up a bunch of position data so we can demonstrate filtering
     Position.set({ zone: "map1", x: 1, y: 1, player: msg.sender });

--- a/examples/minimal/packages/contracts/script/PostDeploy.s.sol
+++ b/examples/minimal/packages/contracts/script/PostDeploy.s.sol
@@ -18,11 +18,8 @@ contract PostDeploy is Script {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
     // Manually deploy a system with another namespace
     ChatNamespacedSystem chatNamespacedSystem = new ChatNamespacedSystem();

--- a/examples/multiple-accounts/packages/contracts/script/PostDeploy.s.sol
+++ b/examples/multiple-accounts/packages/contracts/script/PostDeploy.s.sol
@@ -13,11 +13,8 @@ contract PostDeploy is Script {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
     // Add a last call
     IWorld(worldAddress).LastCall__newCall();

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -122,7 +122,15 @@ in your contracts directory to use the default anvil private key.`,
     withWorldProxy: configV2.deploy.upgradeableWorldImplementation,
   });
   if (opts.worldAddress == null || opts.alwaysRunPostDeploy) {
-    await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile, opts.forgeScriptOptions, privateKey);
+    await postDeploy(
+      config.postDeployScript,
+      worldDeploy.address,
+      rpc,
+      profile,
+      opts.forgeScriptOptions,
+      privateKey,
+      opts.awsKmsKeyId !== undefined,
+    );
   }
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));
 

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -122,7 +122,7 @@ in your contracts directory to use the default anvil private key.`,
     withWorldProxy: configV2.deploy.upgradeableWorldImplementation,
   });
   if (opts.worldAddress == null || opts.alwaysRunPostDeploy) {
-    await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile, opts.forgeScriptOptions);
+    await postDeploy(config.postDeployScript, worldDeploy.address, rpc, profile, opts.forgeScriptOptions, privateKey);
   }
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));
 

--- a/packages/cli/src/utils/postDeploy.ts
+++ b/packages/cli/src/utils/postDeploy.ts
@@ -11,6 +11,7 @@ export async function postDeploy(
   profile: string | undefined,
   forgeOptions: string | undefined,
   privateKey: Hex,
+  kms: boolean,
 ): Promise<void> {
   // TODO: make this more robust as it is likely to fail for any args that have a space in them
   const userOptions = forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
@@ -33,8 +34,8 @@ export async function postDeploy(
       "--rpc-url",
       rpc,
       "-vvv",
-      "--private-key",
-      privateKey,
+      ...(privateKey ? ["--private-key", privateKey] : []),
+      ...(kms ? ["--aws"] : []),
       ...userOptions,
     ],
     {

--- a/packages/cli/src/utils/postDeploy.ts
+++ b/packages/cli/src/utils/postDeploy.ts
@@ -34,8 +34,7 @@ export async function postDeploy(
       "--rpc-url",
       rpc,
       "-vvv",
-      ...(privateKey ? ["--private-key", privateKey] : []),
-      ...(kms ? ["--aws"] : []),
+      ...(kms ? ["--aws"] : ["--private-key", privateKey]),
       ...userOptions,
     ],
     {

--- a/packages/cli/src/utils/postDeploy.ts
+++ b/packages/cli/src/utils/postDeploy.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 import path from "path";
 import chalk from "chalk";
 import { getScriptDirectory, forge } from "@latticexyz/common/foundry";
+import { Hex } from "viem";
 
 export async function postDeploy(
   postDeployScript: string,
@@ -9,6 +10,7 @@ export async function postDeploy(
   rpc: string,
   profile: string | undefined,
   forgeOptions: string | undefined,
+  privateKey: Hex,
 ): Promise<void> {
   // TODO: make this more robust as it is likely to fail for any args that have a space in them
   const userOptions = forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
@@ -32,6 +34,8 @@ export async function postDeploy(
       rpc,
       "-vvv",
       ...userOptions,
+      "--private-key",
+      privateKey,
     ],
     {
       profile: profile,

--- a/packages/cli/src/utils/postDeploy.ts
+++ b/packages/cli/src/utils/postDeploy.ts
@@ -33,9 +33,9 @@ export async function postDeploy(
       "--rpc-url",
       rpc,
       "-vvv",
-      ...userOptions,
       "--private-key",
       privateKey,
+      ...userOptions,
     ],
     {
       profile: profile,

--- a/templates/phaser/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/phaser/packages/contracts/script/PostDeploy.s.sol
@@ -6,23 +6,18 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
-    // ------------------ EXAMPLES ------------------
-
-    // Call increment on the world via the registered function selector
-    uint32 newValue = IWorld(worldAddress).increment();
-    console.log("Increment via IWorld:", newValue);
+    // Add a last call
+    IWorld(worldAddress).LastCall__newCall();
 
     vm.stopBroadcast();
   }

--- a/templates/phaser/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/phaser/packages/contracts/script/PostDeploy.s.sol
@@ -6,7 +6,6 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
@@ -16,8 +15,11 @@ contract PostDeploy is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast();
 
-    // Add a last call
-    IWorld(worldAddress).LastCall__newCall();
+    // ------------------ EXAMPLES ------------------
+
+    // Call increment on the world via the registered function selector
+    uint32 newValue = IWorld(worldAddress).increment();
+    console.log("Increment via IWorld:", newValue);
 
     vm.stopBroadcast();
   }

--- a/templates/react-ecs/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/react-ecs/packages/contracts/script/PostDeploy.s.sol
@@ -6,23 +6,18 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
-    // ------------------ EXAMPLES ------------------
-
-    // Call increment on the world via the registered function selector
-    uint32 newValue = IWorld(worldAddress).increment();
-    console.log("Increment via IWorld:", newValue);
+    // Add a last call
+    IWorld(worldAddress).LastCall__newCall();
 
     vm.stopBroadcast();
   }

--- a/templates/react-ecs/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/react-ecs/packages/contracts/script/PostDeploy.s.sol
@@ -6,7 +6,6 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
@@ -16,8 +15,11 @@ contract PostDeploy is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast();
 
-    // Add a last call
-    IWorld(worldAddress).LastCall__newCall();
+    // ------------------ EXAMPLES ------------------
+
+    // Call increment on the world via the registered function selector
+    uint32 newValue = IWorld(worldAddress).increment();
+    console.log("Increment via IWorld:", newValue);
 
     vm.stopBroadcast();
   }

--- a/templates/react/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/react/packages/contracts/script/PostDeploy.s.sol
@@ -13,11 +13,8 @@ contract PostDeploy is Script {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
     // We can set table records directly
     Tasks.set("1", TasksData({ description: "Walk the dog", createdAt: block.timestamp, completedAt: 0 }));

--- a/templates/vanilla/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/vanilla/packages/contracts/script/PostDeploy.s.sol
@@ -6,23 +6,18 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
 
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
     // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
-    // ------------------ EXAMPLES ------------------
-
-    // Call increment on the world via the registered function selector
-    uint32 newValue = IWorld(worldAddress).increment();
-    console.log("Increment via IWorld:", newValue);
+    // Add a last call
+    IWorld(worldAddress).LastCall__newCall();
 
     vm.stopBroadcast();
   }

--- a/templates/vanilla/packages/contracts/script/PostDeploy.s.sol
+++ b/templates/vanilla/packages/contracts/script/PostDeploy.s.sol
@@ -6,7 +6,6 @@ import { console } from "forge-std/console.sol";
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { LastCall } from "../src/codegen/index.sol";
 
 contract PostDeploy is Script {
   function run(address worldAddress) external {
@@ -16,8 +15,11 @@ contract PostDeploy is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast();
 
-    // Add a last call
-    IWorld(worldAddress).LastCall__newCall();
+    // ------------------ EXAMPLES ------------------
+
+    // Call increment on the world via the registered function selector
+    uint32 newValue = IWorld(worldAddress).increment();
+    console.log("Increment via IWorld:", newValue);
 
     vm.stopBroadcast();
   }

--- a/test/mock-game-contracts/script/PostDeploy.s.sol
+++ b/test/mock-game-contracts/script/PostDeploy.s.sol
@@ -18,8 +18,7 @@ contract PostDeploy is Script {
     address mary = makeAddr("mary");
     address joe = makeAddr("joe");
 
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-    vm.startBroadcast(deployerPrivateKey);
+    vm.startBroadcast();
 
     Position.set({ player: bob, x: 1, y: -1 });
     Health.set({ player: bob, health: 5 });


### PR DESCRIPTION
We now pass the deployer private key to the PostDeploy script with `forge script --private-key`.

Loading the deployer `PRIVATE_KEY` directly in the script is inflexible. For example, it breaks with AWS KMS because there is no local private key in that setup. 

