### PR TITLE
fix(cli): deployer should wait for prereq txs

### DIFF
--- a/.changeset/long-dogs-wash.md
+++ b/.changeset/long-dogs-wash.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Deployer now waits for prerequisite transactions before continuing.

--- a/packages/cli/src/deploy/configToModules.ts
+++ b/packages/cli/src/deploy/configToModules.ts
@@ -5,10 +5,8 @@ import { SchemaAbiType, SchemaAbiTypeToPrimitiveType } from "@latticexyz/schema-
 import { bytesToHex } from "viem";
 import { createPrepareDeploy } from "./createPrepareDeploy";
 import { World } from "@latticexyz/world";
-import { getContractArtifact } from "../utils/getContractArtifact";
 import { importContractArtifact } from "../utils/importContractArtifact";
 import { resolveWithContext } from "@latticexyz/world/internal";
-import metadataModule from "@latticexyz/world-module-metadata/out/MetadataModule.sol/MetadataModule.json" assert { type: "json" };
 
 /** Please don't add to this list! These are kept for backwards compatibility and assumes the downstream project has this module installed as a dependency. */
 const knownModuleArtifacts = {
@@ -19,28 +17,11 @@ const knownModuleArtifacts = {
     "@latticexyz/world-modules/out/Unstable_CallWithSignatureModule.sol/Unstable_CallWithSignatureModule.json",
 };
 
-const metadataModuleArtifact = getContractArtifact(metadataModule);
-
 export async function configToModules<config extends World>(
   config: config,
   // TODO: remove/replace `forgeOutDir`
   forgeOutDir: string,
 ): Promise<readonly Module[]> {
-  const defaultModules: Module[] = [
-    // TODO: replace metadata install here with custom logic inside `ensureModules` or an `ensureDefaultModules` to check
-    //       if metadata namespace exists, if we own it, and if so transfer ownership to the module before reinstalling
-    //       (https://github.com/latticexyz/mud/issues/3035)
-    {
-      optional: true,
-      name: "MetadataModule",
-      installAsRoot: false,
-      installData: "0x",
-      prepareDeploy: createPrepareDeploy(metadataModuleArtifact.bytecode, metadataModuleArtifact.placeholders),
-      deployedBytecodeSize: metadataModuleArtifact.deployedBytecodeSize,
-      abi: metadataModuleArtifact.abi,
-    },
-  ];
-
   const modules = await Promise.all(
     config.modules.map(async (mod): Promise<Module> => {
       let artifactPath = mod.artifactPath;
@@ -98,5 +79,5 @@ export async function configToModules<config extends World>(
     }),
   );
 
-  return [...defaultModules, ...modules];
+  return modules;
 }

--- a/packages/cli/src/deploy/ensureContract.ts
+++ b/packages/cli/src/deploy/ensureContract.ts
@@ -4,7 +4,6 @@ import { contractSizeLimit, salt } from "./common";
 import { sendTransaction } from "@latticexyz/common";
 import { debug } from "./debug";
 import pRetry from "p-retry";
-import { wait } from "@latticexyz/common/utils";
 
 export type Contract = {
   bytecode: Hex;
@@ -56,11 +55,7 @@ export async function ensureContract({
         }),
       {
         retries: 3,
-        onFailedAttempt: async (error) => {
-          const delay = error.attemptNumber * 500;
-          debug(`failed to deploy ${debugLabel}, retrying in ${delay}ms...`);
-          await wait(delay);
-        },
+        onFailedAttempt: () => debug(`failed to deploy ${debugLabel}, retrying...`),
       },
     ),
   ];

--- a/packages/cli/src/deploy/ensureContractsDeployed.ts
+++ b/packages/cli/src/deploy/ensureContractsDeployed.ts
@@ -1,8 +1,7 @@
 import { Client, Transport, Chain, Account, Hex } from "viem";
-import { waitForTransactionReceipt } from "viem/actions";
-import { debug } from "./debug";
 import { Contract, ensureContract } from "./ensureContract";
 import { uniqueBy } from "@latticexyz/common/utils";
+import { waitForTransactions } from "./waitForTransactions";
 
 export async function ensureContractsDeployed({
   client,
@@ -20,14 +19,11 @@ export async function ensureContractsDeployed({
     await Promise.all(uniqueContracts.map((contract) => ensureContract({ client, deployerAddress, ...contract })))
   ).flat();
 
-  if (txs.length) {
-    debug("waiting for contracts");
-    // wait for each tx separately/serially, because parallelizing results in RPC errors
-    for (const tx of txs) {
-      await waitForTransactionReceipt(client, { hash: tx });
-      // TODO: throw if there was a revert?
-    }
-  }
+  await waitForTransactions({
+    client,
+    hashes: txs,
+    debugLabel: "contract deploys",
+  });
 
   return txs;
 }

--- a/packages/cli/src/deploy/ensureResourceTags.ts
+++ b/packages/cli/src/deploy/ensureResourceTags.ts
@@ -10,7 +10,7 @@ import { ensureModules } from "./ensureModules";
 import metadataModule from "@latticexyz/world-module-metadata/out/MetadataModule.sol/MetadataModule.json" assert { type: "json" };
 import { getContractArtifact } from "../utils/getContractArtifact";
 import { createPrepareDeploy } from "./createPrepareDeploy";
-import { waitForTransactionReceipt } from "viem/actions";
+import { waitForTransactions } from "./waitForTransactions";
 
 const metadataModuleArtifact = getContractArtifact(metadataModule);
 
@@ -72,15 +72,14 @@ export async function ensureResourceTags<const value>({
       },
     ],
   });
+
   // Wait for metadata module to be available, otherwise calling the metadata system below may fail.
   // This is only here because OPStack chains don't let us estimate gas with pending block tag.
-  debug("waiting for metadata module installation to confirm");
-  for (const tx of moduleTxs) {
-    const receipt = await waitForTransactionReceipt(client, { hash: tx });
-    if (receipt.status === "reverted") {
-      throw new Error(`Transaction reverted: ${tx}`);
-    }
-  }
+  await waitForTransactions({
+    client,
+    hashes: moduleTxs,
+    debugLabel: "metadata module installation",
+  });
 
   debug("setting", pendingTags.length, "resource tags");
   return (

--- a/packages/cli/src/deploy/ensureSystems.ts
+++ b/packages/cli/src/deploy/ensureSystems.ts
@@ -4,7 +4,6 @@ import { Library, System, WorldDeploy, worldAbi } from "./common";
 import { debug } from "./debug";
 import { getSystems } from "./getSystems";
 import { getResourceAccess } from "./getResourceAccess";
-import { wait } from "@latticexyz/common/utils";
 import pRetry from "p-retry";
 import { ensureContractsDeployed } from "./ensureContractsDeployed";
 
@@ -87,11 +86,7 @@ export async function ensureSystems({
           }),
         {
           retries: 3,
-          onFailedAttempt: async (error) => {
-            const delay = error.attemptNumber * 500;
-            debug(`failed to register system ${resourceToLabel(system)}, retrying in ${delay}ms...`);
-            await wait(delay);
-          },
+          onFailedAttempt: () => debug(`failed to register system ${resourceToLabel(system)}, retrying...`),
         },
       ),
     ),
