### PR TITLE
ci: only use commit in snapshot version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "ignore": [],
   "snapshot": {
     "useCalculatedVersion": true,
-    "prereleaseTemplate": "{tag}-{commit}"
+    "prereleaseTemplate": "{commit}"
   },
   "privatePackages": {
     "tag": false,

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -50,7 +50,7 @@ jobs:
       # so doing it manually here
       - name: Publish snapshots
         run: |
-          pnpm changeset version --snapshot ${{ github.ref_name }}
+          pnpm changeset version --snapshot
           pnpm changeset publish --tag ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should fix not being able to tag snapshot versions in npm with a slash from our branch naming scheme.

The underlying issue is we're using the branch name in both the npm version and npm tag. And npm seems to explode when there's a slash in the version name because the version determines the path/filename of the packaged `.tgz` file.

If we decouple the npm version from the npm tag, we should get the behavior we want.