### PR TITLE
chore: include main branch when fetching during pre-release action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+          ref: main
 
       - name: "Setup"
         uses: ./.github/actions/setup


### PR DESCRIPTION
pulled out from #2996 