### PR TITLE
fix(explorer): better observer decorator types

### DIFF
--- a/.changeset/perfect-parrots-wonder.md
+++ b/.changeset/perfect-parrots-wonder.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/explorer": patch
+---
+
+Fixed `observer` decorator types so it can be used in more places.

--- a/packages/explorer/src/observer/decorator.ts
+++ b/packages/explorer/src/observer/decorator.ts
@@ -13,11 +13,11 @@ export type ObserverOptions = {
 
 let writeCounter = 0;
 
-export function observer<
-  transport extends Transport = Transport,
+export function observer({ explorerUrl = "http://localhost:13690", waitForStateChange }: ObserverOptions = {}): <
+  transport extends Transport,
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
->({ explorerUrl = "http://localhost:13690", waitForStateChange }: ObserverOptions = {}): (
+>(
   client: Client<transport, chain, account>,
 ) => Pick<WalletActions<chain, account>, "writeContract"> {
   const emit = createBridge({ url: `${explorerUrl}/internal/observer-relay` });

--- a/packages/explorer/src/observer/decorator.ts
+++ b/packages/explorer/src/observer/decorator.ts
@@ -13,10 +13,11 @@ export type ObserverOptions = {
 
 let writeCounter = 0;
 
-export function observer<transport extends Transport, chain extends Chain, account extends Account>({
-  explorerUrl = "http://localhost:13690",
-  waitForStateChange,
-}: ObserverOptions = {}): (
+export function observer<
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+>({ explorerUrl = "http://localhost:13690", waitForStateChange }: ObserverOptions = {}): (
   client: Client<transport, chain, account>,
 ) => Pick<WalletActions<chain, account>, "writeContract"> {
   const emit = createBridge({ url: `${explorerUrl}/internal/observer-relay` });


### PR DESCRIPTION
it's hard to extend certain clients (e.g. in a Wagmi's `createConfig`'s `client` option) without this

follows decorator patterns seen in viem 