### PR TITLE
refactor(cli,world-module-metadata): install metadata module once

### DIFF
--- a/packages/cli/src/deploy/ensureModules.ts
+++ b/packages/cli/src/deploy/ensureModules.ts
@@ -59,14 +59,13 @@ export async function ensureModules({
                     args: [moduleAddress, mod.installData],
                   });
             } catch (error) {
-              if (mod.optional) {
-                debug(
-                  `optional module ${mod.name} install failed, skipping\n  ${error instanceof BaseError ? error.shortMessage : error}`,
-                );
-                return;
-              }
               if (error instanceof BaseError && error.message.includes("Module_AlreadyInstalled")) {
                 debug(`module ${mod.name} already installed`);
+                return;
+              }
+              if (mod.optional) {
+                debug(`optional module ${mod.name} install failed, skipping`);
+                debug(error);
                 return;
               }
               throw error;

--- a/packages/cli/src/deploy/ensureResourceLabels.ts
+++ b/packages/cli/src/deploy/ensureResourceLabels.ts
@@ -38,7 +38,7 @@ export async function ensureResourceLabels({
     return [];
   }
 
-  debug(`setting ${resources.length} resource labels`);
+  debug("setting", resources.length, "resource labels");
   return (
     await Promise.all(
       resourcesToSet.map(async ({ resourceId, label }) => {

--- a/packages/world-module-metadata/gas-report.json
+++ b/packages/world-module-metadata/gas-report.json
@@ -9,7 +9,7 @@
     "file": "test/MetadataModule.t.sol",
     "test": "testInstall",
     "name": "install metadata module",
-    "gasUsed": 1106562
+    "gasUsed": 1109853
   },
   {
     "file": "test/MetadataModule.t.sol",

--- a/packages/world-module-metadata/src/MetadataModule.sol
+++ b/packages/world-module-metadata/src/MetadataModule.sol
@@ -26,7 +26,11 @@ contract MetadataModule is Module {
     revert Module_RootInstallNotSupported();
   }
 
-  function install(bytes memory) public {
+  function install(bytes memory args) public {
+    // naive check to ensure this is only installed once
+    // TODO: update this + deployer to be idempotent
+    requireNotInstalled(__self, args);
+
     IBaseWorld world = IBaseWorld(_world());
 
     ResourceId namespace = ResourceTag._tableId.getNamespaceId();


### PR DESCRIPTION
since the deployer doesn't really support idempotent modules with prerequisites (like this module needing ownership of the metadata namespace), we'll just do a "not installed" check for now

when we update the module to be idempotent, it'll be different bytecode and deployed to a separate address anyway, and can remove the "not installed" check at that point

this hopefully improves UX of rerunning deploy with module already installed instead of the cryptic error around "optional module install failed" until #3035 is done