### PR TITLE
feat(cli): paginate world deploy logs

### DIFF
--- a/.changeset/good-crabs-trade.md
+++ b/.changeset/good-crabs-trade.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+When deploying to an existing world, the deployer now paginates with [`fetchLogs`](https://github.com/latticexyz/mud/blob/main/packages/block-logs-stream/src/fetchLogs.ts) to find the world deployment.

--- a/.changeset/large-windows-sort.md
+++ b/.changeset/large-windows-sort.md
@@ -3,5 +3,5 @@
 ---
 
 - For block range size errors, `fetchLogs` now reduces the max block range for subsequent requests in its loop. For block out of range or response size errors, only the current request's block range is reduced until the request succeeds, then it resets to the max block range.
-- Added `fetchBlockLogs` to request all block logs in one async call rather than an async generator.
+- Added `fetchBlockLogs` to find all matching logs of the given block range, grouped by block number, in a single async call.
 - Loosened the `publicClient` type and switched to tree shakable actions.

--- a/.changeset/large-windows-sort.md
+++ b/.changeset/large-windows-sort.md
@@ -2,6 +2,6 @@
 "@latticexyz/block-logs-stream": patch
 ---
 
-- For block range size errors, `fetchLogs` now reduces the max block range for subsequent requests in its loop. For block out of range or response size errors, only the block range is reduced until the request succeeds, then it resets to the max block range.
+- For block range size errors, `fetchLogs` now reduces the max block range for subsequent requests in its loop. For block out of range or response size errors, only the current request's block range is reduced until the request succeeds, then it resets to the max block range.
 - Added `fetchBlockLogs` to request all block logs in one async call rather than an async generator.
 - Loosened the `publicClient` type and switched to tree shakable actions.

--- a/.changeset/large-windows-sort.md
+++ b/.changeset/large-windows-sort.md
@@ -1,0 +1,7 @@
+---
+"@latticexyz/block-logs-stream": patch
+---
+
+- For block range size errors, `fetchLogs` now reduces the max block range for subsequent requests in its loop. For block out of range or response size errors, only the block range is reduced until the request succeeds, then it resets to the max block range.
+- Added `fetchBlockLogs` to request all block logs in one async call rather than an async generator.
+- Loosened the `publicClient` type and switched to tree shakable actions.

--- a/packages/block-logs-stream/src/blockRangeToLogs.test.ts
+++ b/packages/block-logs-stream/src/blockRangeToLogs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { blockRangeToLogs } from "./blockRangeToLogs";
 import { Subject, lastValueFrom, map, toArray } from "rxjs";
-import { EIP1193RequestFn, RpcLog, Transport, createPublicClient, createTransport } from "viem";
+import { EIP1193RequestFn, RpcLog, Transport, createClient, createTransport } from "viem";
 import { wait } from "@latticexyz/common/utils";
 
 vi.useFakeTimers();
@@ -14,9 +14,10 @@ const mockTransport: Transport = () =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     request: mockedTransportRequest as any,
     type: "mock",
+    retryCount: 0,
   });
 
