### PR TITLE
refactor: waitForStateChange -> waitForTransaction

### DIFF
--- a/.changeset/thick-countries-double.md
+++ b/.changeset/thick-countries-double.md
@@ -1,0 +1,11 @@
+---
+"@latticexyz/explorer": patch
+---
+
+Renamed optional `waitForStateChange` param in `observer()` decorator to `waitForTransaction` to better align with `@latticexyz/store-sync` packages.
+
+```diff
+ const { waitForTransaction } = syncToZustand(...);
+-observer({ waitForStateChange: waitForTransaction });
++observer({ waitForTransaction });
+```

--- a/examples/local-explorer/packages/client/src/mud/setupNetwork.ts
+++ b/examples/local-explorer/packages/client/src/mud/setupNetwork.ts
@@ -18,7 +18,7 @@ import { getNetworkConfig } from "./getNetworkConfig";
 import IWorldAbi from "contracts/out/IWorld.sol/IWorld.abi.json";
 import { createBurnerAccount, transportObserver } from "@latticexyz/common";
 import { transactionQueue } from "@latticexyz/common/actions";
-import { observer, type WaitForStateChange } from "@latticexyz/explorer/observer";
+import { observer, type WaitForTransaction } from "@latticexyz/explorer/observer";
 
 /*
  * Import our MUD config, which includes strong types for
@@ -34,7 +34,7 @@ export type SetupNetworkResult = Awaited<ReturnType<typeof setupNetwork>>;
 
 export async function setupNetwork() {
   const networkConfig = await getNetworkConfig();
-  const waitForStateChange = Promise.withResolvers<WaitForStateChange>();
+  const waitForTx = Promise.withResolvers<WaitForTransaction>();
 
   /*
    * Create a viem public (read only) client
@@ -60,7 +60,7 @@ export async function setupNetwork() {
     .extend(transactionQueue())
     .extend(
       observer({
-        waitForStateChange: (hash) => waitForStateChange.promise.then((fn) => fn(hash)),
+        waitForTransaction: (hash) => waitForTx.promise.then((fn) => fn(hash)),
       }),
     );
 
@@ -85,7 +85,7 @@ export async function setupNetwork() {
     publicClient,
     startBlock: BigInt(networkConfig.initialBlockNumber),
   });
-  waitForStateChange.resolve(waitForTransaction);
+  waitForTx.resolve(waitForTransaction);
 
   return {
     tables,

--- a/packages/explorer/src/exports/observer.ts
+++ b/packages/explorer/src/exports/observer.ts
@@ -1,3 +1,3 @@
 export { createBridge, type CreateBridgeOpts } from "../observer/bridge";
 export type { Messages, MessageType, EmitMessage } from "../observer/messages";
-export { observer, type ObserverOptions, type WaitForStateChange } from "../observer/decorator";
+export { observer, type ObserverOptions, type WaitForTransaction } from "../observer/decorator";

--- a/packages/explorer/src/observer/decorator.ts
+++ b/packages/explorer/src/observer/decorator.ts
@@ -4,16 +4,16 @@ import { formatAbiItem, getAction } from "viem/utils";
 import { createBridge } from "./bridge";
 import { ReceiptSummary } from "./common";
 
-export type WaitForStateChange = (hash: Hex) => Promise<ReceiptSummary>;
+export type WaitForTransaction = (hash: Hex) => Promise<ReceiptSummary>;
 
 export type ObserverOptions = {
   explorerUrl?: string;
-  waitForStateChange?: WaitForStateChange;
+  waitForTransaction?: WaitForTransaction;
 };
 
 let writeCounter = 0;
 
-export function observer({ explorerUrl = "http://localhost:13690", waitForStateChange }: ObserverOptions = {}): <
+export function observer({ explorerUrl = "http://localhost:13690", waitForTransaction }: ObserverOptions = {}): <
   transport extends Transport,
   chain extends Chain | undefined = Chain | undefined,
   account extends Account | undefined = Account | undefined,
@@ -52,12 +52,12 @@ export function observer({ explorerUrl = "http://localhost:13690", waitForStateC
         });
       });
 
-      if (waitForStateChange) {
+      if (waitForTransaction) {
         write.then((hash) => {
-          const receipt = waitForStateChange(hash);
-          emit("waitForStateChange", { writeId });
+          const receipt = waitForTransaction(hash);
+          emit("waitForTransaction", { writeId });
           Promise.allSettled([receipt]).then(([result]) => {
-            emit("waitForStateChange:result", { ...result, writeId });
+            emit("waitForTransaction:result", { ...result, writeId });
           });
         });
       }

--- a/packages/explorer/src/observer/messages.ts
+++ b/packages/explorer/src/observer/messages.ts
@@ -18,10 +18,10 @@ export type Messages = {
   "waitForTransactionReceipt:result": PromiseSettledResult<ReceiptSummary> & {
     writeId: string;
   };
-  waitForStateChange: {
+  waitForTransaction: {
     writeId: string;
   };
-  "waitForStateChange:result": PromiseSettledResult<ReceiptSummary> & {
+  "waitForTransaction:result": PromiseSettledResult<ReceiptSummary> & {
     writeId: string;
   };
 };

--- a/packages/store-sync/src/stash/syncToStash.ts
+++ b/packages/store-sync/src/stash/syncToStash.ts
@@ -35,8 +35,7 @@ export type SyncToStashOptions = {
   startSync?: boolean;
 };
 
-export type SyncToStashResult = Omit<SyncResult, "waitForTransaction"> & {
-  waitForStateChange: SyncResult["waitForTransaction"];
+export type SyncToStashResult = SyncResult & {
   stopSync: () => void;
 };
 
@@ -50,7 +49,7 @@ export async function syncToStash({
 
   const storageAdapter = createStorageAdapter({ stash });
 
-  const { waitForTransaction: waitForStateChange, ...sync } = await createStoreSync({
+  const sync = await createStoreSync({
     storageAdapter,
     publicClient: client.extend(publicActions) as never,
     address,
@@ -70,7 +69,6 @@ export async function syncToStash({
 
   return {
     ...sync,
-    waitForStateChange,
     stopSync,
   };
 }


### PR DESCRIPTION
I thought moving towards `waitForStateChange` would be clearer, but realized state may not change as a result of a transaction, so reverting back to `waitForTransaction`.