### PR TITLE
ci: add timeout to e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ jobs:
   main:
     name: Run end-to-end tests
     runs-on: depot-ubuntu-22.04-16
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:12.1-alpine

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,6 @@ jobs:
   main:
     name: Run end-to-end tests
     runs-on: depot-ubuntu-22.04-16
-    timeout-minutes: 25
     services:
       postgres:
         image: postgres:12.1-alpine
@@ -54,6 +53,7 @@ jobs:
         uses: ./.github/actions/require-empty-diff
 
       - name: Run tests
+        timeout-minutes: 15
         env:
           DATABASE_URL: "postgres://postgres@localhost:5432/postgres"
         working-directory: ./e2e


### PR DESCRIPTION
This PR add a timeout of 25 minutes to the e2e tests.
After looking at the history of the e2e tests runs, I saw that it usually takes 8-12 minutes to complete these tests so I arbitrarly chose 25 minutes which is approximately 2x of the max runtime observed.

Let me know if you feel that 25 minutes is still too high.

Closes #2761