### PR TITLE
fix(store-indexer): fix distance from follow block metric

### DIFF
--- a/.changeset/lazy-rivers-live.md
+++ b/.changeset/lazy-rivers-live.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-indexer": patch
+---
+
+Fixed the `distance_from_follow_block` gauge to be a positive number if the latest processed block is lagging behind the latest remote block.

--- a/packages/store-indexer/bin/postgres-indexer.ts
+++ b/packages/store-indexer/bin/postgres-indexer.ts
@@ -71,7 +71,7 @@ async function getDistanceFromFollowBlock(): Promise<bigint> {
     getLatestStoredBlockNumber(),
     publicClient.getBlock({ blockTag: env.FOLLOW_BLOCK_TAG }),
   ]);
-  return (latestStoredBlockNumber ?? -1n) - latestFollowBlock.number;
+  return latestFollowBlock.number - (latestStoredBlockNumber ?? -1n);
 }
 
 const latestStoredBlockNumber = await getLatestStoredBlockNumber();

--- a/packages/store-indexer/bin/sqlite-indexer.ts
+++ b/packages/store-indexer/bin/sqlite-indexer.ts
@@ -78,7 +78,7 @@ async function getDistanceFromFollowBlock(): Promise<bigint> {
     getLatestStoredBlockNumber(),
     publicClient.getBlock({ blockTag: env.FOLLOW_BLOCK_TAG }),
   ]);
-  return (latestStoredBlockNumber ?? -1n) - latestFollowBlock.number;
+  return latestFollowBlock.number - (latestStoredBlockNumber ?? -1n);
 }
 
 const currentChainState = await getCurrentChainState();


### PR DESCRIPTION
Followup to #2763 - the intention was for the `distance_from_follow_block` gauge to be a positive number if the latest stored block is lagging behind the follow block