### PR TITLE
ci: refactor workflows to add ability to use different node.js versions

### DIFF
--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -1,15 +1,20 @@
 name: Setup prerequisites
 description: Setup pnpm, Node.js, and Foundry
+inputs:
+ node-version:
+    description: 'Node.js version to install'
+    required: true
+    default: 18
 runs:
   using: composite
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
 
-    - name: Setup node
-      uses: actions/setup-node@v3
+    - name: Setup node v${{ inputs.node-version }}
+      uses: actions/setup-node@v4
       with:
-        node-version-file: .nvmrc
+        node-version: ${{ inputs.node-version }}
         registry-url: https://registry.npmjs.org
         cache: pnpm
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,10 +1,17 @@
 name: Setup
 description: Common setup steps used by our workflows
+inputs:
+ node-version:
+    description: 'Node.js version to install'
+    required: true
+    default: 18
 runs:
   using: composite
   steps:
     - name: Setup prerequisites
       uses: ./.github/actions/setup-prerequisites
+      with:
+          node-version: ${{ inputs.node-version }}
 
     # pnpm no longer runs this before the actual install (https://github.com/pnpm/pnpm/issues/3760)
     # but we need to create some placeholder files like bins so that the install step can find them and put references to them in the right spot

--- a/.github/workflows/build-nodejs-matrix.yml
+++ b/.github/workflows/build-nodejs-matrix.yml
@@ -1,0 +1,18 @@
+name: Build a matrix of Node.js versions used by other workflows
+
+on:
+  workflow_call:
+    outputs:
+      node-version:
+        description: "Matrix of Node.js versions"
+        value: ${{ jobs.build_matrix.outputs.node-version }}
+
+jobs:
+  build_matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - id: set_matrix
+        # update node-version with versions of node that will be run by the workflow
+        run: echo "node-version=[18,20]" >> $GITHUB_OUTPUT
+    outputs:
+      node-version: ${{ steps.set_matrix.outputs.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,15 @@ on:
   pull_request:
 
 jobs:
+  build-nodejs-matrix:
+    uses: ./.github/workflows/build-nodejs-matrix.yml
   test:
-    name: Run tests
+    name: Run tests (Node.js v${{ matrix.node-version }})
+    needs: build-nodejs-matrix
     runs-on: depot-ubuntu-22.04-16
+    strategy:
+      matrix:
+        node-version: ${{ fromJson(needs.build-nodejs-matrix.outputs.node-version) }}
     services:
       postgres:
         image: postgres:12.1-alpine
@@ -35,6 +41,8 @@ jobs:
       - name: Setup
         if: steps.check_changes.outputs.changes_outside_docs
         uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Build
         if: steps.check_changes.outputs.changes_outside_docs


### PR DESCRIPTION
This PR adds the ability to use different node.js versions when running workflows.
It leverages github actions' matrices that allow for running a same workflow with a different set of "inputs", in this case a different version of node.js.

I only added this new feature to the "test" workflow for now but I'll be happy to update the other workflows once this approach has been validated ;)

I have not been able to add Node.js 22, it looks like there's an error during the compilation of the "better-sqlite3" package that needs some investigation.

Closes #2466