@@ -153,11 +148,7 @@ export async function ensureSystems({
           }),
         {
           retries: 3,
-          onFailedAttempt: async (error) => {
-            const delay = error.attemptNumber * 500;
-            debug(`failed to revoke access, retrying in ${delay}ms...`);
-            await wait(delay);
-          },
+          onFailedAttempt: () => debug("failed to revoke access, retrying..."),
         },
       ),
     ),
@@ -173,11 +164,7 @@ export async function ensureSystems({
           }),
         {
           retries: 3,
-          onFailedAttempt: async (error) => {
-            const delay = error.attemptNumber * 500;
-            debug(`failed to grant access, retrying in ${delay}ms...`);
-            await wait(delay);
-          },
+          onFailedAttempt: () => debug("failed to grant access, retrying..."),
         },
       ),
     ),

--- a/packages/cli/src/deploy/ensureTables.ts
+++ b/packages/cli/src/deploy/ensureTables.ts
@@ -13,7 +13,6 @@ import {
 import { debug } from "./debug";
 import { getTables } from "./getTables";
 import pRetry from "p-retry";
-import { wait } from "@latticexyz/common/utils";
 import { Table } from "@latticexyz/config";
 
 export async function ensureTables({
@@ -59,11 +58,7 @@ export async function ensureTables({
             }),
           {
             retries: 3,
-            onFailedAttempt: async (error) => {
-              const delay = error.attemptNumber * 500;
-              debug(`failed to register table ${resourceToLabel(table)}, retrying in ${delay}ms...`);
-              await wait(delay);
-            },
+            onFailedAttempt: () => debug(`failed to register table ${resourceToLabel(table)}, retrying...`),
           },
         );
       }),