-const publicClient = createPublicClient({
+const publicClient = createClient({
   transport: mockTransport,
 });
 

--- a/packages/block-logs-stream/src/blockRangeToLogs.ts
+++ b/packages/block-logs-stream/src/blockRangeToLogs.ts
@@ -1,16 +1,16 @@
 import { EMPTY, OperatorFunction, concatMap, from, pipe, tap } from "rxjs";
 import { FetchLogsResult, fetchLogs } from "./fetchLogs";
 import { AbiEvent } from "abitype";
-import { Address, BlockNumber, PublicClient } from "viem";
+import { Address, BlockNumber, Client } from "viem";
 import { debug } from "./debug";
 
-export type BlockRangeToLogsOptions<TAbiEvents extends readonly AbiEvent[]> = {
+export type BlockRangeToLogsOptions<abiEvents extends readonly AbiEvent[]> = {
   /**
-   * [viem `PublicClient`][0] used for fetching logs from the RPC.
+   * [viem `Client`][0] used for fetching logs from the RPC.
    *
    * [0]: https://viem.sh/docs/clients/public.html
    */
-  publicClient: PublicClient;
+  publicClient: Client;
   /**
    * Optional contract address(es) to fetch logs for.
    */
@@ -18,16 +18,16 @@ export type BlockRangeToLogsOptions<TAbiEvents extends readonly AbiEvent[]> = {
   /**
    * Events to fetch logs for.
    */
-  events: TAbiEvents;
+  events: abiEvents;
   /**
    * Optional maximum block range, if your RPC limits the amount of blocks fetched at a time.
    */
   maxBlockRange?: bigint;
 };
 
-export type BlockRangeToLogsResult<TAbiEvents extends readonly AbiEvent[]> = OperatorFunction<
+export type BlockRangeToLogsResult<abiEvents extends readonly AbiEvent[]> = OperatorFunction<
   { startBlock: BlockNumber; endBlock: BlockNumber },
-  FetchLogsResult<TAbiEvents>
+  FetchLogsResult<abiEvents>
 >;
 
 /**
@@ -38,12 +38,12 @@ export type BlockRangeToLogsResult<TAbiEvents extends readonly AbiEvent[]> = Ope
  * @param {BlockRangeToLogsOptions<AbiEvent[]>} options See `BlockRangeToLogsOptions`.
  * @returns {BlockRangeToLogsResult<AbiEvent[]>} An operator function that transforms a stream of block ranges into a stream of fetched logs.
  */
-export function blockRangeToLogs<TAbiEvents extends readonly AbiEvent[]>({
+export function blockRangeToLogs<abiEvents extends readonly AbiEvent[]>({
   publicClient,
   address,
   events,
   maxBlockRange,
-}: BlockRangeToLogsOptions<TAbiEvents>): BlockRangeToLogsResult<TAbiEvents> {
+}: BlockRangeToLogsOptions<abiEvents>): BlockRangeToLogsResult<abiEvents> {
   let fromBlock: bigint;
   let toBlock: bigint;
 
@@ -56,7 +56,7 @@ export function blockRangeToLogs<TAbiEvents extends readonly AbiEvent[]>({
     // so it always uses the latest `toBlock` value.
     concatMap(() => {
       if (fromBlock > toBlock) return EMPTY;
-      debug("fetching logs for block range", { fromBlock, toBlock });
+      debug(`fetching logs for block range ${fromBlock}-${toBlock}`);
       return from(
         fetchLogs({
           publicClient,

--- a/packages/block-logs-stream/src/createBlockStream.ts
+++ b/packages/block-logs-stream/src/createBlockStream.ts
@@ -1,19 +1,25 @@
 import { Observable } from "rxjs";
-import type { Block, BlockTag, PublicClient } from "viem";
+import type { Block, BlockTag, Client } from "viem";
+import { watchBlocks } from "viem/actions";
+import { getAction } from "viem/utils";
 
-export type CreateBlockStreamOptions<TBlockTag extends BlockTag> = {
-  publicClient: PublicClient;
-  blockTag: TBlockTag;
+export type CreateBlockStreamOptions<blockTag extends BlockTag> = {
+  publicClient: Client;
+  blockTag: blockTag;
 };
 
-export type CreateBlockStreamResult<TBlockTag extends BlockTag> = Observable<Block<bigint, false, TBlockTag>>;
+export type CreateBlockStreamResult<blockTag extends BlockTag> = Observable<Block<bigint, false, blockTag>>;
 
-export function createBlockStream<TBlockTag extends BlockTag>({
+export function createBlockStream<blockTag extends BlockTag>({
   publicClient,
   blockTag,
-}: CreateBlockStreamOptions<TBlockTag>): CreateBlockStreamResult<TBlockTag> {
+}: CreateBlockStreamOptions<blockTag>): CreateBlockStreamResult<blockTag> {
   return new Observable(function subscribe(subscriber) {
-    return publicClient.watchBlocks({
+    return getAction(
+      publicClient,
+      watchBlocks,
+      "watchBlocks",
+    )({
       blockTag,
       emitOnBegin: true,
       onBlock: (block) => subscriber.next(block),

--- a/packages/block-logs-stream/src/fetchBlockLogs.ts
+++ b/packages/block-logs-stream/src/fetchBlockLogs.ts
@@ -1,6 +1,7 @@
-import { AbiEvent, Log } from "viem";
+import { AbiEvent } from "viem";
 import { GroupLogsByBlockNumberResult, groupLogsByBlockNumber } from "./groupLogsByBlockNumber";
 import { FetchLogsOptions, FetchLogsResult, fetchLogs } from "./fetchLogs";
+import { iteratorToArray } from "@latticexyz/common/utils";
 
 /**
  * Fetches all logs from the blockchain for the given range, grouped by block number.
@@ -12,14 +13,14 @@ import { FetchLogsOptions, FetchLogsResult, fetchLogs } from "./fetchLogs";
  *
  * @param {FetchLogsOptions<AbiEvent[]>} options See `FetchLogsOptions`.
  *
+ * @returns {GroupLogsByBlockNumberResult} See `GroupLogsByBlockNumberResult`.
+ *
  * @throws Will throw an error if the block range can't be reduced any further.
  */
 export async function fetchBlockLogs<abiEvents extends readonly AbiEvent[]>(
   opts: FetchLogsOptions<abiEvents>,
-): Promise<GroupLogsByBlockNumberResult<Log<bigint, number, false, undefined, true, abiEvents, undefined>>> {
-  const results: FetchLogsResult<abiEvents>[] = [];
-  for await (const result of fetchLogs(opts)) {
-    results.push(result);
-  }
-  return groupLogsByBlockNumber(results.flatMap((result) => result.logs));
+): Promise<GroupLogsByBlockNumberResult<FetchLogsResult<abiEvents>["logs"][number]>> {
+  const fetchedLogs = await iteratorToArray(fetchLogs(opts));
+  const logs = fetchedLogs.flatMap(({ logs }) => logs);
+  return groupLogsByBlockNumber(logs);
 }

--- a/packages/block-logs-stream/src/fetchBlockLogs.ts
+++ b/packages/block-logs-stream/src/fetchBlockLogs.ts
@@ -1,0 +1,25 @@
+import { AbiEvent, Log } from "viem";
+import { GroupLogsByBlockNumberResult, groupLogsByBlockNumber } from "./groupLogsByBlockNumber";
+import { FetchLogsOptions, FetchLogsResult, fetchLogs } from "./fetchLogs";
+
+/**
+ * Fetches all logs from the blockchain for the given range, grouped by block number.
+ *
+ * @remarks
+ * The function will fetch logs according to the given options.
+ * If the function encounters rate limits, it will retry until `maxRetryCount` is reached.
+ * If the function encounters a block range that is too large, it will half the block range and retry, until the block range can't be halved anymore.
+ *
+ * @param {FetchLogsOptions<AbiEvent[]>} options See `FetchLogsOptions`.
+ *
+ * @throws Will throw an error if the block range can't be reduced any further.
+ */
+export async function fetchBlockLogs<abiEvents extends readonly AbiEvent[]>(
+  opts: FetchLogsOptions<abiEvents>,
+): Promise<GroupLogsByBlockNumberResult<Log<bigint, number, false, undefined, true, abiEvents, undefined>>> {
+  const results: FetchLogsResult<abiEvents>[] = [];
+  for await (const result of fetchLogs(opts)) {
+    results.push(result);
+  }
+  return groupLogsByBlockNumber(results.flatMap((result) => result.logs));
+}

--- a/packages/block-logs-stream/src/fetchLogs.test.ts
+++ b/packages/block-logs-stream/src/fetchLogs.test.ts
@@ -5,7 +5,7 @@ import {
   RpcLog,
   RpcRequestError,
   Transport,
-  createPublicClient,
+  createClient,
   createTransport,
   hexToNumber,
 } from "viem";
@@ -19,9 +19,10 @@ const mockTransport: Transport = () =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     request: mockedTransportRequest as any,
     type: "mock",
+    retryCount: 0,
   });
 
-const publicClient = createPublicClient({
+const publicClient = createClient({
   transport: mockTransport,
 });
 
@@ -189,77 +190,7 @@ describe("fetchLogs", () => {
           {
             "address": "0x",
             "fromBlock": "0x0",
-            "toBlock": "0x3e8",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x0",
-            "toBlock": "0x3e8",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x0",
-            "toBlock": "0x3e8",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x0",
             "toBlock": "0x1f4",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x1f5",
-            "toBlock": "0x5dd",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x1f5",
-            "toBlock": "0x5dd",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x1f5",
-            "toBlock": "0x5dd",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x1f5",
-            "toBlock": "0x5dd",
             "topics": [
               [],
             ],
@@ -279,7 +210,7 @@ describe("fetchLogs", () => {
           {
             "address": "0x",
             "fromBlock": "0x3ea",
-            "toBlock": "0x7d0",
+            "toBlock": "0x5de",
             "topics": [
               [],
             ],
@@ -288,47 +219,7 @@ describe("fetchLogs", () => {
         [
           {
             "address": "0x",
-            "fromBlock": "0x3ea",
-            "toBlock": "0x7d0",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x3ea",
-            "toBlock": "0x7d0",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x3ea",
-            "toBlock": "0x7d0",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x3ea",
-            "toBlock": "0x5dd",
-            "topics": [
-              [],
-            ],
-          },
-        ],
-        [
-          {
-            "address": "0x",
-            "fromBlock": "0x5de",
+            "fromBlock": "0x5df",
             "toBlock": "0x7d0",
             "topics": [
               [],
@@ -353,10 +244,10 @@ describe("fetchLogs", () => {
         {
           "fromBlock": 1002n,
           "logs": [],
-          "toBlock": 1501n,
+          "toBlock": 1502n,
         },
         {
-          "fromBlock": 1502n,
+          "fromBlock": 1503n,
           "logs": [],
           "toBlock": 2000n,
         },

--- a/packages/block-logs-stream/src/fetchLogs.ts
+++ b/packages/block-logs-stream/src/fetchLogs.ts
@@ -45,6 +45,7 @@ export type FetchLogsResult<abiEvents extends readonly AbiEvent[]> = {
 };
 
 const RATE_LIMIT_ERRORS = [
+  // tests
   "rate limit exceeded",
   // https://github.com/ethereum-optimism/optimism/blob/4fb534ab3d924ac87383e1e70ae4872340d68d9d/proxyd/backend.go#L83
   "over rate limit",
@@ -54,6 +55,7 @@ const RATE_LIMIT_ERRORS = [
 
 // These errors will reduce the max block range for all remaining iterations.
 const MAX_BLOCK_RANGE_ERRORS = [
+  // tests
   "block range exceeded",
   // https://github.com/ethereum-optimism/optimism/blob/4fb534ab3d924ac87383e1e70ae4872340d68d9d/proxyd/rewriter.go#L36
   "block range is too large",
@@ -104,7 +106,7 @@ export async function* fetchLogs<abiEvents extends readonly AbiEvent[]>({
   while (fromBlock <= getLogsOpts.toBlock) {
     try {
       const toBlock = fromBlock + blockRange;
-      debug("getting logs", { fromBlock, toBlock, blockRange });
+      debug(`getting logs for blocks ${fromBlock}-${toBlock} (${blockRange} blocks, ${maxBlockRange} max)`);
       const logs = await getAction(
         publicClient,
         getLogs,
@@ -119,7 +121,7 @@ export async function* fetchLogs<abiEvents extends readonly AbiEvent[]>({
 
       if (retryCount < maxRetryCount && RATE_LIMIT_ERRORS.some((e) => error.message.includes(e))) {
         const seconds = 2 * retryCount;
-        debug(`too many requests, retrying in ${seconds}s`, error);
+        debug(`too many requests, retrying in ${seconds}s`);
         await wait(1000 * seconds);
         retryCount += 1;
         continue;
@@ -135,7 +137,7 @@ export async function* fetchLogs<abiEvents extends readonly AbiEvent[]>({
         if (isMaxBlockRangeError) {
           maxBlockRange = blockRange;
         }
-        debug(`got block range error, trying a block range of ${blockRange} (max ${maxBlockRange})`);
+        debug(`got block range error, retrying with ${blockRange} blocks, ${maxBlockRange} max`);
         continue;
       }
 

--- a/packages/block-logs-stream/src/groupLogsByBlockNumber.ts
+++ b/packages/block-logs-stream/src/groupLogsByBlockNumber.ts
@@ -1,11 +1,11 @@
 import { BlockNumber } from "viem";
 import { bigIntSort, isDefined } from "@latticexyz/common/utils";
 
-type PartialLog = { blockNumber: bigint; logIndex: number };
+type PartialLog = { readonly blockNumber: bigint; readonly logIndex: number };
 
 export type GroupLogsByBlockNumberResult<log extends PartialLog> = {
-  blockNumber: log["blockNumber"];
-  logs: readonly log[];
+  readonly blockNumber: log["blockNumber"];
+  readonly logs: readonly log[];
 }[];
 
 /**

--- a/packages/block-logs-stream/src/groupLogsByBlockNumber.ts
+++ b/packages/block-logs-stream/src/groupLogsByBlockNumber.ts
@@ -3,9 +3,9 @@ import { bigIntSort, isDefined } from "@latticexyz/common/utils";
 
 type PartialLog = { blockNumber: bigint; logIndex: number };
 
-export type GroupLogsByBlockNumberResult<TLog extends PartialLog> = {
-  blockNumber: TLog["blockNumber"];
-  logs: TLog[];
+export type GroupLogsByBlockNumberResult<log extends PartialLog> = {
+  blockNumber: log["blockNumber"];
+  logs: readonly log[];
 }[];
 
 /**
@@ -22,10 +22,10 @@ export type GroupLogsByBlockNumberResult<TLog extends PartialLog> = {
  * @returns An array of objects where each object represents a distinct block and includes the block number,
  * the block hash, and an array of logs for that block.
  */
-export function groupLogsByBlockNumber<TLog extends PartialLog>(
-  logs: readonly TLog[],
+export function groupLogsByBlockNumber<log extends PartialLog>(
+  logs: readonly log[],
   toBlock?: BlockNumber,
-): GroupLogsByBlockNumberResult<TLog> {
+): GroupLogsByBlockNumberResult<log> {
   const blockNumbers = Array.from(new Set(logs.map((log) => log.blockNumber)));
   blockNumbers.sort(bigIntSort);
 

--- a/packages/block-logs-stream/src/index.ts
+++ b/packages/block-logs-stream/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./blockRangeToLogs";
 export * from "./createBlockStream";
+export * from "./fetchBlockLogs";
 export * from "./fetchLogs";
 export * from "./groupLogsByBlockNumber";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "@ark/util": "catalog:",
     "@aws-sdk/client-kms": "^3.556.0",
     "@latticexyz/abi-ts": "workspace:*",
+    "@latticexyz/block-logs-stream": "workspace:*",
     "@latticexyz/common": "workspace:*",
     "@latticexyz/config": "workspace:*",
     "@latticexyz/gas-report": "workspace:*",

--- a/packages/cli/src/deploy/getWorldDeploy.ts
+++ b/packages/cli/src/deploy/getWorldDeploy.ts
@@ -1,5 +1,6 @@
 import { Client, Address, getAddress, parseAbi } from "viem";
-import { getBlockNumber, getLogs } from "viem/actions";
+import { getBlock } from "viem/actions";
+import { fetchBlockLogs } from "@latticexyz/block-logs-stream";
 import { WorldDeploy, worldDeployEvents } from "./common";
 import { debug } from "./debug";
 import { logsToWorldDeploy } from "./logsToWorldDeploy";
@@ -16,20 +17,22 @@ export async function getWorldDeploy(client: Client, worldAddress: Address): Pro
 
   debug("looking up world deploy for", address);
 
-  const stateBlock = await getBlockNumber(client);
-  const logs = await getLogs(client, {
-    strict: true,
+  const [fromBlock, toBlock] = await Promise.all([
+    getBlock(client, { blockTag: "earliest" }),
+    getBlock(client, { blockTag: "latest" }),
+  ]);
+
+  const blockLogs = await fetchBlockLogs({
+    publicClient: client,
     address,
     events: parseAbi(worldDeployEvents),
-    // this may fail for certain RPC providers with block range limits
-    // if so, could potentially use our fetchLogs helper (which does pagination)
-    fromBlock: "earliest",
-    toBlock: stateBlock,
+    fromBlock: fromBlock.number,
+    toBlock: toBlock.number,
   });
 
   deploy = {
-    ...logsToWorldDeploy(logs),
-    stateBlock,
+    ...logsToWorldDeploy(blockLogs.flatMap((block) => block.logs)),
+    stateBlock: toBlock.number,
   };
   deploys.set(address, deploy);
 

--- a/packages/cli/src/deploy/getWorldDeploy.ts
+++ b/packages/cli/src/deploy/getWorldDeploy.ts
@@ -28,6 +28,7 @@ export async function getWorldDeploy(client: Client, worldAddress: Address): Pro
     events: parseAbi(worldDeployEvents),
     fromBlock: fromBlock.number,
     toBlock: toBlock.number,
+    maxBlockRange: 100_000n,
   });
 
   deploy = {

--- a/packages/common/src/utils/iteratorToArray.ts
+++ b/packages/common/src/utils/iteratorToArray.ts
@@ -1,4 +1,4 @@
-export async function iteratorToArray<T>(iterator: AsyncIterable<T>): Promise<T[]> {
+export async function iteratorToArray<T>(iterator: AsyncIterable<T>): Promise<readonly T[]> {
   const items: T[] = [];
   for await (const item of iterator) {
     items.push(item);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@latticexyz/abi-ts':
         specifier: workspace:*
         version: link:../abi-ts
+      '@latticexyz/block-logs-stream':
+        specifier: workspace:*
+        version: link:../block-logs-stream
       '@latticexyz/common':
         specifier: workspace:*
         version: link:../common
@@ -13930,7 +13933,7 @@ snapshots:
       '@motionone/easing': 10.18.0
       '@motionone/types': 10.17.1
       '@motionone/utils': 10.18.0
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/dom@10.18.0':
     dependencies:
@@ -13939,23 +13942,23 @@ snapshots:
       '@motionone/types': 10.17.1
       '@motionone/utils': 10.18.0
       hey-listen: 1.0.8
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/easing@10.18.0':
     dependencies:
       '@motionone/utils': 10.18.0
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/generators@10.18.0':
     dependencies:
       '@motionone/types': 10.17.1
       '@motionone/utils': 10.18.0
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/svelte@10.16.4':
     dependencies:
       '@motionone/dom': 10.18.0
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/types@10.17.1': {}
 
@@ -13963,12 +13966,12 @@ snapshots:
     dependencies:
       '@motionone/types': 10.17.1
       hey-listen: 1.0.8
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@motionone/vue@10.16.4':
     dependencies:
       '@motionone/dom': 10.18.0
-      tslib: 2.6.2
+      tslib: 2.7.0
 
   '@next/env@14.2.5': {}
 


### PR DESCRIPTION
pulled out of https://github.com/latticexyz/mud/pull/3215
related to https://github.com/latticexyz/mud/issues/1522
closes https://github.com/latticexyz/mud/issues/2729

leans on `fetchLogs` to get all logs of a given range, paginating and reducing block range as needed