### PR TITLE
feat(common): export base tsconfig

### DIFF
--- a/.changeset/selfish-olives-yawn.md
+++ b/.changeset/selfish-olives-yawn.md
@@ -59,3 +59,10 @@ And your TS config in `packages/client/tsconfig.json` might look like:
 ```
 
 You may need to adjust the above configs to include any additional TS options you've set. This config pattern may also reveal new TS errors that need to be fixed or rules disabled.
+
+If you want to keep your existing TS configs, we recommend at least updating your `moduleResolution` setting.
+
+```diff
+-"moduleResolution": "node"
++"moduleResolution": "Bundler"
+```

--- a/.changeset/selfish-olives-yawn.md
+++ b/.changeset/selfish-olives-yawn.md
@@ -23,4 +23,39 @@
 "solhint-plugin-mud": patch
 ---
 
-Removed TS source from published packages in favor of DTS in an effort to improve TS performance.
+TS source has been removed from published packages in favor of DTS in an effort to improve TS performance. All packages now inherit from a base TS config in `@latticexyz/common` to allow us to continue iterating on TS performance without requiring changes in your project code.
+
+If you have a MUD project that you're upgrading, we suggest adding a `tsconfig.json` file to your project workspace that extends this base config.
+
+```sh
+pnpm add -D @latticexyz/common
+echo "{\n  \"extends\": \"@latticexyz/common/tsconfig.base.json\"\n}" > tsconfig.json
+```
+
+Then in each package of your project, inherit from your workspace root's config.
+
+For example, your TS config in `packages/contracts/tsconfig.json` might look like:
+
+```json
+{
+  "extends": "../../tsconfig.json"
+}
+```
+
+And your TS config in `packages/client/tsconfig.json` might look like:
+
+```json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client"],
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
+  "include": ["src"]
+}
+```
+
+You may need to adjust the above configs to include any additional TS options you've set. This config pattern may also reveal new TS errors that need to be fixed or rules disabled.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,10 +18,12 @@
     "./foundry": "./dist/foundry.js",
     "./type-utils": "./dist/type-utils.js",
     "./utils": "./dist/utils.js",
-    "./kms": "./dist/kms.js"
+    "./kms": "./dist/kms.js",
+    "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "tsconfig.base.json"
   ],
   "scripts": {
     "build": "pnpm run build:js",

--- a/packages/common/tsconfig.base.json
+++ b/packages/common/tsconfig.base.json
@@ -18,6 +18,5 @@
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true
-  },
-  "exclude": ["**/dist", "**/node_modules", "**/docs", "**/e2e"]
+  }
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM"],
     "outDir": "dist"
   },
   "include": ["src"]

--- a/packages/create-mud/scripts/copy-templates.sh
+++ b/packages/create-mud/scripts/copy-templates.sh
@@ -33,8 +33,9 @@ find ./dist/templates/* -name ".gitignore" -type f | while read -r file; do
 done
 
 # For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
-# To strip out the `paths`, we replace the template workspace root `tsconfig.json` with the monorepo's `tsconfig.base.json`.
-tsconfig=$(realpath "$(dirname $0)/../../../tsconfig.base.json")
+# To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+# @latticexyz/common/tsconfig.base.json
+tsconfig=$(realpath "$(dirname $0)/tsconfig.base.json")
 find ./dist/templates/*/tsconfig.json -type f | while read -r file; do
   echo "Replacing $file with $tsconfig"
   cp "$tsconfig" "$file"

--- a/packages/create-mud/scripts/tsconfig.base.json
+++ b/packages/create-mud/scripts/tsconfig.base.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@latticexyz/common/tsconfig.base.json"
+}

--- a/templates/phaser/package.json
+++ b/templates/phaser/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",
+    "@latticexyz/common": "link:../../packages/common",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/templates/phaser/tsconfig.json
+++ b/templates/phaser/tsconfig.json
@@ -1,5 +1,6 @@
-// For local development, we extend the monorepo's `tsconfig.json`, which includes paths to resolve TS source.
-// When building templates, this file will get replaced by monorepo's `tsconfig.base.json`.
+// For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
+// To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+// @latticexyz/common/tsconfig.base.json
 {
   "extends": "../../tsconfig.json"
 }

--- a/templates/react-ecs/package.json
+++ b/templates/react-ecs/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",
+    "@latticexyz/common": "link:../../packages/common",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/templates/react-ecs/tsconfig.json
+++ b/templates/react-ecs/tsconfig.json
@@ -1,5 +1,6 @@
-// For local development, we extend the monorepo's `tsconfig.json`, which includes paths to resolve TS source.
-// When building templates, this file will get replaced by monorepo's `tsconfig.base.json`.
+// For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
+// To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+// @latticexyz/common/tsconfig.base.json
 {
   "extends": "../../tsconfig.json"
 }

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",
+    "@latticexyz/common": "link:../../packages/common",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/templates/react/tsconfig.json
+++ b/templates/react/tsconfig.json
@@ -1,5 +1,6 @@
-// For local development, we extend the monorepo's `tsconfig.json`, which includes paths to resolve TS source.
-// When building templates, this file will get replaced by monorepo's `tsconfig.base.json`.
+// For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
+// To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+// @latticexyz/common/tsconfig.base.json
 {
   "extends": "../../tsconfig.json"
 }

--- a/templates/threejs/package.json
+++ b/templates/threejs/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",
+    "@latticexyz/common": "link:../../packages/common",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/templates/threejs/tsconfig.json
+++ b/templates/threejs/tsconfig.json
@@ -1,5 +1,6 @@
-// For local development, we extend the monorepo's `tsconfig.json`, which includes paths to resolve TS source.
-// When building templates, this file will get replaced by monorepo's `tsconfig.base.json`.
+// For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
+// To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+// @latticexyz/common/tsconfig.base.json
 {
   "extends": "../../tsconfig.json"
 }

--- a/templates/vanilla/package.json
+++ b/templates/vanilla/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "link:../../packages/cli",
+    "@latticexyz/common": "link:../../packages/common",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/templates/vanilla/tsconfig.json
+++ b/templates/vanilla/tsconfig.json
@@ -1,5 +1,6 @@
-// For local development, we extend the monorepo's `tsconfig.json`, which includes paths to resolve TS source.
-// When building templates, this file will get replaced by monorepo's `tsconfig.base.json`.
+// For local development, each template workspace extends the monorepo's `tsconfig.json`, which includes `paths` to resolve TS source.
+// To strip out the `paths`, we replace the template workspace root `tsconfig.json` with a new base tsconfig that extends only
+// @latticexyz/common/tsconfig.base.json
 {
   "extends": "../../tsconfig.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    // Note that the base config gets copied over to each template workspace too
-    "./tsconfig.base.json",
-    "./tsconfig.paths.json"
-  ]
+  "extends": ["./packages/common/tsconfig.base.json", "./tsconfig.paths.json"],
+  "exclude": ["**/dist", "**/node_modules", "**/docs", "**/e2e"]
 }


### PR DESCRIPTION
This migrates `tsconfig.base.json` to `@latticexyz/common` so it can be referenced in templates, and updated overtime without creating breaking changes.