### PR TITLE
feat(store-sync): simplify SyncProvider

### DIFF
--- a/packages/store-sync/.eslintrc
+++ b/packages/store-sync/.eslintrc
@@ -1,6 +1,7 @@
 {
-  "extends": ["../../.eslintrc"],
+  "extends": ["../../.eslintrc", "plugin:react/recommended", "plugin:react-hooks/recommended"],
+  "plugins": ["react", "react-hooks"],
   "rules": {
-    "@typescript-eslint/explicit-function-return-type": "error"
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/packages/store-sync/.eslintrc
+++ b/packages/store-sync/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["../../.eslintrc", "plugin:react/recommended", "plugin:react-hooks/recommended"],
   "plugins": ["react", "react-hooks"],
   "rules": {
+    "@typescript-eslint/explicit-function-return-type": "warn",
     "react/react-in-jsx-scope": "off"
   }
 }

--- a/packages/store-sync/src/postgres-decoded/buildColumn.ts
+++ b/packages/store-sync/src/postgres-decoded/buildColumn.ts
@@ -12,7 +12,6 @@ import {
   asNumberArray,
 } from "../postgres/columnTypes";
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
   switch (schemaAbiType) {
     case "bool":

--- a/packages/store-sync/src/postgres/columnTypes.ts
+++ b/packages/store-sync/src/postgres/columnTypes.ts
@@ -2,7 +2,6 @@ import { customType } from "drizzle-orm/pg-core";
 import superjson from "superjson";
 import { Address, ByteArray, bytesToHex, getAddress, Hex, hexToBytes } from "viem";
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asJson = <TData>(name: string) =>
   customType<{ data: TData; driverData: string }>({
     dataType() {
@@ -17,7 +16,6 @@ export const asJson = <TData>(name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asNumber = (name: string, columnType: string) =>
   customType<{ data: number; driverData: string }>({
     dataType() {
@@ -31,7 +29,6 @@ export const asNumber = (name: string, columnType: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asBigInt = (name: string, columnType: string) =>
   customType<{ data: bigint; driverData: string }>({
     dataType() {
@@ -45,7 +42,6 @@ export const asBigInt = (name: string, columnType: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asHex = (name: string) =>
   customType<{ data: Hex; driverData: ByteArray }>({
     dataType() {
@@ -59,7 +55,6 @@ export const asHex = (name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asAddress = (name: string) =>
   customType<{ data: Address; driverData: ByteArray }>({
     dataType() {
@@ -73,7 +68,6 @@ export const asAddress = (name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asBoolArray = (name: string) =>
   customType<{ data: boolean[]; driverData: string[] }>({
     dataType() {
@@ -87,7 +81,6 @@ export const asBoolArray = (name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asNumberArray = (name: string, columnType: string) =>
   customType<{ data: number[]; driverData: string[] }>({
     dataType() {
@@ -101,7 +94,6 @@ export const asNumberArray = (name: string, columnType: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asBigIntArray = (name: string, columnType: string) =>
   customType<{ data: bigint[]; driverData: string[] }>({
     dataType() {

--- a/packages/store-sync/src/react/SyncProvider.tsx
+++ b/packages/store-sync/src/react/SyncProvider.tsx
@@ -13,7 +13,6 @@ export type Props = Omit<SyncOptions, "publicClient"> & {
   children: ReactNode;
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function SyncProvider({ chainId, adapter, children, ...syncOptions }: Props) {
   const existingValue = useContext(SyncContext);
   if (existingValue != null) {

--- a/packages/store-sync/src/react/SyncProvider.tsx
+++ b/packages/store-sync/src/react/SyncProvider.tsx
@@ -1,13 +1,11 @@
 import { ReactNode, createContext, useContext, useEffect } from "react";
 import { useConfig } from "wagmi";
 import { getClient } from "wagmi/actions";
-import { useQuery } from "@tanstack/react-query";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import { SyncAdapter, SyncOptions, SyncResult } from "../common";
 
 /** @internal */
-export const SyncContext = createContext<{
-  sync?: SyncResult;
-} | null>(null);
+export const SyncContext = createContext<UseQueryResult<SyncResult> | null>(null);
 
 export type Props = Omit<SyncOptions, "publicClient"> & {
   chainId: number;
@@ -24,34 +22,29 @@ export function SyncProvider({ chainId, adapter, children, ...syncOptions }: Pro
 
   const config = useConfig();
 
-  const { data: sync, error: syncError } = useQuery({
+  const result = useQuery({
     queryKey: ["sync", chainId],
     queryFn: async () => {
       const client = getClient(config, { chainId });
       if (!client) {
         throw new Error(`Unable to retrieve Viem client for chain ${chainId}.`);
       }
-
-      return adapter({ publicClient: client, ...syncOptions });
+      return await adapter({ publicClient: client, ...syncOptions });
     },
     staleTime: Infinity,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
-  if (syncError) throw syncError;
 
   useEffect(() => {
-    if (!sync) return;
-
-    const sub = sync.storedBlockLogs$.subscribe({
+    const sub = result.data?.storedBlockLogs$.subscribe({
       error: (error) => console.error("got sync error", error),
     });
-
     return (): void => {
-      sub.unsubscribe();
+      sub?.unsubscribe();
     };
-  }, [sync]);
+  }, [result.data?.storedBlockLogs$]);
 
-  return <SyncContext.Provider value={{ sync }}>{children}</SyncContext.Provider>;
+  return <SyncContext.Provider value={result}>{children}</SyncContext.Provider>;
 }

--- a/packages/store-sync/src/react/useSync.ts
+++ b/packages/store-sync/src/react/useSync.ts
@@ -1,12 +1,12 @@
 import { useContext } from "react";
 import { SyncContext } from "./SyncProvider";
 import { SyncResult } from "../common";
+import { UseQueryResult } from "@tanstack/react-query";
 
-export function useSync(): Partial<SyncResult> {
+export function useSync(): UseQueryResult<SyncResult> {
   const value = useContext(SyncContext);
   if (value == null) {
     throw new Error("`useSync` must be used inside a `SyncProvider`.");
   }
-  const { sync } = value;
-  return sync ?? {};
+  return value;
 }

--- a/packages/store-sync/src/recs/defineInternalComponents.ts
+++ b/packages/store-sync/src/recs/defineInternalComponents.ts
@@ -3,7 +3,6 @@ import { Table } from "../common";
 
 export type InternalComponents = ReturnType<typeof defineInternalComponents>;
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function defineInternalComponents(world: World) {
   return {
     RegisteredTables: defineComponent<{ table: Type.T }, Metadata, Table>(

--- a/packages/store-sync/src/sqlite/buildColumn.ts
+++ b/packages/store-sync/src/sqlite/buildColumn.ts
@@ -3,7 +3,6 @@ import { SchemaAbiType } from "@latticexyz/schema-type/internal";
 import { assertExhaustive } from "@latticexyz/common/utils";
 import { address, json } from "./columnTypes";
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function buildColumn(name: string, schemaAbiType: SchemaAbiType) {
   switch (schemaAbiType) {
     case "bool":

--- a/packages/store-sync/src/sqlite/columnTypes.ts
+++ b/packages/store-sync/src/sqlite/columnTypes.ts
@@ -4,7 +4,6 @@ import { Address, Hex, getAddress } from "viem";
 
 // TODO: migrate these to same patterns in postgres/columnTypes
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const json = <TData>(name: string) =>
   customType<{ data: TData; driverData: string }>({
     dataType() {
@@ -18,7 +17,6 @@ export const json = <TData>(name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const address = (name: string) =>
   customType<{ data: Address; driverData: string }>({
     dataType() {
@@ -32,7 +30,6 @@ export const address = (name: string) =>
     },
   })(name);
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const asHex = (name: string) =>
   customType<{ data: Hex; driverData: Hex }>({
     dataType() {

--- a/packages/store-sync/src/trpc-indexer/createAppRouter.ts
+++ b/packages/store-sync/src/trpc-indexer/createAppRouter.ts
@@ -6,7 +6,6 @@ import { input } from "../indexer-client/input";
 /**
  * @deprecated
  */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createAppRouter() {
   const t = initTRPC.context<{ queryAdapter: QueryAdapter }>().create({
     transformer: superjson,


### PR DESCRIPTION
pulled out of #3439 and follows #3451

Whenever I try to work around React Query to get a simpler interface, I always end up rebuilding the same stuff (pending states, error states, etc.). When will I learn to just use React Query? :)