### PR TITLE
chore(store-consumer): skip dev script

### DIFF
--- a/packages/store-consumer/package.json
+++ b/packages/store-consumer/package.json
@@ -27,7 +27,7 @@
     "clean:abi": "forge clean",
     "clean:js": "shx rm -rf dist",
     "clean:mud": "shx rm -rf src/**/codegen",
-    "dev": "tsup --watch",
+    "dev": "echo 'nothing to watch'",
     "gas-report": "gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",
     "test": "forge test",

--- a/packages/store-consumer/package.json
+++ b/packages/store-consumer/package.json
@@ -23,10 +23,8 @@
     "build": "pnpm run build:abi && pnpm run build:abi-ts",
     "build:abi": "forge build",
     "build:abi-ts": "abi-ts",
-    "clean": "pnpm run clean:abi && pnpm run clean:js",
+    "clean": "pnpm run clean:abi",
     "clean:abi": "forge clean",
-    "clean:js": "shx rm -rf dist",
-    "clean:mud": "shx rm -rf src/**/codegen",
     "dev": "echo 'nothing to watch'",
     "gas-report": "gas-report --save gas-report.json",
     "lint": "solhint --config ./.solhint.json 'src/**/*.sol'",
@@ -43,9 +41,7 @@
     "@latticexyz/gas-report": "workspace:*",
     "@types/node": "^18.15.11",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#1eea5bae12ae557d589f9f0f0edae2faa47cb262",
-    "solhint": "^3.3.7",
-    "tsup": "^6.7.0",
-    "vitest": "0.34.6"
+    "solhint": "^3.3.7"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1025,12 +1025,6 @@ importers:
       solhint:
         specifier: ^3.3.7
         version: 3.3.7
-      tsup:
-        specifier: ^6.7.0
-        version: 6.7.0(postcss@8.4.47)(typescript@5.4.2)
-      vitest:
-        specifier: 0.34.6
-        version: 0.34.6(jsdom@22.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.33.0)
 
   packages/store-indexer:
     dependencies:


### PR DESCRIPTION
there are no typescript files in `store-consumer` so `tsup` errors when running `dev`