### PR TITLE
fix(world): switch to TS for ABIs in utils

### DIFF
--- a/.changeset/little-tables-wait.md
+++ b/.changeset/little-tables-wait.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Moved TS utils over to using hardcoded ABIs instead of ones imported from `.abi.json` files to fix some internal type resolution issues.

--- a/packages/world/ts/actions/callFrom.ts
+++ b/packages/world/ts/actions/callFrom.ts
@@ -21,7 +21,6 @@ import {
   encodeKey,
 } from "@latticexyz/protocol-parser/internal";
 import worldConfig from "../../mud.config";
-import IStoreReadAbi from "../../out/IStoreRead.sol/IStoreRead.abi.json";
 
 type CallFromParameters = {
   worldAddress: Hex;
@@ -134,7 +133,42 @@ async function retrieveSystemFunctionFromContract(
 
   const [staticData, encodedLengths, dynamicData] = await _readContract({
     address: worldAddress,
-    abi: IStoreReadAbi,
+    abi: [
+      {
+        type: "function",
+        name: "getRecord",
+        inputs: [
+          {
+            name: "tableId",
+            type: "bytes32",
+            internalType: "ResourceId",
+          },
+          {
+            name: "keyTuple",
+            type: "bytes32[]",
+            internalType: "bytes32[]",
+          },
+        ],
+        outputs: [
+          {
+            name: "staticData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "encodedLengths",
+            type: "bytes32",
+            internalType: "EncodedLengths",
+          },
+          {
+            name: "dynamicData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+        stateMutability: "view",
+      },
+    ],
     functionName: "getRecord",
     args: [table.tableId, encodeKey(keySchema, { worldFunctionSelector })],
   });

--- a/packages/world/ts/encodeSystemCall.ts
+++ b/packages/world/ts/encodeSystemCall.ts
@@ -1,6 +1,6 @@
 import { Abi, EncodeFunctionDataParameters, Hex, encodeFunctionData, type ContractFunctionName } from "viem";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
+import { worldCallAbi } from "./worldCallAbi";
 
 export type SystemCall<abi extends Abi, functionName extends ContractFunctionName<abi>> = EncodeFunctionDataParameters<
   abi,
@@ -15,9 +15,7 @@ export function encodeSystemCall<abi extends Abi, functionName extends ContractF
   systemId,
   functionName,
   args,
-}: SystemCall<abi, functionName>): AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof IWorldCallAbi, "call">["inputs"]
-> {
+}: SystemCall<abi, functionName>): AbiParametersToPrimitiveTypes<ExtractAbiFunction<worldCallAbi, "call">["inputs"]> {
   return [
     systemId,
     encodeFunctionData<abi, functionName>({

--- a/packages/world/ts/encodeSystemCallFrom.ts
+++ b/packages/world/ts/encodeSystemCallFrom.ts
@@ -1,7 +1,7 @@
 import { Abi, EncodeFunctionDataParameters, encodeFunctionData, Address, type ContractFunctionName } from "viem";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
 import { SystemCall } from "./encodeSystemCall";
+import { worldCallAbi } from "./worldCallAbi";
 
 export type SystemCallFrom<abi extends Abi, functionName extends ContractFunctionName<abi>> = SystemCall<
   abi,
@@ -18,7 +18,7 @@ export function encodeSystemCallFrom<abi extends Abi, functionName extends Contr
   functionName,
   args,
 }: SystemCallFrom<abi, functionName>): AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof IWorldCallAbi, "callFrom">["inputs"]
+  ExtractAbiFunction<worldCallAbi, "callFrom">["inputs"]
 > {
   return [
     from,

--- a/packages/world/ts/encodeSystemCalls.ts
+++ b/packages/world/ts/encodeSystemCalls.ts
@@ -1,12 +1,12 @@
 import { Abi, type ContractFunctionName } from "viem";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
 import { SystemCall, encodeSystemCall } from "./encodeSystemCall";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
+import { worldCallAbi } from "./worldCallAbi";
 
 /** Encode system calls to be passed as arguments into `World.batchCall` */
 export function encodeSystemCalls<abi extends Abi, functionName extends ContractFunctionName<abi>>(
   abi: abi,
   systemCalls: readonly Omit<SystemCall<abi, functionName>, "abi">[],
-): AbiParametersToPrimitiveTypes<ExtractAbiFunction<typeof IWorldCallAbi, "call">["inputs"]>[] {
+): AbiParametersToPrimitiveTypes<ExtractAbiFunction<worldCallAbi, "call">["inputs"]>[] {
   return systemCalls.map((systemCall) => encodeSystemCall({ ...systemCall, abi } as SystemCall<abi, functionName>));
 }

--- a/packages/world/ts/encodeSystemCallsFrom.ts
+++ b/packages/world/ts/encodeSystemCallsFrom.ts
@@ -1,14 +1,14 @@
 import { Abi, Address, type ContractFunctionName } from "viem";
-import IWorldCallAbi from "../out/IWorldKernel.sol/IWorldCall.abi.json";
 import { SystemCallFrom, encodeSystemCallFrom } from "./encodeSystemCallFrom";
 import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from "abitype";
+import { worldCallAbi } from "./worldCallAbi";
 
 /** Encode system calls to be passed as arguments into `World.batchCallFrom` */
 export function encodeSystemCallsFrom<abi extends Abi, functionName extends ContractFunctionName<abi>>(
   abi: abi,
   from: Address,
   systemCalls: readonly Omit<SystemCallFrom<abi, functionName>, "abi" | "from">[],
-): AbiParametersToPrimitiveTypes<ExtractAbiFunction<typeof IWorldCallAbi, "callFrom">["inputs"]>[] {
+): AbiParametersToPrimitiveTypes<ExtractAbiFunction<worldCallAbi, "callFrom">["inputs"]>[] {
   return systemCalls.map((systemCall) =>
     encodeSystemCallFrom({ ...systemCall, abi, from } as SystemCallFrom<abi, functionName>),
   );

--- a/packages/world/ts/worldCallAbi.ts
+++ b/packages/world/ts/worldCallAbi.ts
@@ -1,0 +1,60 @@
+// TODO: replace this with abi-ts generated files once we move to
+//       generating full TS files rather than DTS
+
+export const worldCallAbi = [
+  {
+    type: "function",
+    name: "call",
+    inputs: [
+      {
+        name: "systemId",
+        type: "bytes32",
+        internalType: "ResourceId",
+      },
+      {
+        name: "callData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
+    name: "callFrom",
+    inputs: [
+      {
+        name: "delegator",
+        type: "address",
+        internalType: "address",
+      },
+      {
+        name: "systemId",
+        type: "bytes32",
+        internalType: "ResourceId",
+      },
+      {
+        name: "callData",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "bytes",
+        internalType: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+  },
+] as const;
+
+export type worldCallAbi = typeof worldCallAbi;


### PR DESCRIPTION
pulled out of https://github.com/latticexyz/mud/pull/3419

it's common among our packages that you'll see these TS errors from world package when running tsc

```
% pnpm tsc
../world/ts/actions/callFrom.ts:135:9 - error TS2488: Type 'unknown' must have a '[Symbol.iterator]()' method that returns an iterator.

135   const [staticData, encodedLengths, dynamicData] = await _readContract({
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../world/ts/encodeSystemCall.ts:19:22 - error TS2344: Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }[]' does not satisfy the constraint 'Abi'.
  Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }' is not assignable to type 'AbiFunction | AbiConstructor | AbiFallback | AbiReceive | AbiEvent | AbiError'.
    Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }' is not assignable to type 'AbiFunction'.
      Types of property 'type' are incompatible.
        Type 'string' is not assignable to type '"function"'.

19   ExtractAbiFunction<typeof IWorldCallAbi, "call">["inputs"]
                        ~~~~~~~~~~~~~~~~~~~~

../world/ts/encodeSystemCall.ts:21:3 - error TS2322: Type '`0x${string}`[]' is not assignable to type 'never'.

21   return [
     ~~~~~~

../world/ts/encodeSystemCallFrom.ts:21:22 - error TS2344: Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }[]' does not satisfy the constraint 'Abi'.

21   ExtractAbiFunction<typeof IWorldCallAbi, "callFrom">["inputs"]
                        ~~~~~~~~~~~~~~~~~~~~

../world/ts/encodeSystemCallFrom.ts:23:3 - error TS2322: Type '`0x${string}`[]' is not assignable to type 'never'.

23   return [
     ~~~~~~

../world/ts/encodeSystemCalls.ts:10:53 - error TS2344: Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }[]' does not satisfy the constraint 'Abi'.

10 ): AbiParametersToPrimitiveTypes<ExtractAbiFunction<typeof IWorldCallAbi, "call">["inputs"]>[] {
                                                       ~~~~~~~~~~~~~~~~~~~~

../world/ts/encodeSystemCallsFrom.ts:11:53 - error TS2344: Type '{ type: string; name: string; inputs: { name: string; type: string; internalType: string; }[]; outputs: { name: string; type: string; internalType: string; }[]; stateMutability: string; }[]' does not satisfy the constraint 'Abi'.

11 ): AbiParametersToPrimitiveTypes<ExtractAbiFunction<typeof IWorldCallAbi, "callFrom">["inputs"]>[] {
                                                       ~~~~~~~~~~~~~~~~~~~~


Found 7 errors in 5 files.

Errors  Files
     1  ../world/ts/actions/callFrom.ts:135
     2  ../world/ts/encodeSystemCall.ts:19
     2  ../world/ts/encodeSystemCallFrom.ts:21
     1  ../world/ts/encodeSystemCalls.ts:10
     1  ../world/ts/encodeSystemCallsFrom.ts:11
```

this has to do with our ABI JSON -> TS strategy (using DTS files generated by abi-ts), where things aren't resolving properly (see https://github.com/latticexyz/mud/pull/3029)

in the meantime, we'll just hardcode just the ABIs we need as regular TS 