### PR TITLE
feat(explorer): remove dev command from build

### DIFF
--- a/packages/explorer/bin/explorer.ts
+++ b/packages/explorer/bin/explorer.ts
@@ -13,12 +13,17 @@ const __dirname = path.dirname(__filename);
 const argv = minimist(process.argv.slice(2));
 const port = argv.port || process.env.PORT || 13690;
 const chainId = argv.chainId || process.env.CHAIN_ID || 31337;
-const env = argv.env || process.env.NODE_ENV || "production";
 const indexerDatabase = argv.indexerDatabase || process.env.INDEXER_DATABASE || "indexer.db";
 const worldsFile = argv.worldsFile || process.env.WORLDS_FILE || "worlds.json";
 
 let worldAddress = argv.worldAddress || process.env.WORLD_ADDRESS || null;
 let explorerProcess: ChildProcess;
+
+// make sure only "production" is allowed in build
+let env = "production";
+if (process.env.NODE_ENV !== "development") {
+  env = argv.env || process.env.NODE_ENV;
+}
 
 async function startExplorer() {
   let command, args;

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "pnpm run build:explorer && pnpm run build:bin",
-    "build:bin": "tsup",
+    "build:bin": "NODE_ENV=production tsup",
     "build:explorer": "next build && shx cp -r .next/static .next/standalone/packages/explorer/.next",
     "clean": "pnpm run clean:explorer && pnpm run clean:bin",
     "clean:bin": "shx rm -rf dist",

--- a/packages/explorer/tsup.config.ts
+++ b/packages/explorer/tsup.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
+  define: {
+    "process.env.NODE_ENV": "production",
+  },
   entry: ["bin/explorer.ts"],
   target: "esnext",
   format: ["esm"],


### PR DESCRIPTION
First attempt to compile out `next dev` path for `@latticexyz/explorer` build but so far didn't succeed, will continue experimenting with it.