--- a/packages/cli/src/deploy/waitForTransactions.ts
+++ b/packages/cli/src/deploy/waitForTransactions.ts
@@ -1,0 +1,24 @@
+import { Client, Transport, Chain, Account, Hex } from "viem";
+import debug from "debug";
+import { waitForTransactionReceipt } from "viem/actions";
+
+export async function waitForTransactions({
+  client,
+  hashes,
+  debugLabel = "transactions",
+}: {
+  readonly client: Client<Transport, Chain | undefined, Account>;
+  readonly hashes: readonly Hex[];
+  readonly debugLabel: string;
+}): Promise<void> {
+  if (!hashes.length) return;
+
+  debug(`waiting for ${debugLabel} to confirm`);
+  // wait for each tx separately/serially, because parallelizing results in RPC errors
+  for (const hash of hashes) {
+    const receipt = await waitForTransactionReceipt(client, { hash });
+    if (receipt.status === "reverted") {
+      throw new Error(`Transaction reverted: ${hash}`);
+    }
+  }
+}

--- a/packages/cli/src/deploy/waitForTransactions.ts
+++ b/packages/cli/src/deploy/waitForTransactions.ts
@@ -1,5 +1,5 @@
 import { Client, Transport, Chain, Account, Hex } from "viem";
-import debug from "debug";
+import { debug } from "./debug";
 import { waitForTransactionReceipt } from "viem/actions";
 
 export async function waitForTransactions({


### PR DESCRIPTION
we're seeing issues in garnet where registering function selectors fails

```
  mud:cli:deploy found CREATE2 deployer at 0x4e59b44847b379578588920ca78fbf26c0b4956c +0ms
  mud:cli:deploy found balance transfer system at 0xA274B9a7E743cd8dF3c6Fd0aBD47eD55Fc943BC3 +63ms
  mud:cli:deploy found batch call system at 0x53E5c08d82A377167069Ade46d087Ab753538608 +1ms
  mud:cli:deploy found access management system at 0x17ffDEfF94ed0b80c493A179d4B3b09D6d71f627 +13ms
  mud:cli:deploy found core module at 0xDa4E062e8C69D39d9472945232a53F579904AC45 +5ms
  mud:cli:deploy found core registration system at 0xd416f26aafcaaECa50b0dC35bd023e7286BE2961 +6ms
  mud:cli:deploy found world factory at 0x573802f86c51B61d7Cf620952217eC6Ce0537d2E +34ms
  mud:cli:deploy found app__TasksSystem system at 0x6F8B474d9d54086ff1C527ff31eeb463c688E5A6 +55ms
  mud:cli:deploy found balance transfer system at 0xA274B9a7E743cd8dF3c6Fd0aBD47eD55Fc943BC3 +68ms
  mud:cli:deploy found batch call system at 0x53E5c08d82A377167069Ade46d087Ab753538608 +1ms
  mud:cli:deploy found access management system at 0x17ffDEfF94ed0b80c493A179d4B3b09D6d71f627 +14ms
  mud:cli:deploy found core registration system at 0xd416f26aafcaaECa50b0dC35bd023e7286BE2961 +4ms
  mud:cli:deploy found core module at 0xDa4E062e8C69D39d9472945232a53F579904AC45 +2ms
  mud:cli:deploy found world factory at 0x573802f86c51B61d7Cf620952217eC6Ce0537d2E +5ms
  mud:cli:deploy deploying world +0ms
  mud:common:createNonceManager reset nonce to 154 +0ms
  mud:common:writeContract calling deployWorld with nonce 154 at 0x573802f86c51B61d7Cf620952217eC6Ce0537d2E +0ms
  mud:cli:deploy waiting for world deploy +258ms
  mud:cli:deploy deployed world to 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 at block 6506437n +4s
  mud:cli:deploy looking up resource IDs for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +0ms
  mud:cli:deploy found 22 resource IDs for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +38ms
  mud:cli:deploy found 3 existing namespaces: store, world, <root> +0ms
  mud:cli:deploy registering namespaces app +0ms
  mud:common:writeContract calling registerNamespace with nonce 155 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +4s
  mud:cli:deploy waiting for all namespace registration transactions to confirm +142ms
  mud:cli:deploy looking up tables for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +4s
  mud:cli:deploy found 15 tables for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +52ms
  mud:cli:deploy registering tables app__Tasks +0ms
  mud:common:writeContract calling registerTable with nonce 156 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +4s
  mud:cli:deploy looking up resource IDs for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +202ms
  mud:world looking up function selectors for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +0ms
  mud:cli:deploy looking up resource access for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +1ms
  mud:cli:deploy looking up resource access for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +0ms
  mud:cli:deploy found 22 resource IDs for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +39ms
  mud:world found 22 function selectors for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +49ms
  mud:world looking up function signatures for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +0ms
  mud:world found 44 function signatures for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +76ms
  mud:cli:deploy found 7 resource<>address access pairs +94ms
  mud:cli:deploy found 7 resource<>address access pairs +5ms
  mud:cli:deploy looking up systems AccessManagement, BalanceTransfer, BatchCall, Registration +0ms
  mud:cli:deploy registering new systems app__TasksSystem +40ms
  mud:cli:deploy found app__TasksSystem system at 0x6F8B474d9d54086ff1C527ff31eeb463c688E5A6 +36ms
  mud:common:writeContract calling registerSystem with nonce 157 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +360ms
  mud:world looking up function selectors for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +229ms
  mud:world found 22 function selectors for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +58ms
  mud:world looking up function signatures for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +1ms
  mud:world found 44 function signatures for 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +48ms
  mud:cli:deploy registering functions: app__addTask(string), app__completeTask(bytes32), app__deleteTask(bytes32), app__resetTask(bytes32) +248ms
  mud:cli:deploy failed to register function app__completeTask(bytes32), retrying in 500ms... +117ms
  mud:cli:deploy failed to register function app__deleteTask(bytes32), retrying in 500ms... +78ms
  mud:cli:deploy failed to register function app__resetTask(bytes32), retrying in 500ms... +42ms
  mud:cli:deploy failed to register function app__addTask(string), retrying in 500ms... +94ms
  mud:common:writeContract calling registerFunctionSelector with nonce 158 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +2s
  mud:common:writeContract calling registerFunctionSelector with nonce 159 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +110ms
  mud:common:writeContract calling registerFunctionSelector with nonce 160 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +60ms
  mud:common:writeContract calling registerFunctionSelector with nonce 161 at 0x9db9c8f160ca970f29b6e4a84c95c617f681a8c5 +75ms
  mud:cli:deploy waiting for all transactions to confirm +2s
```

sounds like this may be due to gas estimates not working for OPStack chains?

eventually it succeeds due to retries, but this isn't the intent