### PR TITLE
fix(world): resolve module config

### DIFF
--- a/.changeset/smooth-tigers-exist.md
+++ b/.changeset/smooth-tigers-exist.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Added a config resolver to add default values for `modules` in the world config.

--- a/packages/world/ts/config/v2/output.ts
+++ b/packages/world/ts/config/v2/output.ts
@@ -4,11 +4,6 @@ import { DynamicResolution, ValueWithType } from "./dynamicResolution";
 import { Hex } from "viem";
 
 export type Module = {
-  /**
-   * The name of the module
-   * @deprecated
-   */
-  readonly name: string;
   /** Should this module be installed as a root module? */
   readonly root: boolean;
   /** Arguments to be passed to the module's install method */

--- a/packages/world/ts/config/v2/output.ts
+++ b/packages/world/ts/config/v2/output.ts
@@ -4,6 +4,11 @@ import { DynamicResolution, ValueWithType } from "./dynamicResolution";
 import { Hex } from "viem";
 
 export type Module = {
+  /**
+   * The name of the module
+   * @deprecated
+   */
+  readonly name?: string;
   /** Should this module be installed as a root module? */
   readonly root: boolean;
   /** Arguments to be passed to the module's install method */

--- a/packages/world/ts/config/v2/world.ts
+++ b/packages/world/ts/config/v2/world.ts
@@ -74,6 +74,8 @@ export type resolveNamespaceMode<input> = "namespaces" extends keyof input
       >;
     };
 
+type resolveModules<input> = { [key in keyof input]: mergeIfUndefined<input[key], MODULE_DEFAULTS> };
+
 export type resolveWorld<input> = resolveNamespaceMode<input> &
   Omit<resolveStore<input>, "multipleNamespaces" | "namespace" | "namespaces" | "tables"> & {
     readonly tables: flattenNamespacedTables<resolveNamespaceMode<input>>;
@@ -88,7 +90,7 @@ export type resolveWorld<input> = resolveNamespaceMode<input> &
     readonly excludeSystems: "excludeSystems" extends keyof input
       ? input["excludeSystems"]
       : CONFIG_DEFAULTS["excludeSystems"];
-    readonly modules: "modules" extends keyof input ? input["modules"] : CONFIG_DEFAULTS["modules"];
+    readonly modules: "modules" extends keyof input ? resolveModules<input["modules"]> : CONFIG_DEFAULTS["modules"];
     readonly codegen: show<resolveCodegen<"codegen" extends keyof input ? input["codegen"] : {}>>;
     readonly deploy: show<resolveDeploy<"deploy" extends keyof input ? input["deploy"] : {}>>;
   };


### PR DESCRIPTION
Pulled out from #3192 - turns out we weren't resolving the module types with defaults, so if your MUD config included modules it didn't satisfy the `World` output type.