### PR TITLE
docs: update resource labels changeset

### DIFF
--- a/.changeset/orange-dancers-nail.md
+++ b/.changeset/orange-dancers-nail.md
@@ -6,7 +6,7 @@
 
 Tables and systems in config output now include a `label` property. Labels are now used throughout the codebase as a user-friendly way to reference the given resource: config keys, contract names, generated libraries, etc.
 
-We'll no longer transform config keys for tables and systems and their filenames will always correspond to their labels. This should make MUD tooling more intuitive and predictable.
+Inside `namespaces` config output, keys for tables and systems and their filenames will always correspond to their labels. This should make MUD tooling more intuitive and predictable. For backwards compatibility, `tables` config output still uses namespace-prefixed keys.
 
 Labels replace the previous resource `name` usage, which is truncated to `bytes16` to be used as part of the resource ID and, in the future, may not always be human-readable.
 


### PR DESCRIPTION
clarified how we're using resource labels (originally landed in https://github.com/latticexyz/mud/pull/2953) when it comes to top-level config output keys