### PR TITLE
fix(store,world): codegen on Windows

### DIFF
--- a/packages/store/ts/codegen/renderTableIndex.ts
+++ b/packages/store/ts/codegen/renderTableIndex.ts
@@ -1,6 +1,6 @@
 import { renderImportPath, renderList, renderedSolidityHeader } from "@latticexyz/common/codegen";
 import { TableOptions } from "./getTableOptions";
-import path from "node:path/posix";
+import path from "node:path";
 
 /**
  * Returns Solidity code for table index file that imports all codegen tables

--- a/packages/world/ts/node/findSolidityFiles.ts
+++ b/packages/world/ts/node/findSolidityFiles.ts
@@ -3,7 +3,7 @@ import { glob } from "glob";
 
 // TODO: move to common codegen?
 export async function findSolidityFiles({ cwd, pattern = "**" }: { cwd?: string; pattern: string }) {
-  const files = await glob(path.join(pattern, "*.sol"), { cwd });
+  const files = await glob(path.join(pattern, "*.sol"), { cwd, windowsPathsNoEscape: true });
   return files.sort().map((filename) => ({
     filename,
     basename: path.basename(filename, ".sol"),


### PR DESCRIPTION
I saw that there is an issue with codegen on Windows and found 2 problems that are causing it:

- in the `renderTableIndex.ts` file, `node:path/posix` was imported, but using the posix implementation interfered with the ` path.relative` call on Windows, which resulted in an invalid `relative` path (it would return the full path to the table file instead of the relative path to the index file)

- another issue I found is with the `findSolidityFiles` function. It uses the `glob` package in order to find the solidity files using a `pattern`, however, this `pattern` is generated using the `path` node module, which on Windows returns an "escaped" pattern (Windows paths have backslashes which are actually considered escaped characters in the `pattern` used by `glob`). Looking at the `glob` documentation, I found that this problem can be fixed using the `windowsPathsNoEscape: true` option.

Using these 2 fixes I was able to generate the code and also run the tests locally. 