### PR TITLE
build: fix world modules mud config path

### DIFF
--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -44,7 +44,7 @@
       "@latticexyz/world/node": ["./packages/world/ts/node/index.ts"],
       "@latticexyz/world/out/*": ["./packages/world/out/*"],
       "@latticexyz/world/*": ["./packages/world/ts/exports/*.ts"],
-      "@latticexyz/world-modules/mud.config": ["./packages/world-modules/mud.config.ts"],
+      "@latticexyz/world-modules/internal/mud.config": ["./packages/world-modules/mud.config.ts"],
       "@latticexyz/world-modules/out/*": ["./packages/world-modules/out/*"]
     }
   }


### PR DESCRIPTION
missed that this import path was under `/internal` in https://github.com/latticexyz/mud/pull/2828