### PR TITLE
fix(common): extend OP contracts, add redstone ones

### DIFF
--- a/.changeset/plenty-peas-love.md
+++ b/.changeset/plenty-peas-love.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Added OP predeploy contracts for Redstone and Garnet chain configs and added chain-specific contracts for Redstone chain config.

--- a/packages/common/src/chains/garnet.ts
+++ b/packages/common/src/chains/garnet.ts
@@ -23,6 +23,7 @@ export const garnet = {
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: "0xca11bde05977b3631167028862be2a173976ca11",
     },

--- a/packages/common/src/chains/redstone.ts
+++ b/packages/common/src/chains/redstone.ts
@@ -22,8 +22,27 @@ export const redstone = {
     },
   },
   contracts: {
+    ...chainConfig.contracts,
     multicall3: {
       address: "0xca11bde05977b3631167028862be2a173976ca11",
+    },
+    portal: {
+      [sourceId]: {
+        address: "0xC7bCb0e8839a28A1cFadd1CF716de9016CdA51ae",
+        blockCreated: 19578329,
+      },
+    },
+    l2OutputOracle: {
+      [sourceId]: {
+        address: "0xa426A052f657AEEefc298b3B5c35a470e4739d69",
+        blockCreated: 19578337,
+      },
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: "0xc473ca7E02af24c129c2eEf51F2aDf0411c1Df69",
+        blockCreated: 19578331,
+      },
     },
   },
   iconUrls: ["https://redstone.xyz/chain-icons/redstone.png"],


### PR DESCRIPTION
- fixed redstone, garnet chain contract objects, which should have been extending the OP chain config contracts (otherwise its missing predeploys like price oracle)
- added redstone contract addresses now that redstone is live