### PR TITLE
fix(explorer): force dynamic worlds page

### DIFF
--- a/packages/explorer/src/app/(explorer)/worlds/page.tsx
+++ b/packages/explorer/src/app/(explorer)/worlds/page.tsx
@@ -1,6 +1,8 @@
 import { notFound, redirect } from "next/navigation";
 
-export default async function WorldsPage() {
+export const dynamic = "force-dynamic";
+
+export default function WorldsPage() {
   const worldAddress = process.env.WORLD_ADDRESS;
   if (worldAddress) return redirect(`/worlds/${worldAddress}`);
   return notFound();


### PR DESCRIPTION
Force worlds page to be rendered on every request in order to pick up `worldAddress`.