### PR TITLE
ci: add timeout for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Run tests
         if: steps.check_changes.outputs.changes_outside_docs
+        timeout-minutes: 15
         env:
           DATABASE_URL: "postgres://postgres@localhost:5432/postgres"
           AWS_ENDPOINT_URL: "http://localhost:8080"


### PR DESCRIPTION
trying to address runaway tests: https://github.com/latticexyz/mud/pull/2823#issuecomment-2111072372

these take a few mins to run, so 15 mins should give plenty of room for growth
