### PR TITLE
fix: update codegen dir in rm commands

### DIFF
--- a/e2e/packages/contracts/package.json
+++ b/e2e/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "mud deploy",
     "test": "mud test",
     "test:ci": "pnpm run test"

--- a/examples/local-explorer/packages/contracts/package.json
+++ b/examples/local-explorer/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/examples/minimal/packages/contracts/package.json
+++ b/examples/minimal/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "mud deploy",
     "dev": "mud dev-contracts",
     "faucet": "DEBUG=mud:faucet faucet-server",

--- a/examples/multiple-accounts/packages/contracts/package.json
+++ b/examples/multiple-accounts/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "mud deploy",
     "dev": "mud dev-contracts",
     "lint": "pnpm run prettier && pnpm run solhint",

--- a/examples/multiple-namespaces/package.json
+++ b/examples/multiple-namespaces/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "mud deploy",
     "dev": "mud dev-contracts",
     "faucet": "DEBUG=mud:faucet faucet-server",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "build:test-tables": "tsx ./scripts/generate-test-tables.ts",
     "clean": "pnpm run clean:js && pnpm run clean:test-tables",
     "clean:js": "shx rm -rf dist",
-    "clean:test-tables": "shx rm -rf src/codegen",
+    "clean:test-tables": "shx rm -rf src/**/codegen",
     "dev": "tsup --watch",
     "lint": "eslint . --ext .ts",
     "test": "tsc --noEmit && forge test",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -51,7 +51,7 @@
     "clean": "pnpm run clean:abi && pnpm run clean:js && pnpm run clean:mud",
     "clean:abi": "forge clean",
     "clean:js": "shx rm -rf dist",
-    "clean:mud": "shx rm -rf src/codegen && shx rm -rf test/codegen",
+    "clean:mud": "shx rm -rf src/**/codegen test/**/codegen",
     "dev": "tsup --watch",
     "gas-report": "gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",

--- a/packages/world-modules/package.json
+++ b/packages/world-modules/package.json
@@ -34,7 +34,7 @@
     "clean": "pnpm run clean:abi && pnpm run clean:js && pnpm run clean:mud",
     "clean:abi": "forge clean",
     "clean:js": "shx rm -rf dist",
-    "clean:mud": "shx rm -rf src/codegen",
+    "clean:mud": "shx rm -rf src/**/codegen",
     "dev": "tsup --watch",
     "gas-report": "gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",

--- a/packages/world/package.json
+++ b/packages/world/package.json
@@ -51,7 +51,7 @@
     "clean": "pnpm run clean:abi && pnpm run clean:js && pnpm run clean:mud",
     "clean:abi": "forge clean",
     "clean:js": "shx rm -rf dist",
-    "clean:mud": "shx rm -rf src/codegen && shx rm -rf test/codegen",
+    "clean:mud": "shx rm -rf src/**/codegen test/**/codegen",
     "dev": "tsup --watch",
     "gas-report": "gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",

--- a/templates/phaser/packages/contracts/package.json
+++ b/templates/phaser/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/templates/react-ecs/packages/contracts/package.json
+++ b/templates/react-ecs/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/templates/react/packages/contracts/package.json
+++ b/templates/react/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/templates/threejs/packages/contracts/package.json
+++ b/templates/threejs/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/templates/vanilla/packages/contracts/package.json
+++ b/templates/vanilla/packages/contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:garnet": "mud deploy --profile=garnet",
     "deploy:local": "mud deploy",
     "deploy:redstone": "mud deploy --profile=redstone",

--- a/test/mock-game-contracts/package.json
+++ b/test/mock-game-contracts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "mud build",
-    "clean": "forge clean && shx rm -rf src/codegen",
+    "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "DEBUG=mud:* mud deploy"
   },
   "devDependencies": {


### PR DESCRIPTION
if a project switches to multi-namespace mode, the previous command will no longer remove all codegen files, but this new command will