### PR TITLE
fix(world): workaround resolve json issue

### DIFF
--- a/packages/store/ts/protocolVersions.test.ts
+++ b/packages/store/ts/protocolVersions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import StoreAbi from "../out/IStore.sol/IStore.abi.json";
+import type StoreAbiType from "../out/IStore.sol/IStore.abi.json.d";
 import { formatAbi } from "abitype";
 import { protocolVersions } from "./protocolVersions";
 
@@ -19,7 +20,7 @@ import { protocolVersions } from "./protocolVersions";
 
 const [, currentVersion] = fs.readFileSync(`${__dirname}/../src/version.sol`, "utf8").match(/VERSION = "(.*?)"/) ?? [];
 
-const currentAbi = formatAbi(StoreAbi).sort((a, b) => a.localeCompare(b));
+const currentAbi = formatAbi(StoreAbi as typeof StoreAbiType).sort((a, b) => a.localeCompare(b));
 
 describe("Store protocol version", () => {
   it("is up to date", async () => {

--- a/packages/world/ts/actions/callFrom.ts
+++ b/packages/world/ts/actions/callFrom.ts
@@ -23,6 +23,7 @@ import {
 } from "@latticexyz/protocol-parser/internal";
 import worldConfig from "../../mud.config";
 import IStoreReadAbi from "../../out/IStoreRead.sol/IStoreRead.abi.json";
+import type IStoreReadAbiType from "../../out/IStoreRead.sol/IStoreRead.abi.json.d";
 
 // Accepts either `worldFunctionToSystemFunction` or `publicClient`, but not both.
 type CallFromParameters = CallFromFunctionParameters | CallFromClientParameters;
@@ -130,7 +131,7 @@ async function retrieveSystemFunctionFromContract(
 
   const [staticData, encodedLengths, dynamicData] = await publicClient.readContract({
     address: worldAddress,
-    abi: IStoreReadAbi,
+    abi: IStoreReadAbi as typeof IStoreReadAbiType,
     functionName: "getRecord",
     args: [table.tableId, encodeKey(keySchema, { worldFunctionSelector })],
   });

--- a/packages/world/ts/encodeSystemCall.test.ts
+++ b/packages/world/ts/encodeSystemCall.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { encodeSystemCall } from "./encodeSystemCall";
 import { resourceToHex } from "@latticexyz/common";
 import AccessManagementSystemAbi from "../out/AccessManagementSystem.sol/AccessManagementSystem.abi.json";
-import StoreRegistrationSystem from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json";
+import type AccessManagementSystemAbiType from "../out/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d";
+import StoreRegistrationSystemAbi from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json";
+import type StoreRegistrationSystemAbiType from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json.d";
 
 describe("SystemCall", () => {
   it("encodes grantAccess properly", async () => {
@@ -12,7 +14,7 @@ describe("SystemCall", () => {
 
     expect(
       encodeSystemCall({
-        abi: AccessManagementSystemAbi,
+        abi: AccessManagementSystemAbi as typeof AccessManagementSystemAbiType,
         systemId: resourceToHex({ type: "system", namespace: "", name: "" }),
         functionName: "grantAccess",
         args: [resourceId, grantee],
@@ -35,7 +37,7 @@ describe("SystemCall", () => {
 
     expect(
       encodeSystemCall({
-        abi: StoreRegistrationSystem,
+        abi: StoreRegistrationSystemAbi as typeof StoreRegistrationSystemAbiType,
         systemId: resourceToHex({ type: "system", namespace: "", name: "" }),
         functionName: "registerTable",
         args: [tableId, fieldLayout, keySchema, valueSchema, keyNames, fieldNames],

--- a/packages/world/ts/encodeSystemCall.ts
+++ b/packages/world/ts/encodeSystemCall.ts
@@ -1,6 +1,6 @@
 import { Abi, EncodeFunctionDataParameters, Hex, encodeFunctionData, type ContractFunctionName } from "viem";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
+import type IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json.d";
 
 export type SystemCall<abi extends Abi, functionName extends ContractFunctionName<abi>> = EncodeFunctionDataParameters<
   abi,

--- a/packages/world/ts/encodeSystemCallFrom.ts
+++ b/packages/world/ts/encodeSystemCallFrom.ts
@@ -1,6 +1,6 @@
 import { Abi, EncodeFunctionDataParameters, encodeFunctionData, Address, type ContractFunctionName } from "viem";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
+import type IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json.d";
 import { SystemCall } from "./encodeSystemCall";
 
 export type SystemCallFrom<abi extends Abi, functionName extends ContractFunctionName<abi>> = SystemCall<

--- a/packages/world/ts/encodeSystemCalls.test.ts
+++ b/packages/world/ts/encodeSystemCalls.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { encodeSystemCalls } from "./encodeSystemCalls";
 import { resourceToHex } from "@latticexyz/common";
 import AccessManagementSystemAbi from "../out/AccessManagementSystem.sol/AccessManagementSystem.abi.json";
-import StoreRegistrationSystem from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json";
+import type AccessManagementSystemAbiType from "../out/AccessManagementSystem.sol/AccessManagementSystem.abi.json.d";
+import StoreRegistrationSystemAbi from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json";
+import type StoreRegistrationSystemAbiType from "../out/StoreRegistrationSystem.sol/StoreRegistrationSystem.abi.json.d";
 
 describe("SystemCalls", () => {
   it("encodes grantAccess properly", async () => {
@@ -11,7 +13,7 @@ describe("SystemCalls", () => {
     const grantee = "0x943728592c20aed37a35c15235466f7a7cd00bd0";
 
     expect(
-      encodeSystemCalls(AccessManagementSystemAbi, [
+      encodeSystemCalls(AccessManagementSystemAbi as typeof AccessManagementSystemAbiType, [
         {
           systemId: resourceToHex({ type: "system", namespace: "", name: "" }),
           functionName: "grantAccess",
@@ -37,7 +39,7 @@ describe("SystemCalls", () => {
     const fieldNames = ["field1", "field2"];
 
     expect(
-      encodeSystemCalls(StoreRegistrationSystem, [
+      encodeSystemCalls(StoreRegistrationSystemAbi as typeof StoreRegistrationSystemAbiType, [
         {
           systemId: resourceToHex({ type: "system", namespace: "", name: "" }),
           functionName: "registerTable",

--- a/packages/world/ts/encodeSystemCalls.ts
+++ b/packages/world/ts/encodeSystemCalls.ts
@@ -1,5 +1,5 @@
 import { Abi, type ContractFunctionName } from "viem";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
+import type IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json.d";
 import { SystemCall, encodeSystemCall } from "./encodeSystemCall";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
 

--- a/packages/world/ts/encodeSystemCallsFrom.ts
+++ b/packages/world/ts/encodeSystemCallsFrom.ts
@@ -1,5 +1,5 @@
 import { Abi, Address, type ContractFunctionName } from "viem";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
+import type IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json.d";
 import { SystemCallFrom, encodeSystemCallFrom } from "./encodeSystemCallFrom";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
 

--- a/packages/world/ts/getWorldAbi.ts
+++ b/packages/world/ts/getWorldAbi.ts
@@ -1,5 +1,6 @@
 import { Client, Abi, Address, getAddress } from "viem";
 import IBaseWorldAbi from "../out/IBaseWorld.sol/IBaseWorld.abi.json";
+import type IBaseWorldAbiType from "../out/IBaseWorld.sol/IBaseWorld.abi.json.d";
 import { functionSignatureToAbiItem } from "./functionSignatureToAbiItem";
 import { getFunctions } from "./getFunctions";
 
@@ -21,7 +22,7 @@ export async function getWorldAbi({
     toBlock,
   });
   const worldFunctionsAbi = worldFunctions.map((func) => functionSignatureToAbiItem(func.signature));
-  const abi = [...IBaseWorldAbi, ...worldFunctionsAbi];
+  const abi = [...(IBaseWorldAbi as typeof IBaseWorldAbiType), ...worldFunctionsAbi] as const;
 
   return abi;
 }

--- a/packages/world/ts/protocolVersions.test.ts
+++ b/packages/world/ts/protocolVersions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import WorldAbi from "../out/IBaseWorld.sol/IBaseWorld.abi.json";
+import type WorldAbiType from "../out/IBaseWorld.sol/IBaseWorld.abi.json.d";
 import { formatAbi } from "abitype";
 import { protocolVersions } from "./protocolVersions";
 
@@ -19,7 +20,7 @@ import { protocolVersions } from "./protocolVersions";
 
 const [, currentVersion] = fs.readFileSync(`${__dirname}/../src/version.sol`, "utf8").match(/VERSION = "(.*?)"/) ?? [];
 
-const currentAbi = formatAbi(WorldAbi).sort((a, b) => a.localeCompare(b));
+const currentAbi = formatAbi(WorldAbi as typeof WorldAbiType).sort((a, b) => a.localeCompare(b));
 
 describe("World protocol version", () => {
   it("is up to date", async () => {

--- a/packages/world/tsconfig.json
+++ b/packages/world/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // needed to ensure tests like those in packages/world/ts/encodeSystemCall.test.ts
-    // resolve narrowed types from .d.ts as opposed to widened ones from abi.json
-    "resolveJsonModule": false,
     "lib": ["ESNext", "DOM"],
     "outDir": "dist"
   },


### PR DESCRIPTION
can either turn on `resolveJsonModule` but get weaker types or turn it off and get strong types from our generated `.json.d.ts`, but not both

this attempts to work around this issue by manually importing the ABI types we need when we need them 😭 

