### PR TITLE
fix(explorer): return empty array for empty results (sqlite indexer)

### DIFF
--- a/.changeset/thin-pianos-repair.md
+++ b/.changeset/thin-pianos-repair.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/explorer": patch
+---
+
+The Explorer now returns an empty array for empty results, instead of throwing an error, when using the local indexer.

--- a/packages/explorer/src/app/(explorer)/api/sqlite-indexer/route.ts
+++ b/packages/explorer/src/app/(explorer)/api/sqlite-indexer/route.ts
@@ -19,8 +19,17 @@ export async function POST(request: Request) {
     const result = [];
     for (const { query } of queries) {
       const data = (await db?.prepare(query).all()) as SqliteTable;
-      if (!data || !data[0]) {
-        throw new Error("No data found");
+
+      if (!data || !Array.isArray(data)) {
+        throw new Error("Invalid query result");
+      }
+
+      if (data.length === 0) {
+        return Response.json({ result: [] });
+      }
+
+      if (!data[0]) {
+        throw new Error("Invalid row data");
       }
 
       const columns = Object.keys(data[0]).map((key) => key.replaceAll("_", "").toLowerCase());

--- a/packages/explorer/src/app/(explorer)/api/sqlite-indexer/route.ts
+++ b/packages/explorer/src/app/(explorer)/api/sqlite-indexer/route.ts
@@ -25,7 +25,8 @@ export async function POST(request: Request) {
       }
 
       if (data.length === 0) {
-        return Response.json({ result: [] });
+        result.push([]);
+        continue;
       }
 
       if (!data[0]) {


### PR DESCRIPTION
Explorer used to throw an error in case of empty results when using local indexer. Now returning an empty array instead of throwing an error.