### PR TITLE
refactor(cli): adjust deploy order

### DIFF
--- a/.changeset/tricky-chefs-care.md
+++ b/.changeset/tricky-chefs-care.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Adjusted deploy order so that the world deploy happens before everything else to avoid spending gas on system contract deploys, etc. if a world cannot be created first.


### PR DESCRIPTION
deploy world then user contracts instead of the other way around, to keep from spending gas on contract deploys in cases where world deploy fails
