### PR TITLE
build: improve tsup config for turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "mud-monorepo",
   "private": true,
   "repository": {
     "type": "git",
@@ -12,7 +13,7 @@
     "build": "turbo run build --concurrency=100%",
     "changelog:generate": "tsx scripts/changelog.ts",
     "clean": "turbo run clean --concurrency=100%",
-    "dev": "TSUP_SKIP_DTS=true turbo run dev --concurrency=100% --filter !@latticexyz/explorer",
+    "dev": "turbo run dev --concurrency=999",
     "dist-tag-rm": "pnpm recursive exec -- sh -c 'npm dist-tag rm $(cat package.json | jq -r \".name\") $TAG || true'",
     "docs:generate:api": "tsx scripts/render-api-docs.ts",
     "fix:package-json": "sort-package-json package.json 'packages/*/package.json' 'templates/*/package.json' 'templates/*/packages/*/package.json' 'examples/*/package.json' 'examples/*/packages/*/package.json' 'e2e/*/package.json' 'e2e/*/packages/*/package.json' 'docs/package.json' 'test/*/package.json'",

--- a/packages/abi-ts/tsup.config.ts
+++ b/packages/abi-ts/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts", "src/abi-ts.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/block-logs-stream/tsup.config.ts
+++ b/packages/block-logs-stream/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -17,15 +17,20 @@ const mudPackages: MudPackages = Object.fromEntries(
     .map(([localPath, packageJson]) => [packageJson.name, { localPath }]),
 );
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts", "src/mud.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
   env: {
     MUD_PACKAGES: JSON.stringify(mudPackages),
   },
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/common/tsup.config.ts
+++ b/packages/common/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     index: "src/index.ts",
     actions: "src/actions/index.ts",
@@ -14,8 +14,13 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     index: "src/exports/index.ts",
     internal: "src/exports/internal.ts",
@@ -8,8 +8,13 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/create-mud/tsup.config.ts
+++ b/packages/create-mud/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/cli.ts"],
   minify: true,
   sourcemap: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/dev-tools/tsup.config.ts
+++ b/packages/dev-tools/tsup.config.ts
@@ -12,17 +12,22 @@ import packageJson from "./package.json";
 const peerDeps = Object.keys(packageJson.peerDependencies);
 const bundledDeps = Object.keys(packageJson.dependencies).filter((dep) => !peerDeps.includes(dep));
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
   injectStyle: true,
   // bundle all non-peer deps
   noExternal: bundledDeps,
   // don't code split otherwise dep imports in bundle seem to break
   splitting: false,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/explorer/tsup.config.ts
+++ b/packages/explorer/tsup.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   tsconfig: "tsconfig.tsup.json",
   entry: ["src/bin/explorer.ts", "src/exports/observer.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: false,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/faucet/tsup.config.ts
+++ b/packages/faucet/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts", "bin/faucet-server.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/gas-report/tsup.config.ts
+++ b/packages/gas-report/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["ts/index.ts", "ts/gas-report.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/protocol-parser/tsup.config.ts
+++ b/packages/protocol-parser/tsup.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     index: "src/exports/index.ts",
     internal: "src/exports/internal.ts",
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/recs/tsup.config.ts
+++ b/packages/recs/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts", "src/deprecated/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/schema-type/tsup.config.ts
+++ b/packages/schema-type/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     index: "src/typescript/exports/index.ts",
     internal: "src/typescript/exports/internal.ts",
@@ -9,9 +9,14 @@ export default defineConfig({
   outDir: "dist",
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
   injectStyle: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/solhint-config-mud/tsup.config.ts
+++ b/packages/solhint-config-mud/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["cjs"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/solhint-plugin-mud/tsup.config.ts
+++ b/packages/solhint-plugin-mud/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["cjs"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/stash/tsup.config.ts
+++ b/packages/stash/tsup.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     index: "src/exports/index.ts",
     internal: "src/exports/internal.ts",
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/store-indexer/tsup.config.ts
+++ b/packages/store-indexer/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: [
     "src/index.ts",
     "bin/postgres-frontend.ts",
@@ -10,8 +10,13 @@ export default defineConfig({
   ],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/store-sync/tsup.config.ts
+++ b/packages/store-sync/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: [
     "src/index.ts",
     "src/sqlite/index.ts",
@@ -14,8 +14,13 @@ export default defineConfig({
   ],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/store/tsup.config.ts
+++ b/packages/store/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     "mud.config": "mud.config.ts",
     index: "ts/exports/index.ts",
@@ -10,8 +10,13 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: ["src/index.ts"],
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/world-module-metadata/tsup.config.ts
+++ b/packages/world-module-metadata/tsup.config.ts
@@ -1,13 +1,18 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     "mud.config": "mud.config.ts",
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/world-modules/tsup.config.ts
+++ b/packages/world-modules/tsup.config.ts
@@ -1,13 +1,18 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     "mud.config": "mud.config.ts",
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));

--- a/packages/world/tsup.config.ts
+++ b/packages/world/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
   entry: {
     "mud.config": "mud.config.ts",
     index: "ts/exports/index.ts",
@@ -10,8 +10,13 @@ export default defineConfig({
   },
   target: "esnext",
   format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
   sourcemap: true,
-  clean: true,
   minify: true,
-});
+  // don't generate DTS during watch mode because it's slow
+  // we're likely using TS source in this mode anyway
+  dts: !opts.watch,
+  // don't clean during watch mode to avoid removing
+  // previously-built DTS files, which other build tasks
+  // depend on
+  clean: !opts.watch,
+}));


### PR DESCRIPTION
This fixes the weirdness around explorer building.

We have turbo configured to run `build` task for each dep as a prerequisite of `dev` task. Before this change, tsup was configured to only run DTS in a special dev mode using `TSUP_SKIP_DTS` (because DTS generation is slow). This meant that explorer couldn't find the DTS files it expects when building and the build would fail.

Instead, we now always build DTS when running a regular tsup build (not watch mode). When tsup is in watch mode, it skips DTS and _also_ skips cleaning, to avoid deleting previously generated DTS files. We need this configured this way otherwise a fast task like building common package would run build + dev, where dev would clean DTS files, then explorer wouldn't be able to find them when it goes to build itself.