### PR TITLE
feat(cli): mud decode-error command

### DIFF
--- a/packages/cli/src/commands/decode-error.ts
+++ b/packages/cli/src/commands/decode-error.ts
@@ -1,0 +1,91 @@
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import type { CommandModule } from "yargs";
+import chalk from "chalk";
+import { Abi, BaseError, decodeErrorResult, Hex, isHex } from "viem";
+import { formatAbiItemWithArgs } from "viem/utils";
+import { loadConfig, resolveConfigPath } from "@latticexyz/config/node";
+import { getOutDirectory } from "@latticexyz/common/foundry";
+import { World as WorldConfig } from "@latticexyz/world";
+import { MUDError } from "@latticexyz/common/errors";
+import IBaseWorldAbi from "@latticexyz/world/out/IBaseWorld.sol/IBaseWorld.abi.json" assert { type: "json" };
+import { logError } from "../utils/errors";
+
+type Options = {
+  error: string;
+  configPath?: string;
+  profile?: string;
+};
+
+const commandModule: CommandModule<Options, Options> = {
+  command: "decode-error",
+
+  describe: "Decode an error in HEX format into a human-readable error",
+
+  builder(yargs) {
+    return yargs.options({
+      error: { type: "string", required: true, desc: "An error in HEX format" },
+      configPath: { type: "string", desc: "Path to the MUD config file" },
+      profile: { type: "string", desc: "The foundry profile to use" },
+    });
+  },
+
+  async handler(opts) {
+    try {
+      if (!isHex(opts.error)) {
+        throw new MUDError('Argument "error" must be in HEX format');
+      }
+
+      let IWorldAbi: Abi;
+      try {
+        // first try to use the user ABI located in the MUD project
+        const profile = opts.profile ?? process.env.FOUNDRY_PROFILE;
+
+        const configPath = await resolveConfigPath(opts.configPath);
+        const config = (await loadConfig(configPath)) as WorldConfig;
+        const rootDir = path.dirname(configPath);
+
+        const outDir = await getOutDirectory(profile);
+
+        const IWorldAbiPath = path.join(
+          rootDir,
+          outDir,
+          `${config.codegen.worldInterfaceName}.sol`,
+          `${config.codegen.worldInterfaceName}.abi.json`,
+        );
+
+        IWorldAbi = JSON.parse(readFileSync(IWorldAbiPath, "utf8"));
+      } catch (error) {
+        // catch and log error and warn user that we'll be using MUD's IBaseWorld ABI
+        console.log(error);
+        console.log(chalk.yellow("Could not find user ABI, using MUD's IBaseWorld ABI instead"));
+        IWorldAbi = IBaseWorldAbi;
+      }
+
+      const { abiItem, args: errorArgs } = decodeErrorResult({
+        abi: IWorldAbi,
+        data: opts.error as Hex,
+      });
+
+      const formattedError = formatAbiItemWithArgs({
+        abiItem,
+        args: errorArgs ?? [],
+        includeName: true,
+      });
+
+      console.log(chalk.green(`Decoded error: ${formattedError}`));
+    } catch (error) {
+      // process viem error to extract the error message
+      if (error instanceof BaseError) {
+        logError(chalk.red((error as BaseError).shortMessage));
+      } else {
+        logError(error);
+      }
+      process.exit(1);
+    }
+
+    process.exit(0);
+  },
+};
+
+export default commandModule;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -14,6 +14,7 @@ import test from "./test";
 import trace from "./trace";
 import devContracts from "./dev-contracts";
 import verify from "./verify";
+import decodeError from "./decode-error";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Each command has different options
 export const commands: CommandModule<any, any>[] = [
@@ -30,4 +31,5 @@ export const commands: CommandModule<any, any>[] = [
   devContracts,
   abiTs,
   verify,
+  decodeError,
 ];


### PR DESCRIPTION
This PR adds a `decode-error` command to the MUD cli.

The arguments for this new command are as follow:

- `error`: required `string` representing the error in HEX format
- `configPath`: an optional `string` representing a path to a MUD config file
- `profile`:  an optional `string` representing a Foundry profile to use

This new command will try to find a user `IWorldAbi` by leveraging a MUD config file. If no user `IWorldAbi` file is found, the command will fallback to the `IBaseWorld` ABI to try to decode the error.

Example of `decode-error` runs:
```sh
# decode an error using MUD's provided ABI
mud decode-error --error 0x15e34a49

(node:204616) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Error: Did not find a `mud.config.ts` file. Are you inside a MUD project?
    at d (file:///home/work/Documents/dev/other/mud/packages/config/dist/deprecated/node.js:1:702)
    at async t (file:///home/work/Documents/dev/other/mud/packages/config/dist/deprecated/node.js:1:536)
    at async Object.handler (file:///home/work/Documents/dev/other/mud/packages/cli/dist/commands-KRB5RRPE.js:38:1344)
Could not find user ABI, using MUD's IBaseWorld ABI instead
Decoded error: World_AlreadyInitialized()
```

```ssh
# decode an error that leverages a user ABI
# [
#  {
#    "inputs": [
#      {
#        "name": "a",
#        "type": "string"
#      }
#    ],
#    "name": "AccessDeniedError",
#    "type": "error"
#  },
# ...
# ]
#
mud decode-error --error 0x83aa206e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a796f7520646f206e6f7420686176652061636365737320736572000000000000

(node:205151) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Decoded error: AccessDeniedError(a: you do not have access ser)
```

Closes #2788 