### PR TITLE
fix: explorer dev port

### DIFF
--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -17,7 +17,7 @@
     "clean": "pnpm run clean:explorer && pnpm run clean:bin",
     "clean:bin": "shx rm -rf dist",
     "clean:explorer": "shx rm -rf .next .turbo",
-    "dev": "next dev",
+    "dev": "next dev --port 13690",
     "lint": "next lint",
     "start": "node .next/standalone/packages/explorer/server.js"
   },


### PR DESCRIPTION
start explorer in same port we expect to run it in when using the bin