### PR TITLE
fix(store-sync): add NoInfer to syncToRecs options

### DIFF
--- a/.changeset/four-peas-swim.md
+++ b/.changeset/four-peas-swim.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+TypeScript performance improvements.

--- a/.changeset/four-peas-swim.md
+++ b/.changeset/four-peas-swim.md
@@ -2,4 +2,4 @@
 "@latticexyz/store-sync": patch
 ---
 
-TypeScript performance improvements.
+Added `NoInfer` to a part of `SyncToRecsOptions` to improve TypeScript performance.

--- a/packages/store-sync/src/recs/syncToRecs.ts
+++ b/packages/store-sync/src/recs/syncToRecs.ts
@@ -7,9 +7,8 @@ import { createStoreSync } from "../createStoreSync";
 import { singletonEntity } from "./singletonEntity";
 import { SyncStep } from "../SyncStep";
 
-type SyncToRecsOptions<config extends StoreConfig, extraTables extends Record<string, Table>> = Omit<
-  SyncOptions<config>,
-  "config"
+type SyncToRecsOptions<config extends StoreConfig, extraTables extends Record<string, Table>> = NoInfer<
+  Omit<SyncOptions<config>, "config">
 > & {
   world: RecsWorld;
   config: config;


### PR DESCRIPTION
No strong types are needed for this part of the config and @ssalbdivad spotted that the part of the config is a major typescript performance bottleneck.