### PR TITLE
chore: fetch main branch when running prerelease action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+          ref: main
 
       - name: "Setup"
         uses: ./.github/actions/setup


### PR DESCRIPTION
the main branch wasn't present in the action and was failing when attempting to checkout the changelog file