### PR TITLE
fix(cli): don't overload system abi type

### DIFF
--- a/.changeset/seven-seahorses-roll.md
+++ b/.changeset/seven-seahorses-roll.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Fixed an issue with overloaded system ABI types.

--- a/packages/cli/src/deploy/common.ts
+++ b/packages/cli/src/deploy/common.ts
@@ -92,14 +92,17 @@ export type System = DeterministicContract & {
   // world registration
   // TODO: replace this with system manifest data
   readonly worldFunctions: readonly WorldFunction[];
-  // human readable ABIs to register onchain
-  readonly abi: readonly string[];
-  readonly worldAbi: readonly string[];
+  // metadata to register onchain
+  readonly metadata: {
+    // human readable ABIs
+    readonly abi: readonly string[];
+    readonly worldAbi: readonly string[];
+  };
 };
 
 export type DeployedSystem = Omit<
   System,
-  "label" | "namespaceLabel" | "abi" | "worldAbi" | "prepareDeploy" | "deployedBytecodeSize" | "allowedSystemIds"
+  "label" | "namespaceLabel" | "abi" | "metadata" | "prepareDeploy" | "deployedBytecodeSize" | "allowedSystemIds"
 > & {
   address: Address;
 };

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -181,11 +181,11 @@ export async function deploy({
     .filter((table) => table.label !== table.name)
     .map(({ tableId: resourceId, label }) => ({ resourceId, tag: "label", value: label }));
 
-  const systemTags = systems.flatMap(({ name, systemId: resourceId, label, abi, worldAbi }) => [
+  const systemTags = systems.flatMap(({ name, systemId: resourceId, label, metadata }) => [
     // only register labels if they differ from the resource ID
     ...(label !== name ? [{ resourceId, tag: "label", value: label }] : []),
-    { resourceId, tag: "abi", value: abi.join("\n") },
-    { resourceId, tag: "worldAbi", value: worldAbi.join("\n") },
+    { resourceId, tag: "abi", value: metadata.abi.join("\n") },
+    { resourceId, tag: "worldAbi", value: metadata.worldAbi.join("\n") },
   ]);
 
   const tagTxs = await ensureResourceTags({

--- a/packages/cli/src/deploy/resolveConfig.ts
+++ b/packages/cli/src/deploy/resolveConfig.ts
@@ -108,8 +108,11 @@ export async function resolveConfig({
         prepareDeploy: createPrepareDeploy(contractData.bytecode, contractData.placeholders),
         deployedBytecodeSize: contractData.deployedBytecodeSize,
         worldFunctions,
-        abi: manifest.abi,
-        worldAbi: manifest.worldAbi,
+        abi: contractData.abi,
+        metadata: {
+          abi: manifest.abi,
+          worldAbi: manifest.worldAbi,
+        },
       };
     });
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "Node",
     "lib": ["DOM", "ESNext"],
     "outDir": "dist"
   },


### PR DESCRIPTION
pulled out of https://github.com/latticexyz/mud/pull/3290

not sure why this appeared there but not in main, but `abi` on `System` type was being overloaded (`Abi` set by `DeterministicContract` and then `string[]` set by `System`) throwing type errors

ideally one of these becomes authoritative (e.g. manifest) but didn't wanna think through that at the moment, so I moved the metadata stuff aside