### PR TITLE
refactor(store,world): rename TS keys of resource labels

### DIFF
--- a/packages/store/ts/config/v2/input.ts
+++ b/packages/store/ts/config/v2/input.ts
@@ -8,11 +8,11 @@ export type EnumsInput = {
 };
 
 export type SchemaInput = {
-  readonly [key: string]: string;
+  readonly [fieldName: string]: string;
 };
 
 export type ScopedSchemaInput<scope extends Scope> = {
-  readonly [key: string]: keyof scope["types"];
+  readonly [fieldName: string]: keyof scope["types"];
 };
 
 export type TableCodegenInput = Partial<TableCodegen>;
@@ -30,7 +30,7 @@ export type TableInput = {
 };
 
 export type TablesInput = {
-  readonly [key: string]: Omit<TableInput, "namespace" | "name">;
+  readonly [label: string]: Omit<TableInput, "namespace" | "name">;
 };
 
 export type CodegenInput = Partial<Codegen>;
@@ -55,7 +55,7 @@ export type StoreInput = {
 export type TableShorthandInput = SchemaInput | string;
 
 export type TablesWithShorthandsInput = {
-  readonly [key: string]: TableInput | TableShorthandInput;
+  readonly [label: string]: TableInput | TableShorthandInput;
 };
 
 export type StoreWithShorthandsInput = evaluate<Omit<StoreInput, "tables"> & { tables: TablesWithShorthandsInput }>;

--- a/packages/store/ts/config/v2/output.ts
+++ b/packages/store/ts/config/v2/output.ts
@@ -71,7 +71,7 @@ export type Store = {
    */
   readonly sourceDirectory: string;
   readonly tables: {
-    readonly [namespacedTableName: string]: Table;
+    readonly [label: string]: Table;
   };
   readonly userTypes: UserTypes;
   readonly enums: EnumsInput;

--- a/packages/store/ts/config/v2/tables.ts
+++ b/packages/store/ts/config/v2/tables.ts
@@ -5,8 +5,8 @@ import { Scope, AbiTypeScope } from "./scope";
 import { validateTable, resolveTable } from "./table";
 
 export type validateTables<tables, scope extends Scope = AbiTypeScope> = {
-  [key in keyof tables]: tables[key] extends object
-    ? validateTable<tables[key], scope, { inStoreContext: true }>
+  [label in keyof tables]: tables[label] extends object
+    ? validateTable<tables[label], scope, { inStoreContext: true }>
     : ErrorMessage<`Expected full table config.`>;
 };
 
@@ -24,7 +24,7 @@ export function validateTables<scope extends Scope = AbiTypeScope>(
 }
 
 export type resolveTables<tables, scope extends Scope = AbiTypeScope> = evaluate<{
-  readonly [key in keyof tables]: resolveTable<mergeIfUndefined<tables[key], { name: key }>, scope>;
+  readonly [label in keyof tables]: resolveTable<mergeIfUndefined<tables[label], { name: label }>, scope>;
 }>;
 
 export function resolveTables<tables extends TablesInput, scope extends Scope = AbiTypeScope>(
@@ -36,8 +36,8 @@ export function resolveTables<tables extends TablesInput, scope extends Scope = 
   }
 
   return Object.fromEntries(
-    Object.entries(tables).map(([key, table]) => {
-      return [key, resolveTable(mergeIfUndefined(table, { name: key }), scope)];
+    Object.entries(tables).map(([label, table]) => {
+      return [label, resolveTable(mergeIfUndefined(table, { name: label }), scope)];
     }),
   ) as never;
 }

--- a/packages/world/ts/config/v2/input.ts
+++ b/packages/world/ts/config/v2/input.ts
@@ -103,7 +103,7 @@ export type WorldInput = evaluate<
 
 export type NamespacesInput = { [label: string]: NamespaceInput };
 
-export type NamespaceInput = Pick<StoreInput, "namespace" | "tables">;
+export type NamespaceInput = Pick<StoreInput, "tables">;
 
 /******** Variations with shorthands ********/
 

--- a/packages/world/ts/config/v2/input.ts
+++ b/packages/world/ts/config/v2/input.ts
@@ -101,9 +101,9 @@ export type WorldInput = evaluate<
   }
 >;
 
-export type NamespacesInput = { [key: string]: NamespaceInput };
+export type NamespacesInput = { [label: string]: NamespaceInput };
 
-export type NamespaceInput = Pick<StoreInput, "tables">;
+export type NamespaceInput = Pick<StoreInput, "namespace" | "tables">;
 
 /******** Variations with shorthands ********/
 

--- a/packages/world/ts/config/v2/namespaces.ts
+++ b/packages/world/ts/config/v2/namespaces.ts
@@ -38,7 +38,7 @@ export function validateNamespace<scope extends Scope = AbiTypeScope>(
 }
 
 export type validateNamespaces<namespaces, scope extends Scope = AbiTypeScope> = {
-  [namespace in keyof namespaces]: validateNamespace<namespaces[namespace], scope>;
+  [label in keyof namespaces]: validateNamespace<namespaces[label], scope>;
 };
 
 export function validateNamespaces<scope extends Scope = AbiTypeScope>(

--- a/packages/world/ts/config/v2/output.ts
+++ b/packages/world/ts/config/v2/output.ts
@@ -40,7 +40,7 @@ export type System = {
   readonly accessList: readonly string[];
 };
 
-export type Systems = { readonly [key: string]: System };
+export type Systems = { readonly [label: string]: System };
 
 export type Deploy = {
   /** The name of a custom World contract to deploy. If no name is provided, a default MUD World is deployed */

--- a/packages/world/ts/config/v2/systems.ts
+++ b/packages/world/ts/config/v2/systems.ts
@@ -4,7 +4,7 @@ import { SystemsInput } from "./input";
 import { mergeIfUndefined } from "@latticexyz/store/config/v2";
 
 export type resolveSystems<systems extends SystemsInput> = {
-  [system in keyof systems]: mergeIfUndefined<systems[system], typeof SYSTEM_DEFAULTS>;
+  [label in keyof systems]: mergeIfUndefined<systems[label], typeof SYSTEM_DEFAULTS>;
 };
 
 export function resolveSystems<systems extends SystemsInput>(systems: systems): resolveSystems<systems> {


### PR DESCRIPTION
just a small internal naming change for key names used in TS mappings to align with the terminology we've started using