### PR TITLE
docs: add changeset for bug fix

### DIFF
--- a/.changeset/cuddly-pandas-fail.md
+++ b/.changeset/cuddly-pandas-fail.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/explorer": patch
+---
+
+Fixed an issue where live queries were running while paused and vice versa.


### PR DESCRIPTION
after merging https://github.com/latticexyz/mud/pull/3444, I spotted [a subtle bug fix](https://github.com/latticexyz/mud/pull/3444/files#diff-9b06d0bdfafdf404c488f6a77449e85ea71d13ac2214e3ac7ea6319500b79949R90) that wanted to make sure was captured by changelog in case anyone uses MUD v2.2.15