### PR TITLE
feat(cli): quieter automine

### DIFF
--- a/.changeset/flat-bulldogs-smash.md
+++ b/.changeset/flat-bulldogs-smash.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Reduced the log noise from enabling/disabling automine on non-Anvil chains.

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -138,7 +138,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   console.log("Deploying from", client.account.address);
 
   // Attempt to enable automine for the duration of the deploy. Noop if automine is not available.
-  const { reset: resetMiningMode } = await enableAutomine(client);
+  const resetMiningMode = await enableAutomine(client);
 
   const startTime = Date.now();
   const worldDeploy = await deploy({

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -138,7 +138,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   console.log("Deploying from", client.account.address);
 
   // Attempt to enable automine for the duration of the deploy. Noop if automine is not available.
-  const resetMiningMode = await enableAutomine(client);
+  const automine = await enableAutomine(client);
 
   const startTime = Date.now();
   const worldDeploy = await deploy({
@@ -165,7 +165,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   }
 
   // Reset mining mode after deploy
-  await resetMiningMode?.();
+  await automine?.reset();
 
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));
 

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -165,7 +165,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   }
 
   // Reset mining mode after deploy
-  await resetMiningMode();
+  await resetMiningMode?.();
 
   console.log(chalk.green("Deployment completed in", (Date.now() - startTime) / 1000, "seconds"));
 

--- a/packages/cli/src/utils/enableAutomine.ts
+++ b/packages/cli/src/utils/enableAutomine.ts
@@ -12,14 +12,12 @@ type MiningMode =
       blockTime: number;
     };
 
-export type EnableAutomineResult = () => Promise<void>;
+export type EnableAutomineResult = undefined | (() => Promise<void>);
 
 export async function enableAutomine(client: Client): Promise<EnableAutomineResult> {
   const miningMode = await getMiningMode(client).catch(() => undefined);
   // doesn't support automine or is already in automine
-  if (!miningMode || miningMode.type === "automine") {
-    return async () => {};
-  }
+  if (!miningMode || miningMode.type === "automine") return;
 
   debug("Enabling automine");
   await setMiningMode(client, { type: "automine" });

--- a/packages/cli/src/utils/enableAutomine.ts
+++ b/packages/cli/src/utils/enableAutomine.ts
@@ -12,7 +12,7 @@ type MiningMode =
       blockTime: number;
     };
 
-export type EnableAutomineResult = undefined | (() => Promise<void>);
+export type EnableAutomineResult = undefined | { reset: () => Promise<void> };
 
 export async function enableAutomine(client: Client): Promise<EnableAutomineResult> {
   const miningMode = await getMiningMode(client).catch(() => undefined);
@@ -21,9 +21,11 @@ export async function enableAutomine(client: Client): Promise<EnableAutomineResu
 
   debug("Enabling automine");
   await setMiningMode(client, { type: "automine" });
-  return () => {
-    debug("Disabling automine");
-    return setMiningMode(client, miningMode);
+  return {
+    reset: () => {
+      debug("Disabling automine");
+      return setMiningMode(client, miningMode);
+    },
   };
 }
 


### PR DESCRIPTION
currently if you deploy to a non-anvil chain, the deploy starts out with a big error

```
  mud:cli Enabling automine +0ms
  mud:cli Skipping automine +43ms
  mud:cli MethodNotFoundRpcError: The method "anvil_getAutomine" does not exist / is not available.
  mud:cli
  mud:cli URL: [http://](https://rpc.garnetchain.com/)
  mud:cli Request body: {"method":"anvil_getAutomine"}
  mud:cli
  mud:cli Details: Method not found
  mud:cli Version: 2.21.6
  mud:cli     at withRetry.delay.count.count (/Users/kevin/Projects/latticexyz/eat-the-fly/node_modules/.pnpm/viem@2.21.6_bufferutil@4.0.8_typescript@5.4.2_utf-8-validate@5.0.10_zod@3.23.8/node_modules/viem/utils/buildRequest.ts:132:25)
  mud:cli     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

we can probably just quiet these