### PR TITLE
feat: restore typesVersions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release:check": "changeset status --verbose --since=origin/main",
     "release:publish": "pnpm install && pnpm build && changeset publish",
     "release:version": "changeset version && pnpm install --lockfile-only && pnpm run changelog:generate",
-    "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json'",
+    "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json' 'test/*/package.json'",
     "test": "pnpm run --recursive test",
     "test:ci": "pnpm run --recursive --parallel test:ci",
     "type-stats-repo": "attest stats packages/*"

--- a/packages/abi-ts/package.json
+++ b/packages/abi-ts/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "bin": {
     "abi-ts": "./dist/abi-ts.js"
   },

--- a/packages/block-logs-stream/package.json
+++ b/packages/block-logs-stream/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "bin": {
     "mud": "./dist/mud.js"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,6 +21,37 @@
     "./kms": "./dist/kms.js",
     "./tsconfig.base.json": "./tsconfig.base.json"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "actions": [
+        "./dist/actions.d.ts"
+      ],
+      "chains": [
+        "./dist/chains.d.ts"
+      ],
+      "codegen": [
+        "./dist/codegen.d.ts"
+      ],
+      "errors": [
+        "./dist/errors.d.ts"
+      ],
+      "foundry": [
+        "./dist/foundry.d.ts"
+      ],
+      "type-utils": [
+        "./dist/type-utils.d.ts"
+      ],
+      "utils": [
+        "./dist/utils.d.ts"
+      ],
+      "kms": [
+        "./dist/kms.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "tsconfig.base.json"

--- a/packages/common/tsconfig.base.json
+++ b/packages/common/tsconfig.base.json
@@ -1,3 +1,4 @@
+// Please take care editing this! All of our packages and templates extend this base config.
 {
   "compilerOptions": {
     "module": "esnext",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -16,6 +16,25 @@
     "./register": "./dist/deprecated/register.js",
     "./node": "./dist/deprecated/node.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ],
+      "library": [
+        "./dist/deprecated/library.d.ts"
+      ],
+      "register": [
+        "./dist/deprecated/register.d.ts"
+      ],
+      "node": [
+        "./dist/deprecated/node.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/faucet/package.json
+++ b/packages/faucet/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/src/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/src/index.d.ts"
+      ]
+    }
+  },
   "bin": {
     "faucet-server": "./dist/bin/faucet-server.js"
   },

--- a/packages/gas-report/package.json
+++ b/packages/gas-report/package.json
@@ -12,14 +12,20 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "bin": {
     "gas-report": "./dist/gas-report.js"
   },
   "files": [
     "dist",
     "out",
-    "src",
-    "foundry.toml"
+    "src"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/protocol-parser/package.json
+++ b/packages/protocol-parser/package.json
@@ -13,6 +13,16 @@
     ".": "./dist/index.js",
     "./internal": "./dist/internal.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -13,6 +13,16 @@
     ".": "./dist/index.js",
     "./internal": "./dist/internal.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/recs/package.json
+++ b/packages/recs/package.json
@@ -12,6 +12,16 @@
     ".": "./dist/index.js",
     "./deprecated": "./dist/deprecated/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "deprecated": [
+        "./dist/deprecated/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/schema-type/package.json
+++ b/packages/schema-type/package.json
@@ -14,10 +14,22 @@
     "./internal": "./dist/internal.js",
     "./deprecated": "./dist/deprecated.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ],
+      "deprecated": [
+        "./dist/deprecated.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "out",
-    "foundry.toml",
     "src"
   ],
   "scripts": {

--- a/packages/solhint-config-mud/package.json
+++ b/packages/solhint-config-mud/package.json
@@ -10,6 +10,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/solhint-plugin-mud/package.json
+++ b/packages/solhint-plugin-mud/package.json
@@ -10,6 +10,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/store-indexer/package.json
+++ b/packages/store-indexer/package.json
@@ -12,6 +12,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/src/index.d.ts"
+      ]
+    }
+  },
   "bin": {
     "postgres-decoded-indexer": "./dist/bin/postgres-decoded-indexer.js",
     "postgres-frontend": "./dist/bin/postgres-frontend.js",

--- a/packages/store-sync/package.json
+++ b/packages/store-sync/package.json
@@ -19,6 +19,34 @@
     "./trpc-indexer": "./dist/trpc-indexer/index.js",
     "./zustand": "./dist/zustand/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "indexer-client": [
+        "./dist/indexer-client/index.d.ts"
+      ],
+      "postgres": [
+        "./dist/postgres/index.d.ts"
+      ],
+      "postgres-decoded": [
+        "./dist/postgres-decoded/index.d.ts"
+      ],
+      "recs": [
+        "./dist/recs/index.d.ts"
+      ],
+      "sqlite": [
+        "./dist/sqlite/index.d.ts"
+      ],
+      "trpc-indexer": [
+        "./dist/trpc-indexer/index.d.ts"
+      ],
+      "zustand": [
+        "./dist/zustand/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -19,10 +19,34 @@
     "./register": "./dist/register.js",
     "./out/*": "./out/*"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ],
+      "mud.config": [
+        "./dist/mud.config.d.ts"
+      ],
+      "codegen": [
+        "./dist/codegen.d.ts"
+      ],
+      "config": [
+        "./dist/config.d.ts"
+      ],
+      "config/v2": [
+        "./dist/config/v2.d.ts"
+      ],
+      "register": [
+        "./dist/register.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "out",
-    "foundry.toml",
     "src"
   ],
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,6 +11,13 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/world-modules/package.json
+++ b/packages/world-modules/package.json
@@ -13,10 +13,16 @@
     "./internal/mud.config": "./dist/mud.config.js",
     "./out/*": "./out/*"
   },
+  "typesVersions": {
+    "*": {
+      "internal/mud.config": [
+        "./dist/mud.config.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "out",
-    "foundry.toml",
     "src"
   ],
   "scripts": {

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -18,10 +18,31 @@
     "./node": "./dist/node.js",
     "./out/*": "./out/*"
   },
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "internal": [
+        "./dist/internal.d.ts"
+      ],
+      "mud.config": [
+        "./dist/mud.config.d.ts"
+      ],
+      "config/v2": [
+        "./dist/config/v2.d.ts"
+      ],
+      "register": [
+        "./dist/register.d.ts"
+      ],
+      "node": [
+        "./dist/node.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "out",
-    "foundry.toml",
     "src",
     "test/MudTest.t.sol"
   ],


### PR DESCRIPTION
closes https://github.com/latticexyz/mud/issues/2871

for backwards compatibility with `moduleResolution: "node"`
we had removed this in https://github.com/latticexyz/mud/pull/2828 but it broke projects when upgrading MUD verisons

(intentionally didn't include a changeset because this can be considered part of the changes in https://github.com/latticexyz/mud/pull/2828 and https://github.com/latticexyz/mud/pull/2873)