### PR TITLE
refactor(store): remove V1 `codegenIndexFilename`

### DIFF
--- a/packages/store/ts/codegen/tablegen.ts
+++ b/packages/store/ts/codegen/tablegen.ts
@@ -38,7 +38,7 @@ export async function tablegen({ configPath, config, remappings }: TablegenOptio
 
   // write table index
   if (allTableOptions.length > 0) {
-    const fullOutputPath = path.join(outputDirectory, configV1.codegenIndexFilename);
+    const fullOutputPath = path.join(outputDirectory, config.codegen.indexFilename);
     const output = renderTableIndex(allTableOptions);
     await formatAndWriteSolidity(output, fullOutputPath, "Generated table index");
   }

--- a/packages/store/ts/config/defaults.ts
+++ b/packages/store/ts/config/defaults.ts
@@ -2,7 +2,6 @@ export const PATH_DEFAULTS = {
   storeImportPath: "@latticexyz/store/src/",
   userTypesFilename: "common.sol",
   codegenDirectory: "codegen",
-  codegenIndexFilename: "index.sol",
 } as const;
 
 export type PATH_DEFAULTS = typeof PATH_DEFAULTS;

--- a/packages/store/ts/config/storeConfig.ts
+++ b/packages/store/ts/config/storeConfig.ts
@@ -349,8 +349,6 @@ export type MUDUserConfig<
     userTypesFilename?: string;
     /** Path to the directory where generated files will be placed. (Default is "codegen") */
     codegenDirectory?: string;
-    /** Filename where codegen index will be generated. Default is "index.sol" */
-    codegenIndexFilename?: string;
   };
 
 const StoreConfigUnrefined = z
@@ -360,7 +358,6 @@ const StoreConfigUnrefined = z
     tables: zTablesConfig,
     userTypesFilename: z.string().default(PATH_DEFAULTS.userTypesFilename),
     codegenDirectory: z.string().default(PATH_DEFAULTS.codegenDirectory),
-    codegenIndexFilename: z.string().default(PATH_DEFAULTS.codegenIndexFilename),
   })
   .merge(zEnumsConfig)
   .merge(zUserTypesConfig);

--- a/packages/store/ts/config/v2/compat.ts
+++ b/packages/store/ts/config/v2/compat.ts
@@ -16,7 +16,6 @@ export type storeToV1<store> = store extends Store
       storeImportPath: store["codegen"]["storeImportPath"];
       userTypesFilename: store["codegen"]["userTypesFilename"];
       codegenDirectory: store["codegen"]["outputDirectory"];
-      codegenIndexFilename: store["codegen"]["indexFilename"];
       tables: {
         [key in keyof store["tables"] as store["tables"][key]["name"]]: tableToV1<store["tables"][key]>;
       };
@@ -68,7 +67,6 @@ export function storeToV1<store>(store: conform<store, Store>): storeToV1<store>
     storeImportPath: store.codegen.storeImportPath,
     userTypesFilename: store.codegen.userTypesFilename,
     codegenDirectory: store.codegen.outputDirectory,
-    codegenIndexFilename: store.codegen.indexFilename,
     tables: resolvedTables,
     v2: store,
   } as never;

--- a/packages/store/ts/register/mudConfig.test-d.ts
+++ b/packages/store/ts/register/mudConfig.test-d.ts
@@ -53,6 +53,5 @@ describe("mudConfig", () => {
     storeImportPath: "@latticexyz/store/src/";
     userTypesFilename: "common.sol";
     codegenDirectory: "codegen";
-    codegenIndexFilename: "index.sol";
   }>();
 });


### PR DESCRIPTION
This usages of this property can be replaced by the V2 `config.codegen.indexFilename`.

Pulled out of https://github.com/latticexyz/mud/pull/2880