### PR TITLE
fix(entrykit): don't call decorator

### DIFF
--- a/packages/entrykit/package.json
+++ b/packages/entrykit/package.json
@@ -55,7 +55,7 @@
     "@rainbow-me/rainbowkit": "2.1.7",
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",
-    "permissionless": "^0.2.3",
+    "permissionless": "0.2.25",
     "react-error-boundary": "^4.0.13",
     "react-merge-refs": "^2.1.1",
     "tailwind-merge": "^1.12.0",

--- a/packages/entrykit/src/getSessionClient.ts
+++ b/packages/entrykit/src/getSessionClient.ts
@@ -18,13 +18,14 @@ export async function getSessionClient<chain extends Chain>({
   worldAddress: Address;
 }): Promise<SessionClient<chain>> {
   const bundlerTransport = getBundlerTransport(client.chain);
-
-  const sessionClient = createBundlerClient({
+  const bundlerClient = createBundlerClient({
     transport: bundlerTransport,
     client,
     account: sessionAccount,
-  })
-    .extend(smartAccountActions())
+  });
+
+  const sessionClient = bundlerClient
+    .extend(smartAccountActions)
     .extend(callFrom({ worldAddress, delegatorAddress: userAddress, publicClient: client }))
     // TODO: add observer once we conditionally fetch receipts while bridge is open
     .extend(() => ({ userAddress }));

--- a/packages/entrykit/src/onboarding/Session.tsx
+++ b/packages/entrykit/src/onboarding/Session.tsx
@@ -13,7 +13,7 @@ export type Props = {
 };
 
 export function Session({ isActive, isExpanded, userClient, registerSpender, registerDelegation }: Props) {
-  const { data: sessionClient } = useSessionClient(userClient.account.address);
+  const sessionClient = useSessionClient(userClient.account.address);
   const setup = useSetupSession({ userClient });
   const hasSession = !registerDelegation && !registerDelegation;
 
@@ -23,9 +23,9 @@ export function Session({ isActive, isExpanded, userClient, registerSpender, reg
     // individual mutations, even though the keys match. And the one we want the status of
     // seems to stay pending. This is sorta resolved by triggering this after a timeout.
     const timer = setTimeout(() => {
-      if (isActive && setup.status === "idle" && sessionClient && !hasSession) {
+      if (isActive && setup.status === "idle" && sessionClient.data && !hasSession) {
         setup.mutate({
-          sessionClient,
+          sessionClient: sessionClient.data,
           registerSpender,
           registerDelegation,
         });
@@ -50,12 +50,12 @@ export function Session({ isActive, isExpanded, userClient, registerSpender, reg
             variant={isActive ? "primary" : "tertiary"}
             className="flex-shrink-0 text-sm p-1 w-28"
             autoFocus={isActive}
-            pending={!sessionClient || setup.status === "pending"}
+            pending={!sessionClient.data || setup.status === "pending"}
             onClick={
-              sessionClient
+              sessionClient.data
                 ? () =>
                     setup.mutate({
-                      sessionClient,
+                      sessionClient: sessionClient.data,
                       registerSpender,
                       registerDelegation,
                     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,8 +487,8 @@ importers:
         specifier: ^16.0.3
         version: 16.0.3
       permissionless:
-        specifier: ^0.2.3
-        version: 0.2.3(viem@2.21.19(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))
+        specifier: 0.2.25
+        version: 0.2.25(viem@2.21.19(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(webauthn-p256@0.0.10)
       react-error-boundary:
         specifier: ^4.0.13
         version: 4.0.13(react@18.2.0)
@@ -9868,10 +9868,11 @@ packages:
   peek-stream@1.1.3:
     resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
 
-  permissionless@0.2.3:
-    resolution: {integrity: sha512-7OB7zGLeDNXGbiAxjoJA40bF8Zugf1GHFRDunXMgaN4Ft78ZOmkeuLEeZD7STfHOtUA0g03unZwQc8Q7m1+f7w==}
+  permissionless@0.2.25:
+    resolution: {integrity: sha512-O0YUNBpouF/S0EGfk3PLuGHN3vYGRK4nJZAyGC5uq72NbHoi0Ao0bWxdTeBw6/rNyrcE7CMKtU5KxrSnIV+mcw==}
     peerDependencies:
-      viem: ^2.20.0
+      viem: ^2.21.54
+      webauthn-p256: 0.0.10
 
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -23546,9 +23547,10 @@ snapshots:
       duplexify: 3.7.1
       through2: 2.0.5
 
-  permissionless@0.2.3(viem@2.21.19(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)):
+  permissionless@0.2.25(viem@2.21.19(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(webauthn-p256@0.0.10):
     dependencies:
       viem: 2.21.19(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      webauthn-p256: 0.0.10
 
   picocolors@1.0.0: {}
 


### PR DESCRIPTION
I was seeing errors like `extendFn is not a function` that stemmed from assuming `smartAccountActions` was meant to be called/instantiated. Not sure how this didn't show up before, but I seem to recall seeing this sporadically. Might be related to semver (as in a prior patch version had diff behavior), so I also pinned the permissionless version.