### PR TITLE
ci: separate publish workflow to ensure order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - "docs/**"
+
+# Ensure only one workflow/job is publishing to npm at a time
+concurrency: publish-to-npm
+
+jobs:
+  release:
+    uses: "./.github/workflows/release.yml"
+    secrets: inherit
+
+  snapshot:
+    needs: [release]
+    uses: "./.github/workflows/snapshot.yml"
+    secrets: inherit
+
+  docker:
+    needs: [release, snapshot]
+    uses: "./.github/workflows/docker.yml"
+    secrets: inherit
+
+  test-snapshot:
+    uses: ./.github/workflows/test-published-packages.yml
+    needs: [release, snapshot]
+    with:
+      tag-or-version: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,20 +12,24 @@ concurrency: publish-to-npm
 
 jobs:
   release:
+    if: github.repository == 'latticexyz/mud'
     uses: "./.github/workflows/release.yml"
     secrets: inherit
 
   snapshot:
+    if: github.repository == 'latticexyz/mud'
     needs: [release]
     uses: "./.github/workflows/snapshot.yml"
     secrets: inherit
 
   docker:
+    if: github.repository == 'latticexyz/mud'
     needs: [release, snapshot]
     uses: "./.github/workflows/docker.yml"
     secrets: inherit
 
   test-snapshot:
+    if: github.repository == 'latticexyz/mud'
     uses: ./.github/workflows/test-published-packages.yml
     needs: [release, snapshot]
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,7 @@
 name: Release 🔖
 
 on:
-  push:
-    branches:
-      - "main"
-    paths-ignore:
-      - "docs/**"
+  workflow_call:
 
 # Ensure only one workflow/job is publishing to npm at a time
 concurrency: publish-to-npm
@@ -16,7 +12,6 @@ env:
 jobs:
   release:
     name: Release
-    if: github.repository == 'latticexyz/mud'
     runs-on: ubuntu-latest
     # Permissions necessary for Changesets to push a new branch and open PRs
     # (for automated Version Packages PRs), and request the JWT for provenance.
@@ -31,19 +26,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: "Setup"
-        uses: ./.github/actions/setup
-
-      - name: Set deployment token
-        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Check for pre.json file existence
         id: check_files
         uses: andstor/file-existence-action@v2.0.0
         with:
           files: ".changeset/pre.json"
+
+      - name: "Setup"
+        if: steps.check_files.outputs.files_exists == 'false'
+        uses: ./.github/actions/setup
+
+      - name: Set deployment token
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create version PR or publish 🚀
         if: steps.check_files.outputs.files_exists == 'false'
@@ -53,7 +50,3 @@ jobs:
           version: pnpm release:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker:
-    uses: ./.github/workflows/docker.yml
-    needs: release

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,14 +1,8 @@
 name: Snapshot release
 
-# Releases a snapshot release when new commits merge to main
-# This ensures the release process is working as expected
 on:
+  workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "docs/**"
 
 # Ensure only one workflow/job is publishing to npm at a time
 concurrency: publish-to-npm
@@ -64,13 +58,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  docker:
-    uses: ./.github/workflows/docker.yml
-    needs: release-snapshot
-
-  test-snapshot:
-    uses: ./.github/workflows/test-published-packages.yml
-    needs: release-snapshot
-    with:
-      tag-or-version: ${{ github.ref_name }}

--- a/.github/workflows/test-published-packages.yml
+++ b/.github/workflows/test-published-packages.yml
@@ -11,6 +11,7 @@ on:
       tag-or-version:
         required: true
         type: string
+        description: npm tag or version of MUD
 
 jobs:
   test-create-mud-project:


### PR DESCRIPTION
moves our npm publish step to a single workflow that calls out to the previous workflows, but with `needs` to ensure order of operations

noticed that we had both "snapshot" and "release" CI steps running simultaneously, where "snapshot" would sometimes run first (due to concurrency), which would publish a new npm version for a release but not properly tag+release on github
