### PR TITLE
fix(explorer): display nested inputs

### DIFF
--- a/.changeset/hip-rings-rule.md
+++ b/.changeset/hip-rings-rule.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/explorer": patch
+---
+
+Fixed object inputs display in the transactions table row.

--- a/.changeset/hip-rings-rule.md
+++ b/.changeset/hip-rings-rule.md
@@ -2,4 +2,4 @@
 "@latticexyz/explorer": patch
 ---
 
-Fixed object inputs display in the transactions table row.
+Fixed inputs display in the transactions table row.

--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/observe/TransactionTableRow.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/observe/TransactionTableRow.tsx
@@ -86,7 +86,9 @@ export function TransactionTableRow({ row }: { row: Row<WatchedTransaction> }) {
                       {data.functionData?.args?.map((arg, idx) => (
                         <div key={idx} className="flex">
                           <span className="flex-shrink-0 text-xs text-white/60">arg {idx + 1}:</span>
-                          <span className="ml-2 text-xs">{String(arg)}</span>
+                          <span className="ml-2 whitespace-pre-wrap text-xs">
+                            {typeof arg === "object" && arg !== null ? JSON.stringify(arg, null, 2) : String(arg)}
+                          </span>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
Nested inputs would show up as `[Object object]` before. Now showing the full input.

![CleanShot 2024-10-08 at 13 06 30](https://github.com/user-attachments/assets/ddaeb314-6c0e-4e29-be2d-cac8fd846920)
