### PR TITLE
feat(common): loosen client type in tx queue

### DIFF
--- a/.changeset/tender-ties-draw.md
+++ b/.changeset/tender-ties-draw.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Loosened `publicClient` type for `transactionQueue` action decorator and `writeContract` and `sendTransaction` actions so that they can be used with plain, undecorated Viem clients.

--- a/packages/common/src/actions/transactionQueue.ts
+++ b/packages/common/src/actions/transactionQueue.ts
@@ -1,15 +1,15 @@
-import type { Transport, Chain, Account, WalletActions, Client, PublicClient } from "viem";
+import type { Transport, Chain, Account, WalletActions, Client } from "viem";
 import { writeContract as mud_writeContract } from "../writeContract";
 import { sendTransaction as mud_sendTransaction } from "../sendTransaction";
 
-export type TransactionQueueOptions<chain extends Chain> = {
+export type TransactionQueueOptions<chain extends Chain | undefined> = {
   /**
    * `publicClient` can be provided to be used in place of the extended viem client for making public action calls
    * (`getChainId`, `getTransactionCount`, `simulateContract`, `call`). This helps in cases where the extended
    * viem client is a smart account client, like in [permissionless.js](https://github.com/pimlicolabs/permissionless.js),
    * where the transport is the bundler, not an RPC.
    */
-  publicClient?: PublicClient<Transport, chain>;
+  publicClient?: Client<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
    * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions
@@ -19,7 +19,7 @@ export type TransactionQueueOptions<chain extends Chain> = {
   queueConcurrency?: number;
 };
 
-export function transactionQueue<chain extends Chain>(
+export function transactionQueue<chain extends Chain | undefined>(
   opts: TransactionQueueOptions<chain> = {},
 ): <transport extends Transport, account extends Account | undefined = Account | undefined>(
   client: Client<transport, chain, account>,

--- a/packages/common/src/sendTransaction.ts
+++ b/packages/common/src/sendTransaction.ts
@@ -5,7 +5,6 @@ import {
   SendTransactionParameters,
   Transport,
   SendTransactionReturnType,
-  PublicClient,
   SendTransactionRequest,
 } from "viem";
 import { sendTransaction as viem_sendTransaction } from "viem/actions";
@@ -25,7 +24,7 @@ export type SendTransactionExtraOptions<chain extends Chain | undefined> = {
    * viem client is a smart account client, like in [permissionless.js](https://github.com/pimlicolabs/permissionless.js),
    * where the transport is the bundler, not an RPC.
    */
-  publicClient?: PublicClient<Transport, chain>;
+  publicClient?: Client<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
    * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions

--- a/packages/common/src/writeContract.ts
+++ b/packages/common/src/writeContract.ts
@@ -8,7 +8,6 @@ import {
   WriteContractReturnType,
   ContractFunctionName,
   ContractFunctionArgs,
-  PublicClient,
 } from "viem";
 import { writeContract as viem_writeContract } from "viem/actions";
 import pRetry from "p-retry";
@@ -27,7 +26,7 @@ export type WriteContractExtraOptions<chain extends Chain | undefined> = {
    * viem client is a smart account client, like in [permissionless.js](https://github.com/pimlicolabs/permissionless.js),
    * where the transport is the bundler, not an RPC.
    */
-  publicClient?: PublicClient<Transport, chain>;
+  publicClient?: Client<Transport, chain>;
   /**
    * Adjust the number of concurrent calls to the mempool. This defaults to `1` to ensure transactions are ordered
    * and nonces are handled properly. Any number greater than that is likely to see nonce errors and/or transactions


### PR DESCRIPTION
Internally, we've migrated to using `getAction` for all client actions (https://github.com/latticexyz/mud/pull/3071), so we don't need this specific of a type. This lets us pass in plain/undecorated clients into these helpers.
