### PR TITLE
fix: changeset minor version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -60,12 +60,12 @@
     "vitest": "0.34.6"
   },
   "peerDependencies": {
-    "@latticexyz/common": "2.0.12",
-    "@latticexyz/recs": "2.0.12",
-    "@latticexyz/store": "2.0.12",
-    "@latticexyz/store-sync": "2.0.12",
-    "@latticexyz/utils": "2.0.12",
-    "@latticexyz/world": "2.0.12"
+    "@latticexyz/common": "2.x",
+    "@latticexyz/recs": "2.x",
+    "@latticexyz/store": "2.x",
+    "@latticexyz/store-sync": "2.x",
+    "@latticexyz/utils": "2.x",
+    "@latticexyz/world": "2.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
closes #2977 

looks like changeset has some weird logic for resolving peer dependencies: https://github.com/changesets/changesets/issues/1279

we can work around this by:
- enabling experimental peer dep flag in changeset
- specifying a wider version range for workspace peer deps
