### PR TITLE
fix(cli): checksum deployed world addresses

### DIFF
--- a/.changeset/warm-rules-listen.md
+++ b/.changeset/warm-rules-listen.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+The world address stored in `worlds.json` and `deploys/latest.json` is now checksummed.

--- a/packages/cli/src/deploy/logsToWorldDeploy.ts
+++ b/packages/cli/src/deploy/logsToWorldDeploy.ts
@@ -1,4 +1,4 @@
-import { AbiEventSignatureNotFoundError, Log, decodeEventLog, hexToString, parseAbi } from "viem";
+import { AbiEventSignatureNotFoundError, Log, decodeEventLog, hexToString, parseAbi, getAddress } from "viem";
 import { WorldDeploy, worldDeployEvents } from "./common";
 import { isDefined } from "@latticexyz/common/utils";
 
@@ -14,6 +14,9 @@ export function logsToWorldDeploy(logs: readonly Log<bigint, number, false>[]): 
             topics: log.topics,
             data: log.data,
           }),
+          // Log addresses are not checksummed, but we want them checksummed before writing to disk.
+          // https://github.com/wevm/viem/issues/2207
+          address: getAddress(log.address),
         };
       } catch (error: unknown) {
         if (error instanceof AbiEventSignatureNotFoundError) {


### PR DESCRIPTION
Fixes #3305 – quick fix to add `getAddress` to checksum these (`viem` bug).