### PR TITLE
feat(explorer): move filter state to url

### DIFF
--- a/.changeset/sixty-comics-love.md
+++ b/.changeset/sixty-comics-love.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/explorer": patch
+---
+
+Added support for tracking table filtering, sorting, and additional parameters like selected tableId using type-safe URL search params. This ensures that state changes persist across sessions and can be shared with a URL.

--- a/.changeset/sixty-comics-love.md
+++ b/.changeset/sixty-comics-love.md
@@ -2,4 +2,4 @@
 "@latticexyz/explorer": patch
 ---
 
-Added support for tracking table filtering, sorting, and additional parameters like selected tableId using type-safe URL search params. This ensures that state changes persist across sessions and can be shared with a URL.
+Table filters are now included as part of the URL. This enables deep links and improves navigating between pages without losing search state.

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -61,6 +61,7 @@
     "debug": "^4.3.4",
     "lucide-react": "^0.408.0",
     "next": "14.2.5",
+    "nuqs": "^1.19.2",
     "query-string": "^9.1.0",
     "react": "^18",
     "react-dom": "^18",

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/DataExplorer.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/DataExplorer.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { Loader } from "lucide-react";
-import { useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { TableSelector } from "./TableSelector";
 import { TablesViewer } from "./TablesViewer";
 
 export function DataExplorer() {
-  const searchParams = useSearchParams();
   const { data: tables, isLoading } = useQuery({
     queryKey: ["tables"],
     queryFn: async () => {
@@ -16,7 +14,6 @@ export function DataExplorer() {
       if (!response.ok) {
         throw new Error(json.error);
       }
-
       return json;
     },
     select: (data) => data.tables.map((table: { name: string }) => table.name),
@@ -24,7 +21,6 @@ export function DataExplorer() {
     throwOnError: true,
     retry: false,
   });
-  const selectedTable = searchParams.get("tableId") || (tables?.length > 0 ? tables[0] : null);
 
   if (isLoading) {
     return <Loader className="animate-spin" />;
@@ -32,8 +28,8 @@ export function DataExplorer() {
 
   return (
     <>
-      <TableSelector value={selectedTable} options={tables} />
-      <TablesViewer table={selectedTable} />
+      <TableSelector tables={tables} />
+      <TablesViewer />
     </>
   );
 }

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
@@ -1,11 +1,10 @@
 import { ArrowUpDown, Loader } from "lucide-react";
-import { parseAsArrayOf, parseAsBoolean, parseAsJson, parseAsString, useQueryState } from "nuqs";
-import { useRef } from "react";
+import { parseAsBoolean, parseAsJson, parseAsString, useQueryState } from "nuqs";
 import { internalTableNames } from "@latticexyz/store-sync/sqlite";
 import { useQuery } from "@tanstack/react-query";
 import {
   ColumnDef,
-  ColumnSort,
+  SortingState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -20,14 +19,13 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { bufferToBigInt } from "../utils/bufferToBigInt";
 import { EditableTableCell } from "./EditableTableCell";
 
+const emptyColumnSort: SortingState = [];
+
 export function TablesViewer() {
   const [selectedTableId] = useQueryState("tableId");
   const [globalFilter, setGlobalFilter] = useQueryState("filter", parseAsString.withDefault(""));
   const [showAllColumns, setShowAllColumns] = useQueryState("showAllColumns", parseAsBoolean.withDefault(false));
-  const [sorting, setSorting] = useQueryState(
-    "sort",
-    parseAsArrayOf(parseAsJson<ColumnSort>()).withDefault(useRef([]).current),
-  );
+  const [sorting, setSorting] = useQueryState("sort", parseAsJson<SortingState>().withDefault(emptyColumnSort));
 
   const { data: schema } = useQuery({
     queryKey: ["schema", { table: selectedTableId }],

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
@@ -1,6 +1,5 @@
 import { ArrowUpDown, Loader } from "lucide-react";
-import { parseAsBoolean, useQueryState } from "nuqs";
-import { useState } from "react";
+import { parseAsBoolean, parseAsJson, useQueryState } from "nuqs";
 import { internalTableNames } from "@latticexyz/store-sync/sqlite";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -23,8 +22,8 @@ import { EditableTableCell } from "./EditableTableCell";
 export function TablesViewer() {
   const [selectedTableId] = useQueryState("tableId");
   const [globalFilter, setGlobalFilter] = useQueryState("globalFilter");
-  const [showAllColumns, setShowAllColumns] = useQueryState("showAllColumns", parseAsBoolean);
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [showAllColumns, setShowAllColumns] = useQueryState("showAllColumns", parseAsBoolean.withDefault(false));
+  const [sorting, setSorting] = useQueryState("sorting", parseAsJson<SortingState>().withDefault([]));
 
   const { data: schema } = useQuery({
     queryKey: ["schema", { table: selectedTableId }],

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
@@ -19,18 +19,18 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { bufferToBigInt } from "../utils/bufferToBigInt";
 import { EditableTableCell } from "./EditableTableCell";
 
-const emptyColumnSort: SortingState = [];
+const initialSortingState: SortingState = [];
 
 export function TablesViewer() {
-  const [selectedTableId] = useQueryState("tableId");
+  const [selectedTableId] = useQueryState("tableId", parseAsString.withDefault(""));
   const [globalFilter, setGlobalFilter] = useQueryState("filter", parseAsString.withDefault(""));
   const [showAllColumns, setShowAllColumns] = useQueryState("showAllColumns", parseAsBoolean.withDefault(false));
-  const [sorting, setSorting] = useQueryState("sort", parseAsJson<SortingState>().withDefault(emptyColumnSort));
+  const [sorting, setSorting] = useQueryState("sort", parseAsJson<SortingState>().withDefault(initialSortingState));
 
   const { data: schema } = useQuery({
     queryKey: ["schema", { table: selectedTableId }],
     queryFn: async () => {
-      const response = await fetch(`/api/schema?table=${selectedTableId}`);
+      const response = await fetch(`/api/schema?${new URLSearchParams({ table: selectedTableId })}`);
       return response.json();
     },
     select: (data) => {
@@ -41,12 +41,13 @@ export function TablesViewer() {
         return !column.name.startsWith("__");
       });
     },
+    enabled: Boolean(selectedTableId),
   });
 
   const { data: rows } = useQuery({
     queryKey: ["rows", { table: selectedTableId }],
     queryFn: async () => {
-      const response = await fetch(`/api/rows?table=${selectedTableId}`);
+      const response = await fetch(`/api/rows?${new URLSearchParams({ table: selectedTableId })}`);
       return response.json();
     },
     select: (data) => {
@@ -68,7 +69,7 @@ export function TablesViewer() {
   const { data: mudTableConfig } = useQuery({
     queryKey: ["table", { selectedTableId }],
     queryFn: async () => {
-      const response = await fetch(`/api/table?table=${selectedTableId}`);
+      const response = await fetch(`/api/table?${new URLSearchParams({ table: selectedTableId })}`);
       return response.json();
     },
     select: (data) => {

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TablesViewer.tsx
@@ -1,10 +1,11 @@
 import { ArrowUpDown, Loader } from "lucide-react";
-import { parseAsBoolean, parseAsJson, useQueryState } from "nuqs";
+import { parseAsArrayOf, parseAsBoolean, parseAsJson, parseAsString, useQueryState } from "nuqs";
+import { useRef } from "react";
 import { internalTableNames } from "@latticexyz/store-sync/sqlite";
 import { useQuery } from "@tanstack/react-query";
 import {
   ColumnDef,
-  SortingState,
+  ColumnSort,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -21,9 +22,12 @@ import { EditableTableCell } from "./EditableTableCell";
 
 export function TablesViewer() {
   const [selectedTableId] = useQueryState("tableId");
-  const [globalFilter, setGlobalFilter] = useQueryState("globalFilter");
+  const [globalFilter, setGlobalFilter] = useQueryState("filter", parseAsString.withDefault(""));
   const [showAllColumns, setShowAllColumns] = useQueryState("showAllColumns", parseAsBoolean.withDefault(false));
-  const [sorting, setSorting] = useQueryState("sorting", parseAsJson<SortingState>().withDefault([]));
+  const [sorting, setSorting] = useQueryState(
+    "sort",
+    parseAsArrayOf(parseAsJson<ColumnSort>()).withDefault(useRef([]).current),
+  );
 
   const { data: schema } = useQuery({
     queryKey: ["schema", { table: selectedTableId }],
@@ -160,7 +164,7 @@ export function TablesViewer() {
       <div className="flex items-center justify-between gap-4 pb-4">
         <Input
           placeholder="Filter all columns..."
-          value={globalFilter ?? ""}
+          value={globalFilter}
           onChange={(event) => table.setGlobalFilter(event.target.value)}
           className="max-w-sm rounded border px-2 py-1"
         />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       next:
         specifier: 14.2.5
         version: 14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      nuqs:
+        specifier: ^1.19.2
+        version: 1.19.2(next@14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       query-string:
         specifier: ^9.1.0
         version: 9.1.0
@@ -8596,6 +8599,9 @@ packages:
       typescript:
         optional: true
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -8797,6 +8803,11 @@ packages:
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  nuqs@1.19.2:
+    resolution: {integrity: sha512-r6Hw44yMg8tuxr+zS4AmeB+Z++j1pT99DuCfy+XmouCBaXHHhBPOoWZQQuSUI0ja2s00v6o96HdSnvq2/5qOyw==}
+    peerDependencies:
+      next: '>=13.4 <14.0.2 || ^14.0.3'
 
   nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
@@ -20875,6 +20886,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.2
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -21060,6 +21073,11 @@ snapshots:
       set-blocking: 2.0.0
 
   nullthrows@1.1.1: {}
+
+  nuqs@1.19.2(next@14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+    dependencies:
+      mitt: 3.0.1
+      next: 14.2.5(@babel/core@7.25.2)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   nwsapi@2.2.7: {}
 


### PR DESCRIPTION
Added type-safe URL search params using `nuqs`. Given that the Explorer is going to have more filters, and other state, in the future, it's useful to add it now. Also, table state is now stored in URL search params as well so it can be shared. 