### PR TITLE
test: improve type benches with baseline + .ts files, avoiding build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "sort-package-json": "npx sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json' 'test/*/package.json'",
     "test": "pnpm run --recursive test",
     "test:ci": "pnpm run --recursive --parallel test:ci",
+    "type-bench": "pnpm --filter ./test/ts-benchmarks bench",
     "type-stats-repo": "attest stats packages/*"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "package.json": "pnpm sort-package-json"
   },
   "devDependencies": {
-    "@arktype/attest": "0.7.5",
+    "@ark/attest": "0.10.2",
     "@changesets/cli": "^2.27.7",
     "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": "7.1.1",
@@ -56,9 +56,9 @@
     "turbo": "^1.9.3",
     "typescript": "5.4.2"
   },
-  "packageManager": "pnpm@9.1.1",
+  "packageManager": "pnpm@9.6.0",
   "engines": {
     "node": "^18.20.1",
-    "pnpm": "^9.1.1"
+    "pnpm": "^9.6.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,7 +40,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.40",
+    "@ark/util": "catalog:",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/schema-type": "workspace:*",
     "esbuild": "^0.17.15",

--- a/packages/config/src/common.ts
+++ b/packages/config/src/common.ts
@@ -1,7 +1,7 @@
 import { Hex } from "viem";
 import { DynamicAbiType, StaticAbiType } from "@latticexyz/schema-type/internal";
 import { ResourceType } from "@latticexyz/common";
-import { satisfy } from "@arktype/util";
+import { satisfy } from "@ark/util";
 
 /**
  * Common output types of a MUD config. We use these types as inputs for libraries.

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -34,7 +34,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.40",
+    "@ark/util": "catalog:",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/schema-type": "workspace:*",

--- a/packages/query/src/api.ts
+++ b/packages/query/src/api.ts
@@ -1,5 +1,5 @@
 import { Hex } from "viem";
-import { satisfy } from "@arktype/util";
+import { satisfy } from "@ark/util";
 import { StaticPrimitiveType, DynamicPrimitiveType, SchemaAbiType } from "@latticexyz/schema-type/internal";
 import { SchemaToPrimitives } from "@latticexyz/store/internal";
 import { Table } from "@latticexyz/config";

--- a/packages/store-sync/package.json
+++ b/packages/store-sync/package.json
@@ -62,7 +62,7 @@
     "test:ci": "vitest --run"
   },
   "dependencies": {
-    "@arktype/util": "0.1.0",
+    "@ark/util": "catalog:",
     "@latticexyz/block-logs-stream": "workspace:*",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",

--- a/packages/store-sync/src/common.test.ts
+++ b/packages/store-sync/src/common.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import { attest } from "@arktype/attest";
-import { isDisjoint } from "@arktype/util";
+import { attest } from "@ark/attest";
+import { isDisjoint } from "@ark/util";
 import storeConfig from "@latticexyz/store/mud.config";
 import worldConfig from "@latticexyz/world/mud.config";
 import { configToTables } from "./configToTables";

--- a/packages/store-sync/src/configToTables.test.ts
+++ b/packages/store-sync/src/configToTables.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import { configToTables } from "./configToTables";
 import { defineWorld } from "@latticexyz/world";
 import { resourceToHex } from "@latticexyz/common";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 
 describe("configToTables", () => {
   it("flattens tables from single namespace", async () => {

--- a/packages/store-sync/src/configToTables.ts
+++ b/packages/store-sync/src/configToTables.ts
@@ -1,4 +1,4 @@
-import { show } from "@arktype/util";
+import { show } from "@ark/util";
 import { Store } from "@latticexyz/store";
 
 type flattenedTableKeys<config extends Store> = config extends { readonly namespaces: infer namespaces }

--- a/packages/store-sync/src/recs/createStorageAdapter.ts
+++ b/packages/store-sync/src/recs/createStorageAdapter.ts
@@ -12,7 +12,7 @@ import { hexKeyTupleToEntity } from "./hexKeyTupleToEntity";
 import { StorageAdapter, StorageAdapterBlock } from "../common";
 import { singletonEntity } from "./singletonEntity";
 import { tablesToComponents } from "./tablesToComponents";
-import { merge } from "@arktype/util";
+import { merge } from "@ark/util";
 
 export type CreateStorageAdapterOptions<tables extends Tables> = {
   world: RecsWorld;

--- a/packages/store-sync/src/recs/syncToRecs.ts
+++ b/packages/store-sync/src/recs/syncToRecs.ts
@@ -7,7 +7,7 @@ import { createStoreSync } from "../createStoreSync";
 import { singletonEntity } from "./singletonEntity";
 import { SyncStep } from "../SyncStep";
 import { configToTables } from "../configToTables";
-import { merge } from "@arktype/util";
+import { merge } from "@ark/util";
 
 export type SyncToRecsOptions<config extends StoreConfig, extraTables extends Tables> = Omit<SyncOptions, "config"> & {
   world: RecsWorld;

--- a/packages/store-sync/src/recs/syncToRecs.ts
+++ b/packages/store-sync/src/recs/syncToRecs.ts
@@ -9,7 +9,10 @@ import { SyncStep } from "../SyncStep";
 import { configToTables } from "../configToTables";
 import { merge } from "@ark/util";
 
-export type SyncToRecsOptions<config extends StoreConfig, extraTables extends Tables> = Omit<SyncOptions, "config"> & {
+export type SyncToRecsOptions<config extends StoreConfig = StoreConfig, extraTables extends Tables = Tables> = Omit<
+  SyncOptions,
+  "config"
+> & {
   world: RecsWorld;
   config: config;
   tables?: extraTables;

--- a/packages/store-sync/src/recs/tablesToComponents.ts
+++ b/packages/store-sync/src/recs/tablesToComponents.ts
@@ -1,7 +1,7 @@
 import { Tables } from "@latticexyz/config";
 import { tableToComponent } from "./tableToComponent";
 import { World } from "@latticexyz/recs";
-import { show } from "@arktype/util";
+import { show } from "@ark/util";
 
 export type tablesToComponents<tables extends Tables> = {
   [label in keyof tables as tables[label]["label"]]: tableToComponent<tables[label]>;

--- a/packages/store-sync/src/zustand/syncToZustand.ts
+++ b/packages/store-sync/src/zustand/syncToZustand.ts
@@ -7,7 +7,7 @@ import { Address } from "viem";
 import { SyncStep } from "../SyncStep";
 import { Store as StoreConfig } from "@latticexyz/store";
 import { Tables } from "@latticexyz/config";
-import { merge } from "@arktype/util";
+import { merge } from "@ark/util";
 import { configToTables } from "../configToTables";
 
 export type SyncToZustandOptions<config extends StoreConfig, extraTables extends Tables> = Omit<

--- a/packages/store-sync/vitestSetup.ts
+++ b/packages/store-sync/vitestSetup.ts
@@ -1,1 +1,1 @@
-export { setup, cleanup as teardown } from "@arktype/attest";
+export { setup, cleanup as teardown } from "@ark/attest";

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -59,7 +59,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.40",
+    "@ark/util": "catalog:",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/protocol-parser": "workspace:*",
@@ -69,7 +69,6 @@
     "viem": "2.9.20"
   },
   "devDependencies": {
-    "@arktype/attest": "0.7.5",
     "@latticexyz/abi-ts": "workspace:*",
     "@latticexyz/gas-report": "workspace:*",
     "@types/ejs": "^3.1.1",

--- a/packages/store/ts/config/v2/enums.ts
+++ b/packages/store/ts/config/v2/enums.ts
@@ -1,4 +1,4 @@
-import { flatMorph } from "@arktype/util";
+import { flatMorph } from "@ark/util";
 import { EnumsInput } from "./input";
 import { AbiTypeScope, extendScope } from "./scope";
 import { parseNumber } from "./generics";

--- a/packages/store/ts/config/v2/flattenNamespacedTables.ts
+++ b/packages/store/ts/config/v2/flattenNamespacedTables.ts
@@ -1,4 +1,4 @@
-import { show } from "@arktype/util";
+import { show } from "@ark/util";
 import { Namespaces } from "./output";
 
 type flattenNamespacedTableKeys<config> = config extends {

--- a/packages/store/ts/config/v2/namespace.ts
+++ b/packages/store/ts/config/v2/namespace.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, flatMorph } from "@arktype/util";
+import { ErrorMessage, flatMorph } from "@ark/util";
 import { hasOwnKey, mergeIfUndefined } from "./generics";
 import { NamespaceInput } from "./input";
 import { resolveTables, validateTables } from "./tables";

--- a/packages/store/ts/config/v2/namespaces.test.ts
+++ b/packages/store/ts/config/v2/namespaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { defineNamespaces } from "./namespaces";
 
 describe("defineNamespaces", () => {

--- a/packages/store/ts/config/v2/namespaces.ts
+++ b/packages/store/ts/config/v2/namespaces.ts
@@ -1,4 +1,4 @@
-import { show, flatMorph } from "@arktype/util";
+import { show, flatMorph } from "@ark/util";
 import { isObject, mergeIfUndefined } from "./generics";
 import { NamespacesInput } from "./input";
 import { AbiTypeScope, Scope } from "./scope";

--- a/packages/store/ts/config/v2/output.ts
+++ b/packages/store/ts/config/v2/output.ts
@@ -1,4 +1,4 @@
-import { show } from "@arktype/util";
+import { show } from "@ark/util";
 import { AbiType, Schema, Table as BaseTable } from "@latticexyz/config";
 import { EnumsInput } from "./input";
 

--- a/packages/store/ts/config/v2/schema.test.ts
+++ b/packages/store/ts/config/v2/schema.test.ts
@@ -19,11 +19,16 @@ describe("resolveSchema", () => {
       },
     } as const;
 
-    attest<typeof expected>(resolved)
-      .equals(expected)
-      .type.toString.snap(
-        '{ readonly regular: { readonly type: "uint256"; readonly internalType: "uint256"; }; readonly user: { readonly type: "address"; readonly internalType: "CustomType"; }; }',
-      );
+    attest<typeof expected>(resolved).equals(expected).type.toString.snap(`{
+	readonly regular: {
+		readonly type: "uint256"
+		readonly internalType: "uint256"
+	}
+	readonly user: {
+		readonly type: "address"
+		readonly internalType: "CustomType"
+	}
+}`);
   });
 
   it("should throw if a type is not part of the scope", () => {
@@ -57,8 +62,11 @@ describe("resolveSchema", () => {
       },
     } as const;
 
-    attest<typeof expected>(resolved)
-      .equals(expected)
-      .type.toString.snap('{ readonly coordinate: { readonly type: "int32[]"; readonly internalType: "int32[2]"; }; }');
+    attest<typeof expected>(resolved).equals(expected).type.toString.snap(`{
+	readonly coordinate: {
+		readonly type: "int32[]"
+		readonly internalType: "int32[2]"
+	}
+}`);
   });
 });

--- a/packages/store/ts/config/v2/schema.test.ts
+++ b/packages/store/ts/config/v2/schema.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import { defineSchema } from "./schema";
 import { Schema } from "./output";
 import { extendScope, AbiTypeScope } from "./scope";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 
 describe("resolveSchema", () => {
   it("should map user types to their primitive type", () => {

--- a/packages/store/ts/config/v2/schema.ts
+++ b/packages/store/ts/config/v2/schema.ts
@@ -1,4 +1,4 @@
-import { conform, show } from "@arktype/util";
+import { conform, show } from "@ark/util";
 import { AbiTypeScope, Scope } from "./scope";
 import { hasOwnKey, isObject } from "./generics";
 import { SchemaInput } from "./input";

--- a/packages/store/ts/config/v2/scope.test.ts
+++ b/packages/store/ts/config/v2/scope.test.ts
@@ -1,4 +1,4 @@
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { describe, it } from "vitest";
 import { AbiTypeScope, Scope, ScopeOptions, extendScope, getStaticAbiTypeKeys } from "./scope";
 

--- a/packages/store/ts/config/v2/scope.test.ts
+++ b/packages/store/ts/config/v2/scope.test.ts
@@ -6,15 +6,20 @@ describe("extendScope", () => {
   it("should extend the provided scope", () => {
     const extendedScope = extendScope(Scope, { static: "uint256", dynamic: "string" });
     attest<ScopeOptions<{ static: "uint256"; dynamic: "string" }>>(extendedScope).type.toString.snap(
-      '{ types: { static: "uint256"; dynamic: "string"; }; }',
+      '{ types: { static: "uint256"; dynamic: "string" } }',
     );
 
     const furtherExtendedScope = extendScope(extendedScope, { static2: "uint256", dynamic2: "string" });
     attest<ScopeOptions<{ static: "uint256"; dynamic: "string"; static2: "uint256"; dynamic2: "string" }>>(
       furtherExtendedScope,
-    ).type.toString.snap(
-      '{ types: { static: "uint256"; dynamic: "string"; static2: "uint256"; dynamic2: "string"; }; }',
-    );
+    ).type.toString.snap(`{
+	types: {
+		static: "uint256"
+		dynamic: "string"
+		static2: "uint256"
+		dynamic2: "string"
+	}
+}`);
   });
 });
 

--- a/packages/store/ts/config/v2/scope.ts
+++ b/packages/store/ts/config/v2/scope.ts
@@ -1,4 +1,4 @@
-import { Dict, show } from "@arktype/util";
+import { Dict, show } from "@ark/util";
 import { SchemaInput } from "./input";
 import { StaticAbiType, schemaAbiTypes } from "@latticexyz/schema-type/internal";
 import { AbiType } from "./output";

--- a/packages/store/ts/config/v2/store.test.ts
+++ b/packages/store/ts/config/v2/store.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from "vitest";
 import { defineStore } from "./store";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { resourceToHex } from "@latticexyz/common";
 import { Store } from "./output";
-import { satisfy } from "@arktype/util";
+import { satisfy } from "@ark/util";
 import { Hex } from "viem";
 
 describe("defineStore", () => {

--- a/packages/store/ts/config/v2/store.ts
+++ b/packages/store/ts/config/v2/store.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, show, narrow } from "@arktype/util";
+import { ErrorMessage, show, narrow } from "@ark/util";
 import { get, hasOwnKey } from "./generics";
 import { UserTypes } from "./output";
 import { CONFIG_DEFAULTS } from "./defaults";

--- a/packages/store/ts/config/v2/table.test.ts
+++ b/packages/store/ts/config/v2/table.test.ts
@@ -1,4 +1,4 @@
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { describe, it } from "vitest";
 import { getStaticAbiTypeKeys, AbiTypeScope, extendScope } from "./scope";
 import { validateKeys, defineTable } from "./table";

--- a/packages/store/ts/config/v2/table.ts
+++ b/packages/store/ts/config/v2/table.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, conform, show, narrow, requiredKeyOf } from "@arktype/util";
+import { ErrorMessage, conform, show, narrow, requiredKeyOf } from "@ark/util";
 import { isStaticAbiType } from "@latticexyz/schema-type/internal";
 import { Hex } from "viem";
 import { get, hasOwnKey, mergeIfUndefined } from "./generics";

--- a/packages/store/ts/config/v2/tableShorthand.test.ts
+++ b/packages/store/ts/config/v2/tableShorthand.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { AbiTypeScope, extendScope } from "./scope";
 import { NoStaticKeyFieldError, defineTableShorthand } from "./tableShorthand";
 

--- a/packages/store/ts/config/v2/tableShorthand.ts
+++ b/packages/store/ts/config/v2/tableShorthand.ts
@@ -3,7 +3,7 @@ import { hasOwnKey, isObject } from "./generics";
 import { SchemaInput, ScopedSchemaInput, TableShorthandInput } from "./input";
 import { isSchemaInput } from "./schema";
 import { AbiTypeScope, Scope, getStaticAbiTypeKeys } from "./scope";
-import { ErrorMessage, conform } from "@arktype/util";
+import { ErrorMessage, conform } from "@ark/util";
 
 export const NoStaticKeyFieldError =
   "Invalid schema. Expected an `id` field with a static ABI type or an explicit `key` option.";

--- a/packages/store/ts/config/v2/tables.test.ts
+++ b/packages/store/ts/config/v2/tables.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { AbiTypeScope, extendScope } from "./scope";
 import { defineTables, validateTables } from "./tables";
 

--- a/packages/store/ts/config/v2/tables.ts
+++ b/packages/store/ts/config/v2/tables.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, show } from "@arktype/util";
+import { ErrorMessage, show } from "@ark/util";
 import { isObject, mergeIfUndefined } from "./generics";
 import { TableShorthandInput, TablesInput } from "./input";
 import { Scope, AbiTypeScope } from "./scope";

--- a/packages/store/vitestSetup.ts
+++ b/packages/store/vitestSetup.ts
@@ -1,1 +1,1 @@
-export { setup, cleanup as teardown } from "@arktype/attest";
+export { setup, cleanup as teardown } from "@ark/attest";

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -59,7 +59,7 @@
     "test:ci": "pnpm run test"
   },
   "dependencies": {
-    "@arktype/util": "0.0.40",
+    "@ark/util": "catalog:",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/protocol-parser": "workspace:*",
@@ -70,7 +70,6 @@
     "viem": "2.9.20"
   },
   "devDependencies": {
-    "@arktype/attest": "0.7.5",
     "@latticexyz/abi-ts": "workspace:*",
     "@latticexyz/gas-report": "workspace:*",
     "@types/ejs": "^3.1.1",

--- a/packages/world/ts/config/v2/namespaces.ts
+++ b/packages/world/ts/config/v2/namespaces.ts
@@ -1,4 +1,4 @@
-import { show, flatMorph } from "@arktype/util";
+import { show, flatMorph } from "@ark/util";
 import { NamespacesInput } from "./input";
 import { validateNamespace, resolveNamespace } from "./namespace";
 import { groupBy } from "@latticexyz/common/utils";

--- a/packages/world/ts/config/v2/system.test.ts
+++ b/packages/world/ts/config/v2/system.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { resourceToHex } from "@latticexyz/common";
 import { defineSystem } from "./system";
 import { SYSTEM_DEFAULTS } from "./defaults";

--- a/packages/world/ts/config/v2/system.ts
+++ b/packages/world/ts/config/v2/system.ts
@@ -1,7 +1,7 @@
 import { SYSTEM_DEFAULTS } from "./defaults";
 import { SystemInput } from "./input";
 import { hasOwnKey, mergeIfUndefined } from "@latticexyz/store/config/v2";
-import { ErrorMessage, narrow, requiredKeyOf } from "@arktype/util";
+import { ErrorMessage, narrow, requiredKeyOf } from "@ark/util";
 import { Hex } from "viem";
 import { resourceToHex } from "@latticexyz/common";
 

--- a/packages/world/ts/config/v2/systems.ts
+++ b/packages/world/ts/config/v2/systems.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage } from "@arktype/util";
+import { ErrorMessage } from "@ark/util";
 import { isObject } from "@latticexyz/store/config/v2";
 import { SystemsInput } from "./input";
 import { resolveSystem, validateSystem } from "./system";

--- a/packages/world/ts/config/v2/world.test.ts
+++ b/packages/world/ts/config/v2/world.test.ts
@@ -1,9 +1,9 @@
 import { describe, it } from "vitest";
 import { defineWorld } from "./world";
-import { attest } from "@arktype/attest";
+import { attest } from "@ark/attest";
 import { resourceToHex } from "@latticexyz/common";
 import { World } from "./output";
-import { satisfy } from "@arktype/util";
+import { satisfy } from "@ark/util";
 import { Hex } from "viem";
 
 describe("defineWorld", () => {

--- a/packages/world/ts/config/v2/world.ts
+++ b/packages/world/ts/config/v2/world.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage, conform, type withJsDoc } from "@arktype/util";
+import { ErrorMessage, conform, type withJsDoc } from "@ark/util";
 import {
   extendedScope,
   get,

--- a/packages/world/vitestSetup.ts
+++ b/packages/world/vitestSetup.ts
@@ -1,1 +1,1 @@
-export { setup, cleanup as teardown } from "@arktype/attest";
+export { setup, cleanup as teardown } from "@ark/attest";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,19 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@ark/util':
+      specifier: 0.1.2
+      version: 0.1.2
+
 importers:
 
   .:
     devDependencies:
-      '@arktype/attest':
-        specifier: 0.7.5
-        version: 0.7.5(typescript@5.4.2)
+      '@ark/attest':
+        specifier: 0.10.2
+        version: 0.10.2(typescript@5.4.2)
       '@changesets/cli':
         specifier: ^2.27.7
         version: 2.27.7
@@ -312,9 +318,9 @@ importers:
 
   packages/config:
     dependencies:
-      '@arktype/util':
-        specifier: 0.0.40
-        version: 0.0.40
+      '@ark/util':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -543,9 +549,9 @@ importers:
 
   packages/query:
     dependencies:
-      '@arktype/util':
-        specifier: 0.0.40
-        version: 0.0.40
+      '@ark/util':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -598,7 +604,7 @@ importers:
         version: 18.2.22
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.0.0(vite@4.3.6(@types/node@18.15.11))
+        version: 4.0.0(vite@4.3.6(@types/node@20.12.12))
       eslint-plugin-react:
         specifier: 7.31.11
         version: 7.31.11(eslint@8.57.0)
@@ -616,7 +622,7 @@ importers:
         version: 6.7.0(postcss@8.4.23)(typescript@5.4.2)
       vite:
         specifier: ^4.3.6
-        version: 4.3.6(@types/node@18.15.11)
+        version: 4.3.6(@types/node@20.12.12)
       vitest:
         specifier: 0.34.6
         version: 0.34.6(jsdom@22.1.0)
@@ -647,7 +653,7 @@ importers:
         version: 29.5.0(@types/node@18.15.11)
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(esbuild@0.17.17)(jest@29.5.0(@types/node@18.15.11))(typescript@5.4.2)
+        version: 29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(jest@29.5.0(@types/node@18.15.11))(typescript@5.4.2)
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.23)(typescript@5.4.2)
@@ -701,9 +707,9 @@ importers:
 
   packages/store:
     dependencies:
-      '@arktype/util':
-        specifier: 0.0.40
-        version: 0.0.40
+      '@ark/util':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -726,9 +732,6 @@ importers:
         specifier: 2.9.20
         version: 2.9.20(typescript@5.4.2)(zod@3.23.7)
     devDependencies:
-      '@arktype/attest':
-        specifier: 0.7.5
-        version: 0.7.5(typescript@5.4.2)
       '@latticexyz/abi-ts':
         specifier: workspace:*
         version: link:../abi-ts
@@ -880,9 +883,9 @@ importers:
 
   packages/store-sync:
     dependencies:
-      '@arktype/util':
-        specifier: 0.1.0
-        version: 0.1.0
+      '@ark/util':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@latticexyz/block-logs-stream':
         specifier: workspace:*
         version: link:../block-logs-stream
@@ -992,19 +995,19 @@ importers:
         version: 27.4.1
       jest:
         specifier: ^29.3.1
-        version: 29.5.0(@types/node@18.15.11)
+        version: 29.5.0(@types/node@20.12.12)
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(esbuild@0.17.17)(jest@29.5.0(@types/node@18.15.11))(typescript@5.4.2)
+        version: 29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(jest@29.5.0(@types/node@20.12.12))(typescript@5.4.2)
       tsup:
         specifier: ^6.7.0
         version: 6.7.0(postcss@8.4.23)(typescript@5.4.2)
 
   packages/world:
     dependencies:
-      '@arktype/util':
-        specifier: 0.0.40
-        version: 0.0.40
+      '@ark/util':
+        specifier: 'catalog:'
+        version: 0.1.2
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -1030,9 +1033,6 @@ importers:
         specifier: 2.9.20
         version: 2.9.20(typescript@5.4.2)(zod@3.23.7)
     devDependencies:
-      '@arktype/attest':
-        specifier: 0.7.5
-        version: 0.7.5(typescript@5.4.2)
       '@latticexyz/abi-ts':
         specifier: workspace:*
         version: link:../abi-ts
@@ -1199,29 +1199,20 @@ packages:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
 
-  '@arktype/attest@0.7.5':
-    resolution: {integrity: sha512-ZOF9uqLbvoVO6RHhlByJEBBj5qhWLpaCK/wWa5guD1OQR1/a7JZ9jCrDAcaASt6tYBA3dGhDerXhc7FcDWlRQw==}
+  '@ark/attest@0.10.2':
+    resolution: {integrity: sha512-GLsLvxVFhgNx6JlCkhriKQW+XQFxGuOEH4SQNekLkmz1VLvdhy6fwOPWjXQlFiSUjFsF2DX4jOgBsxQs65n3xA==}
     hasBin: true
     peerDependencies:
       typescript: '*'
 
-  '@arktype/fs@0.0.19':
-    resolution: {integrity: sha512-ZEiSc6DgJANSgMTee9lueumCH/3gIikJWT8wlN8CyVk/IDFKFbJb3/BHj906Aw+APvCc8oyvu+2Hanshkgh4Bg==}
+  '@ark/fs@0.1.2':
+    resolution: {integrity: sha512-u0clA/Ka4fxianc31di2B44FKBMJ4+jFzq8I7cmYb+gCTanmyQxcJ5SmHwxK+vcWObGr75T5TxQd2ozIENQAHw==}
 
-  '@arktype/schema@0.1.2':
-    resolution: {integrity: sha512-ggvxs5P0toqd/4/XK76URQrtyOYpbYcLhirEZeTso6FxkloPa0lT+whPg7DNQj5qi2OQXLUHBYKMx9DOb13ViQ==}
+  '@ark/schema@0.2.2':
+    resolution: {integrity: sha512-3GyWVptFzmUZTBAwobiuk2Xa1wXeWNOOaHWcYl3pYTTdl5QNuB/53JnHXL0NrFW4Yvv7cgTcRsZQby7pNAeeJA==}
 
-  '@arktype/util@0.0.38':
-    resolution: {integrity: sha512-IvYMGnkUASJllRk3mdBVgckomKx2LNsDTrWCxz04EBK1OuU+4fJ/smSjxgZVWfopNXZds9sHNxZgTJOIw7GvJw==}
-
-  '@arktype/util@0.0.40':
-    resolution: {integrity: sha512-dwC3xZh9Bz6LWSJq71AUoh06zB0qM65N4zS/NNogbumhbO55yot7yqDlv0qeBMNOWXj/gX7l7l58v0EqEaXN2w==}
-
-  '@arktype/util@0.0.41':
-    resolution: {integrity: sha512-0YURzJ42v+lhlP1t5Dj90YezETRTCdFU0oM4xMVpYsmPx/DHJzr9n7AX1QPAlYWH4wY7hYY3gwai3O+8VntPgw==}
-
-  '@arktype/util@0.1.0':
-    resolution: {integrity: sha512-t5jCNbspCF/XizGfmM5fn+86IMtQgCB2Px3Y1E8ckm5AjTECyI7Aj5pV6e9iL8qXF9FdKA53FBLRzAZUqYBnCw==}
+  '@ark/util@0.1.2':
+    resolution: {integrity: sha512-JhcPZhF8T8Eb9UxJqh3X8tOwZpnuW89azKlPnRhFXymhy/wBFPRC9+J+Vu+iUc/kplW3uloZb9n5R3EVVWUBgw==}
 
   '@aws-crypto/ie11-detection@3.0.0':
     resolution: {integrity: sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==}
@@ -2223,6 +2214,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@prettier/sync@0.5.2':
+    resolution: {integrity: sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==}
+    peerDependencies:
+      prettier: '*'
+
   '@remix-run/router@1.6.0':
     resolution: {integrity: sha512-N13NRw3T2+6Xi9J//3CGLsK2OqC8NMme3d/YX+nh05K9YHWGcv8DycHJrqGScSP4T75o8IN6nqIMhVFU8ohg8w==}
     engines: {node: '>=14'}
@@ -2720,8 +2716,10 @@ packages:
     resolution: {integrity: sha512-RnlSOPh14QbopGCApgkSx5UBgGda5MX1cHqp2fsqfiDyCwGL/m1jaeB9fzu7didVS81LQqGZZuxFBcg8YU8EVw==}
     hasBin: true
 
-  '@typescript/vfs@1.5.0':
-    resolution: {integrity: sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==}
+  '@typescript/vfs@1.5.3':
+    resolution: {integrity: sha512-OSZ/o3wwD5VPZVdGGsXWk7sRGRtwrGnqA4zwmb33FTs7Wxmad0QTkQCbaNyqWA8hL09TCwAthdp8yjFA5G1lvw==}
+    peerDependencies:
+      typescript: '*'
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -2934,8 +2932,8 @@ packages:
   arktype@1.0.29-alpha:
     resolution: {integrity: sha512-glMLgVhIQRSkR3tymiS+POAcWVJH09sfrgic0jHnyFL8BlhHAJZX2BzdImU9zYr1y9NBqy+U93ZNrRTHXsKRDw==}
 
-  arktype@2.0.0-dev.11:
-    resolution: {integrity: sha512-k+WVQoHsHsTyTiVQkO201mxLQxyXHmy3buJW8TXLOkr4X2yOUCp0K1SBscuG9OEJoc8MjpvoIharjPHEkFI7kg==}
+  arktype@2.0.0-beta.2:
+    resolution: {integrity: sha512-WLxtViYiR8T+COYzZgHGnl3eVGwAJJXHRPfGMqRCoMeNpVb1EE+9kMhiEOq0yzEoP6Y91yTPTuhINt3WbBCYxA==}
 
   array-includes@3.1.6:
     resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==}
@@ -3093,7 +3091,6 @@ packages:
 
   bun@1.0.11:
     resolution: {integrity: sha512-cKyQAQOfWNIP511UpQjkABUp7z/5+1ci2kXfhjL9PozHoCaCtnYFtVjeqU1LovpqEP1agAsMiDpGNKbJP89RIw==}
-    cpu: [arm64, x64]
     os: [darwin, linux]
     hasBin: true
 
@@ -4881,6 +4878,9 @@ packages:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  make-synchronized@0.2.9:
+    resolution: {integrity: sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -5480,6 +5480,11 @@ packages:
 
   prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6743,30 +6748,26 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
 
-  '@arktype/attest@0.7.5(typescript@5.4.2)':
+  '@ark/attest@0.10.2(typescript@5.4.2)':
     dependencies:
-      '@arktype/fs': 0.0.19
-      '@arktype/util': 0.0.41
+      '@ark/fs': 0.1.2
+      '@ark/util': 0.1.2
+      '@prettier/sync': 0.5.2(prettier@3.3.3)
       '@typescript/analyze-trace': 0.10.1
-      '@typescript/vfs': 1.5.0
-      arktype: 2.0.0-dev.11
+      '@typescript/vfs': 1.5.3(typescript@5.4.2)
+      arktype: 2.0.0-beta.2
+      prettier: 3.3.3
       typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
 
-  '@arktype/fs@0.0.19': {}
+  '@ark/fs@0.1.2': {}
 
-  '@arktype/schema@0.1.2':
+  '@ark/schema@0.2.2':
     dependencies:
-      '@arktype/util': 0.0.38
+      '@ark/util': 0.1.2
 
-  '@arktype/util@0.0.38': {}
-
-  '@arktype/util@0.0.40': {}
-
-  '@arktype/util@0.0.41': {}
-
-  '@arktype/util@0.1.0': {}
+  '@ark/util@0.1.2': {}
 
   '@aws-crypto/ie11-detection@3.0.0':
     dependencies:
@@ -8092,6 +8093,11 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@prettier/sync@0.5.2(prettier@3.3.3)':
+    dependencies:
+      make-synchronized: 0.2.9
+      prettier: 3.3.3
+
   '@remix-run/router@1.6.0': {}
 
   '@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)':
@@ -8763,9 +8769,10 @@ snapshots:
       treeify: 1.1.0
       yargs: 16.2.0
 
-  '@typescript/vfs@1.5.0':
+  '@typescript/vfs@1.5.3(typescript@5.4.2)':
     dependencies:
       debug: 4.3.4
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8782,13 +8789,13 @@ snapshots:
       - debug
       - utf-8-validate
 
-  '@vitejs/plugin-react@4.0.0(vite@4.3.6(@types/node@18.15.11))':
+  '@vitejs/plugin-react@4.0.0(vite@4.3.6(@types/node@20.12.12))':
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       react-refresh: 0.14.0
-      vite: 4.3.6(@types/node@18.15.11)
+      vite: 4.3.6(@types/node@20.12.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -8963,10 +8970,10 @@ snapshots:
 
   arktype@1.0.29-alpha: {}
 
-  arktype@2.0.0-dev.11:
+  arktype@2.0.0-beta.2:
     dependencies:
-      '@arktype/schema': 0.1.2
-      '@arktype/util': 0.0.38
+      '@ark/schema': 0.2.2
+      '@ark/util': 0.1.2
 
   array-includes@3.1.6:
     dependencies:
@@ -10811,6 +10818,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.5.0(@types/node@20.12.12):
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0(@types/node@20.12.12)
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
   jest-config@29.5.0(@types/node@18.15.11):
     dependencies:
       '@babel/core': 7.21.4
@@ -10837,6 +10863,35 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.15.11
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-config@29.5.0(@types/node@20.12.12):
+    dependencies:
+      '@babel/core': 7.21.4
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.21.4)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.12
     transitivePeerDependencies:
       - supports-color
 
@@ -11080,6 +11135,17 @@ snapshots:
       '@jest/types': 29.5.0
       import-local: 3.1.0
       jest-cli: 29.5.0(@types/node@18.15.11)
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+
+  jest@29.5.0(@types/node@20.12.12):
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0(@types/node@20.12.12)
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -11402,6 +11468,8 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
       - supports-color
+
+  make-synchronized@0.2.9: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -11969,6 +12037,8 @@ snapshots:
   prettier@2.8.4: {}
 
   prettier@3.2.5: {}
+
+  prettier@3.3.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -12754,7 +12824,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(esbuild@0.17.17)(jest@29.5.0(@types/node@18.15.11))(typescript@5.4.2):
+  ts-jest@29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(jest@29.5.0(@types/node@18.15.11))(typescript@5.4.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -12770,7 +12840,23 @@ snapshots:
       '@babel/core': 7.21.4
       '@jest/types': 29.5.0
       babel-jest: 29.5.0(@babel/core@7.21.4)
-      esbuild: 0.17.17
+
+  ts-jest@29.0.5(@babel/core@7.21.4)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.21.4))(jest@29.5.0(@types/node@20.12.12))(typescript@5.4.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@20.12.12)
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.0
+      typescript: 5.4.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.21.4
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.21.4)
 
   tslib@1.14.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - packages/*
   - test/*
+
+catalog:
+  "@ark/util": "0.1.2"

--- a/test/ts-benchmarks/bench.ts
+++ b/test/ts-benchmarks/bench.ts
@@ -1,9 +1,30 @@
-import { bench } from "@arktype/attest";
+import { bench } from "@ark/attest";
 import { syncToRecs } from "@latticexyz/store-sync/recs";
 import { syncToZustand } from "@latticexyz/store-sync/zustand";
 import { Hex, type PublicClient } from "viem";
 import { defineWorld } from "@latticexyz/world";
 import { createWorld } from "@latticexyz/recs";
+
+() => {
+  const config = defineWorld({
+    namespace: "baseline",
+    tables: {
+      test: {
+        schema: {
+          a: "address",
+        },
+        key: ["a"],
+      },
+    },
+  });
+
+  return syncToRecs({
+    world: createWorld(),
+    config,
+    address: {} as Hex,
+    publicClient: {} as PublicClient,
+  });
+};
 
 bench("syncToRecs", async () => {
   const config = defineWorld({

--- a/test/ts-benchmarks/bench.ts
+++ b/test/ts-benchmarks/bench.ts
@@ -1,7 +1,7 @@
 import { bench } from "@ark/attest";
 import { syncToRecs, type SyncToRecsOptions } from "@latticexyz/store-sync/recs";
 import { syncToZustand } from "@latticexyz/store-sync/zustand";
-import { Hex, type PublicClient } from "viem";
+import type { Hex, PublicClient } from "viem";
 import { defineWorld } from "@latticexyz/world";
 import { createWorld } from "@latticexyz/recs";
 
@@ -49,7 +49,7 @@ bench("syncToRecs(1 table)", async () => {
   });
 
   return t;
-}).types([4033, "instantiations"]);
+}).types([4041, "instantiations"]);
 
 bench("syncToRecs(5 tables)", async () => {
   const config = defineWorld({
@@ -105,7 +105,7 @@ bench("syncToRecs(5 tables)", async () => {
   });
 
   return t;
-}).types([16273, "instantiations"]);
+}).types([16313, "instantiations"]);
 
 bench("syncToZustand", async () => {
   const config = defineWorld({
@@ -128,4 +128,4 @@ bench("syncToZustand", async () => {
   });
 
   return t;
-}).types([4090, "instantiations"]);
+}).types([4098, "instantiations"]);

--- a/test/ts-benchmarks/bench.ts
+++ b/test/ts-benchmarks/bench.ts
@@ -27,7 +27,7 @@ bench.baseline(() => {
   });
 });
 
-bench("syncToRecs", async () => {
+bench("syncToRecs(1 table)", async () => {
   const config = defineWorld({
     namespace: "demo",
     tables: {
@@ -51,7 +51,7 @@ bench("syncToRecs", async () => {
   return t;
 }).types([4033, "instantiations"]);
 
-bench("syncToRecs (5)", async () => {
+bench("syncToRecs(5 tables)", async () => {
   const config = defineWorld({
     namespace: "demo",
     tables: {

--- a/test/ts-benchmarks/bench.ts
+++ b/test/ts-benchmarks/bench.ts
@@ -1,11 +1,13 @@
 import { bench } from "@ark/attest";
-import { syncToRecs } from "@latticexyz/store-sync/recs";
+import { syncToRecs, type SyncToRecsOptions } from "@latticexyz/store-sync/recs";
 import { syncToZustand } from "@latticexyz/store-sync/zustand";
 import { Hex, type PublicClient } from "viem";
 import { defineWorld } from "@latticexyz/world";
 import { createWorld } from "@latticexyz/recs";
 
-() => {
+const mockOpts = { address: {} as Hex, publicClient: {} as PublicClient } as const satisfies Partial<SyncToRecsOptions>;
+
+bench.baseline(() => {
   const config = defineWorld({
     namespace: "baseline",
     tables: {
@@ -21,10 +23,9 @@ import { createWorld } from "@latticexyz/recs";
   return syncToRecs({
     world: createWorld(),
     config,
-    address: {} as Hex,
-    publicClient: {} as PublicClient,
+    ...mockOpts,
   });
-};
+});
 
 bench("syncToRecs", async () => {
   const config = defineWorld({
@@ -44,12 +45,67 @@ bench("syncToRecs", async () => {
   const t = await syncToRecs({
     world: createWorld(),
     config,
-    address: {} as Hex,
-    publicClient: {} as PublicClient,
+    ...mockOpts,
   });
 
   return t;
-}).types([21231, "instantiations"]);
+}).types([4033, "instantiations"]);
+
+bench("syncToRecs (5)", async () => {
+  const config = defineWorld({
+    namespace: "demo",
+    tables: {
+      Position: {
+        schema: {
+          entity: "address",
+          x: "int32",
+          y: "int32",
+        },
+        key: ["entity"],
+      },
+      Position2: {
+        schema: {
+          entity2: "address",
+          x2: "int32",
+          y2: "int32",
+        },
+        key: ["entity2"],
+      },
+      Position3: {
+        schema: {
+          entity3: "address",
+          x3: "int32",
+          y3: "int32",
+        },
+        key: ["entity3"],
+      },
+      Position4: {
+        schema: {
+          entity4: "address",
+          x4: "int32",
+          y4: "int32",
+        },
+        key: ["entity4"],
+      },
+      Position5: {
+        schema: {
+          entity5: "address",
+          x5: "int32",
+          y5: "int32",
+        },
+        key: ["entity5"],
+      },
+    },
+  });
+
+  const t = await syncToRecs({
+    world: createWorld(),
+    config,
+    ...mockOpts,
+  });
+
+  return t;
+}).types([16273, "instantiations"]);
 
 bench("syncToZustand", async () => {
   const config = defineWorld({
@@ -68,9 +124,8 @@ bench("syncToZustand", async () => {
 
   const t = await syncToZustand({
     config,
-    address: {} as Hex,
-    publicClient: {} as PublicClient,
+    ...mockOpts,
   });
 
   return t;
-}).types([21214, "instantiations"]);
+}).types([4090, "instantiations"]);

--- a/test/ts-benchmarks/tsconfig.json
+++ b/test/ts-benchmarks/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  // We intentionally do not extend the workspace root tsconfig to avoid paths, because we want this project to resolve types using DTS rather than TS source.
-  "extends": ["../../packages/common/tsconfig.base.json"],
+  "extends": ["../../tsconfig.json"],
   "exclude": ["**/dist", "**/node_modules", "**/docs", "**/e2e"],
   "compilerOptions": {
     "outDir": "dist"


### PR DESCRIPTION
While investigating the type performance issues that led to https://github.com/wevm/viem/pull/2557, I made some improvements to the local type benchmarks.

The new "baseline expression" allows them to be run accurately directly from `.ts` files and gives a much better linear representation of the cost of each bench (note that the scaling between 1 table and 5 tables is close to linear).

Also updated `@arktype` dependencies to the latest version and new `@ark` scope.

closes #2988