### PR TITLE
chore(explorer): disable table data fetch retries

### DIFF
--- a/packages/explorer/src/app/(explorer)/queries/useTableDataQuery.ts
+++ b/packages/explorer/src/app/(explorer)/queries/useTableDataQuery.ts
@@ -79,6 +79,7 @@ export function useTableDataQuery({ table, query }: Props) {
         rows,
       };
     },
+    retry: false,
     enabled: !!table && !!query,
     refetchInterval: (query) => {
       if (query.state.error) return false;

--- a/packages/explorer/src/app/(explorer)/queries/useTablesQuery.ts
+++ b/packages/explorer/src/app/(explorer)/queries/useTablesQuery.ts
@@ -55,6 +55,7 @@ export function useTablesQuery() {
         .filter(isDefined)
         .sort(({ namespace }) => (internalNamespaces.includes(namespace) ? 1 : -1));
     },
+    retry: false,
     refetchInterval: 5000,
   });
 }


### PR DESCRIPTION
Based on feedback disable table data fetch retries to show errors immediately. And when it comes to tables data, if the first fetch fails, the subsequent fails will most likely fail too.