### PR TITLE
build: use correct error message 🏎

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./templates/${{ matrix.template }}
         run: pnpm run build
 
-      - name: Outdated files, run `pnpm gas-report` and commit them
+      - name: Out of date files, run `pnpm build` in `pacakges/contracts`
         uses: ./.github/actions/require-empty-diff
 
       - name: Run tests

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./templates/${{ matrix.template }}
         run: pnpm run build
 
-      - name: Out of date files, run `pnpm build` in `pacakges/contracts`
+      - name: Outdated files, run `pnpm build` and commit them
         uses: ./.github/actions/require-empty-diff
 
       - name: Run tests


### PR DESCRIPTION
It gave me an error message saying I need to run `gas-report`, even though that's not used in the templates. So I fixed it.