### PR TITLE
chore: add ts path for common internal exports

### DIFF
--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -13,6 +13,7 @@
       "@latticexyz/common/type-utils": ["./packages/common/src/type-utils/index.ts"],
       "@latticexyz/common/utils": ["./packages/common/src/utils/index.ts"],
       "@latticexyz/common/kms": ["./packages/common/src/exports/kms.ts"],
+      "@latticexyz/common/internal": ["./packages/common/src/exports/internal.ts"],
       "@latticexyz/config": ["./packages/config/src/exports/index.ts"],
       "@latticexyz/config/*": ["./packages/config/src/exports/*.ts"],
       "@latticexyz/config/node": ["./packages/config/src/deprecated/node"],


### PR DESCRIPTION
missed in #3421 