### PR TITLE
docs: correct msg.sender in emojimon

### DIFF
--- a/docs/pages/guides/emojimon/3-players-and-movement.mdx
+++ b/docs/pages/guides/emojimon/3-players-and-movement.mdx
@@ -127,7 +127,7 @@ The `spawn` function spawns a new player entity on the map.
 ```
 
 In certain cases systems are called by [a MUD `World`](/world) using the call opcode.
-In that case, `msg.sender()` is the `World` that called the system, not the actual player.
+In that case, `msg.sender` is the `World` that called the system, not the actual player.
 `_msgSender()` takes care of this and gives us the real user identity, the one who called the `World`.
 
 ```solidity


### PR DESCRIPTION
In Solidity, `msg.sender` is not a function, so the docs are incorrect and this is confusing. This corrects it so it makes sense.