### PR TITLE
Fix: Update buildSystemsManifest.ts to support windows paths

### DIFF
--- a/packages/world/ts/node/buildSystemsManifest.ts
+++ b/packages/world/ts/node/buildSystemsManifest.ts
@@ -44,8 +44,17 @@ export async function buildSystemsManifest(opts: { rootDir: string; config: Worl
   const forgeOutDir = await getForgeOutDirectory();
   const contractArtifacts = await findContractArtifacts({ forgeOutDir });
 
+  function formatPath(path: string) {
+    if (path !== null) {
+      return path.replace(/\\/g, "/");
+    }
+    return path;
+  }
+
   function getSystemArtifact(system: ResolvedSystem): ContractArtifact {
-    const artifact = contractArtifacts.find((a) => a.sourcePath === system.sourcePath && a.name === system.label);
+    const artifact = contractArtifacts.find(
+      (a) => formatPath(a.sourcePath) === formatPath(system.sourcePath) && a.name === system.label,
+    );
     if (!artifact) {
       throw new Error(
         `Could not find build artifact for system \`${system.label}\` at \`${system.sourcePath}\`. Did \`forge build\` run successfully?`,


### PR DESCRIPTION
 ```mud build``` is not supported in the git bash in windows because the path comparison is failing when checking for artifacts, this fixes this by changing the slashes in a common format 