### PR TITLE
fix(world): worldgen should read system source from root dir

### DIFF
--- a/.changeset/twenty-trains-bathe.md
+++ b/.changeset/twenty-trains-bathe.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Fixed an issue with worldgen when using a different `rootDir` from the current working directory, where worldgen would read system source files from the wrong place.

--- a/packages/world/ts/node/render-solidity/worldgen.ts
+++ b/packages/world/ts/node/render-solidity/worldgen.ts
@@ -49,7 +49,7 @@ export async function worldgen({
 
   await Promise.all(
     systems.map(async (system) => {
-      const data = await fs.readFile(system.sourcePath, "utf8");
+      const data = await fs.readFile(path.join(rootDir, system.sourcePath), "utf8");
       // get external functions from a contract
       const { functions, errors, symbolImports } = contractToInterface(data, system.label);
       const imports = symbolImports.map(


### PR DESCRIPTION
Missed this when refactoring systems and worldgen. This issue only shows up when you cwd and rootDir are different, e.g. running worldgen from a different dir than where the mud config lives.

Found while adding a second MUD config to world-modules in https://github.com/latticexyz/mud/pull/3026