### PR TITLE
feat(cli): support `configPath` cwd

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,3 +1,31 @@
 # cli
 
-docs coming soon
+## Usage
+
+See usage documentation on the [MUD docs](https://mud.dev/cli/tablegen).
+
+## Development
+
+### Debugging
+
+The CLI can be run in a debug environment:
+
+1. Set the `MUD_PACKAGES` environment variable (see `tsup.config.ts`)
+   ```bash
+   export MUD_PACKAGES=$(tsx ./scripts/log-mud-packages)
+   ```
+2. Setup your debugger with `tsx` as the TypeScript loader and `src/mud.ts` as the entrypoint
+3. Set the arguments to whichever command you want to run (e.g. `deploy`) and its options.
+   - Important: add the `--configPath` option as the path of your project's `mud.config.ts` file, because the current working directory will otherwise be the CLI source.
+
+The CLI should now run in your debugger with TypeScript support.
+
+### Production build
+
+The project can be built for production with `tsup`:
+
+```bash
+pnpm build
+```
+
+`pnpm link` can be used to run the locally-built package.

--- a/packages/cli/scripts/log-mud-packages.ts
+++ b/packages/cli/scripts/log-mud-packages.ts
@@ -1,0 +1,5 @@
+import defineConfig from "../tsup.config";
+
+// Log out the MUD_PACKAGES env var so it can be used to run the CLI in development mode
+// @ts-expect-error: defineConfig return type is not properly inferred
+console.log(defineConfig({}).env.MUD_PACKAGES);

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -23,5 +23,5 @@ export async function build({
   await Promise.all([tablegen({ rootDir, config }), worldgen({ rootDir, config })]);
   await forge(["build"], { profile: foundryProfile });
   await buildSystemsManifest({ rootDir, config });
-  await execa("mud", ["abi-ts"], { stdio: "inherit" });
+  await execa("mud", ["abi-ts"], { stdio: "inherit", cwd: rootDir });
 }

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -40,7 +40,7 @@ const commandModule: CommandModule<Options, Options> = {
 
   async handler(opts) {
     const profile = opts.profile ?? process.env.FOUNDRY_PROFILE;
-    const rpc = opts.rpc ?? (await getRpcUrl(profile));
+    const rpc = opts.rpc ?? (await getRpcUrl({ profile }));
     const client = createClient({
       transport: http(rpc, {
         batch: opts.rpcBatch

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -32,7 +32,7 @@ const commandModule: CommandModule<typeof testOptions, TestOptions> = {
       anvil(anvilArgs);
     }
 
-    const forkRpc = opts.worldAddress ? await getRpcUrl(opts.profile) : `http://127.0.0.1:${opts.port}`;
+    const forkRpc = opts.worldAddress ? await getRpcUrl({ profile: opts.profile }) : `http://127.0.0.1:${opts.port}`;
 
     const worldAddress =
       opts.worldAddress ??

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -58,7 +58,7 @@ const commandModule: CommandModule<Options, Options> = {
     const rootDir = path.dirname(configPath);
 
     const profile = args.profile ?? process.env.FOUNDRY_PROFILE;
-    const rpc = args.rpc ?? (await getRpcUrl(profile));
+    const rpc = args.rpc ?? (await getRpcUrl({ profile, cwd: rootDir }));
 
     const config = (await loadConfig(configPath)) as WorldConfig;
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -3,7 +3,7 @@ import { verify } from "../verify";
 import { loadConfig, resolveConfigPath } from "@latticexyz/config/node";
 import { World as WorldConfig } from "@latticexyz/world";
 import { resolveSystems } from "@latticexyz/world/node";
-import { getOutDirectory, getRpcUrl } from "@latticexyz/common/foundry";
+import { FoundryExecOptions, getOutDirectory, getRpcUrl } from "@latticexyz/common/foundry";
 import { getContractData } from "../utils/getContractData";
 import { Hex, createWalletClient, http } from "viem";
 import chalk from "chalk";
@@ -49,9 +49,14 @@ const commandModule: CommandModule<Options, Options> = {
 
     const config = (await loadConfig(configPath)) as WorldConfig;
 
-    const outDir = await getOutDirectory(profile);
+    const foundryExecOptions: FoundryExecOptions = {
+      profile,
+      cwd: rootDir,
+    };
 
-    const rpc = opts.rpc ?? (await getRpcUrl(profile));
+    const outDir = await getOutDirectory(foundryExecOptions);
+
+    const rpc = opts.rpc ?? (await getRpcUrl(foundryExecOptions));
     console.log(
       chalk.bgBlue(
         chalk.whiteBright(`\n Verifying MUD contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`),

--- a/packages/cli/src/runDeploy.ts
+++ b/packages/cli/src/runDeploy.ts
@@ -6,7 +6,7 @@ import { createWalletClient, http, Hex, isHex, stringToHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { loadConfig, resolveConfigPath } from "@latticexyz/config/node";
 import { World as WorldConfig } from "@latticexyz/world";
-import { getOutDirectory, getRpcUrl } from "@latticexyz/common/foundry";
+import { FoundryExecOptions, getOutDirectory, getRpcUrl } from "@latticexyz/common/foundry";
 import chalk from "chalk";
 import { MUDError } from "@latticexyz/common/errors";
 import { resolveConfig } from "./deploy/resolveConfig";
@@ -75,9 +75,14 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
     console.log(chalk.green("\nResolved config:\n"), JSON.stringify(config, null, 2));
   }
 
-  const outDir = await getOutDirectory(profile);
+  const foundryExecOptions: FoundryExecOptions = {
+    profile,
+    cwd: rootDir,
+  };
 
-  const rpc = opts.rpc ?? (await getRpcUrl(profile));
+  const outDir = await getOutDirectory(foundryExecOptions);
+
+  const rpc = opts.rpc ?? (await getRpcUrl(foundryExecOptions));
   console.log(
     chalk.bgBlue(
       chalk.whiteBright(`\n Deploying MUD contracts${profile ? " with profile " + profile : ""} to RPC ${rpc} \n`),
@@ -92,7 +97,7 @@ export async function runDeploy(opts: DeployOptions): Promise<WorldDeploy> {
   const { systems, libraries } = await resolveConfig({
     rootDir,
     config,
-    forgeOutDir: outDir,
+    forgeOutDir: path.join(rootDir, outDir),
   });
 
   const artifacts = await findContractArtifacts({ forgeOutDir: outDir });

--- a/packages/cli/src/utils/getContractData.ts
+++ b/packages/cli/src/utils/getContractData.ts
@@ -7,7 +7,9 @@ import { findPlaceholders } from "./findPlaceholders";
 
 /**
  * Load the contract's abi and bytecode from the file system
- * @param contractName: Name of the contract to load
+ * @param filename Filename of the contract to load
+ * @param contractName Name of the contract to load
+ * @param forgeOutDirectory Directory where the contract was compiled
  */
 export function getContractData(
   filename: string,

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig } from "tsup";
 import { globSync } from "glob";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { MudPackages } from "./src/common";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const mudWorkspace = path.normalize(`${__dirname}/../..`);
 
 const mudPackages: MudPackages = Object.fromEntries(

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -1,4 +1,4 @@
-import { execa, Options } from "execa";
+import { execa, ExecaChildProcess, Options } from "execa";
 
 export interface ForgeConfig {
   // project
@@ -18,13 +18,19 @@ export interface ForgeConfig {
   [key: string]: unknown;
 }
 
+// Execa options for Foundry commands
+export interface FoundryExecOptions extends Options {
+  silent?: boolean;
+  profile?: string;
+}
+
 /**
  * Get forge config as a parsed json object.
  */
-export async function getForgeConfig(profile?: string): Promise<ForgeConfig> {
+export async function getForgeConfig(opts?: FoundryExecOptions): Promise<ForgeConfig> {
   const { stdout } = await execa("forge", ["config", "--json"], {
     stdio: ["inherit", "pipe", "pipe"],
-    env: { FOUNDRY_PROFILE: profile },
+    ...getExecOptions(opts),
   });
 
   return JSON.parse(stdout) as ForgeConfig;
@@ -34,80 +40,89 @@ export async function getForgeConfig(profile?: string): Promise<ForgeConfig> {
  * Get the value of "src" from forge config.
  * The path to the contract sources relative to the root of the project.
  */
-export async function getSrcDirectory(profile?: string): Promise<string> {
-  return (await getForgeConfig(profile)).src;
+export async function getSrcDirectory(opts?: FoundryExecOptions): Promise<string> {
+  return (await getForgeConfig(opts)).src;
 }
 
 /**
  * Get the value of "script" from forge config.
  * The path to the contract sources relative to the root of the project.
  */
-export async function getScriptDirectory(profile?: string): Promise<string> {
-  return (await getForgeConfig(profile)).script;
+export async function getScriptDirectory(opts?: FoundryExecOptions): Promise<string> {
+  return (await getForgeConfig(opts)).script;
 }
 
 /**
  * Get the value of "test" from forge config.
  * The path to the test contract sources relative to the root of the project.
  */
-export async function getTestDirectory(profile?: string): Promise<string> {
-  return (await getForgeConfig(profile)).test;
+export async function getTestDirectory(opts?: FoundryExecOptions): Promise<string> {
+  return (await getForgeConfig(opts)).test;
 }
 
 /**
  * Get the value of "out" from forge config.
  * The path to put contract artifacts in, relative to the root of the project.
  */
-export async function getOutDirectory(profile?: string): Promise<string> {
-  return (await getForgeConfig(profile)).out;
+export async function getOutDirectory(opts?: FoundryExecOptions): Promise<string> {
+  return (await getForgeConfig(opts)).out;
 }
 
 /**
  * Get the value of "eth_rpc_url" from forge config, default to "http://127.0.0.1:8545"
- * @param profile The foundry profile to use
+ * @param opts The options to pass to getForgeConfig
  * @returns The rpc url
  */
-export async function getRpcUrl(profile?: string): Promise<string> {
-  return (await getForgeConfig(profile)).eth_rpc_url || "http://127.0.0.1:8545";
+export async function getRpcUrl(opts?: FoundryExecOptions): Promise<string> {
+  return (await getForgeConfig(opts)).eth_rpc_url || "http://127.0.0.1:8545";
 }
 
 /**
  * Execute a forge command
  * @param args The arguments to pass to forge
- * @param options { profile?: The foundry profile to use; silent?: If true, nothing will be logged to the console }
+ * @param opts { profile?: The foundry profile to use; silent?: If true, nothing will be logged to the console }
  */
-export async function forge(
-  args: string[],
-  options?: { profile?: string; silent?: boolean; env?: NodeJS.ProcessEnv; cwd?: string },
-): Promise<void> {
-  const execOptions: Options<string> = {
-    env: { FOUNDRY_PROFILE: options?.profile, ...options?.env },
-    stdout: "inherit",
-    stderr: "pipe",
-    cwd: options?.cwd,
-  };
-
-  await (options?.silent ? execa("forge", args, execOptions) : execLog("forge", args, execOptions));
+export async function forge(args: string[], opts?: FoundryExecOptions): Promise<string | ExecaChildProcess> {
+  return execFoundry("forge", args, opts);
 }
 
 /**
  * Execute a cast command
  * @param args The arguments to pass to cast
+ * @param options The execution options
  * @returns Stdout of the command
  */
-export async function cast(args: string[], options?: { profile?: string }): Promise<string> {
-  return execLog("cast", args, {
-    env: { FOUNDRY_PROFILE: options?.profile },
-  });
+export async function cast(args: string[], options?: FoundryExecOptions): Promise<string | ExecaChildProcess> {
+  return execLog("cast", args, getExecOptions(options));
 }
 
 /**
  * Start an anvil chain
  * @param args The arguments to pass to anvil
+ * @param options The execution options
  * @returns Stdout of the command
  */
-export async function anvil(args: string[]): Promise<string> {
-  return execLog("anvil", args);
+export async function anvil(args: string[], options?: FoundryExecOptions): Promise<string | ExecaChildProcess> {
+  return execFoundry("anvil", args, options);
+}
+
+/**
+ * Execute a foundry command
+ * @param command The command to execute
+ * @param args The arguments to pass to the command
+ * @param options The executable options. If `silent` is true, nothing will be logged to the console
+ */
+async function execFoundry(
+  command: string,
+  args: string[],
+  options?: FoundryExecOptions,
+): Promise<string | ExecaChildProcess> {
+  const execOptions: Options<string> = {
+    stdout: "inherit",
+    stderr: "pipe",
+    ...getExecOptions(options),
+  };
+  return options?.silent ? execa(command, args, execOptions) : execLog(command, args, execOptions);
 }
 
 /**
@@ -115,6 +130,7 @@ export async function anvil(args: string[]): Promise<string> {
  * Throws an error if the command fails.
  * @param command The command to execute
  * @param args The arguments to pass to the command
+ * @param options The executable options
  * @returns The stdout of the command
  */
 async function execLog(command: string, args: string[], options?: Options<string>): Promise<string> {
@@ -129,4 +145,11 @@ async function execLog(command: string, args: string[], options?: Options<string
     errorMessage += `\nError running "${commandString}"`;
     throw new Error(errorMessage);
   }
+}
+
+function getExecOptions({ profile, env, silent: _, ...opts }: FoundryExecOptions = {}): Options<string> {
+  return {
+    env: { FOUNDRY_PROFILE: profile, ...env },
+    ...opts,
+  };
 }

--- a/packages/world/ts/node/buildSystemsManifest.ts
+++ b/packages/world/ts/node/buildSystemsManifest.ts
@@ -40,9 +40,8 @@ export async function buildSystemsManifest(opts: { rootDir: string; config: Worl
 
   const systems = await resolveSystems(opts);
 
-  // TODO: expose a `cwd` option to make sure this runs relative to `rootDir`
-  const forgeOutDir = await getForgeOutDirectory();
-  const contractArtifacts = await findContractArtifacts({ forgeOutDir });
+  const forgeOutDir = await getForgeOutDirectory({ cwd: opts.rootDir });
+  const contractArtifacts = await findContractArtifacts({ forgeOutDir: path.join(opts.rootDir, forgeOutDir) });
 
   function getSystemArtifact(system: ResolvedSystem): ContractArtifact {
     const artifact = contractArtifacts.find((a) => a.sourcePath === system.sourcePath && a.name === system.label);


### PR DESCRIPTION
- Add support for easily running the CLI from a local build (without linking) by exposing the cwd for all relevant commands, fixing the TODO in `buildSystemsManifest`. The cwd is obtained through the `configPath` for the project.
- Standardise interface for foundry commands with `execa`
- Add documentation for the CLI, including local development and debugging (it's cleaner to run the TypeScript directly rather than build and link, I found)