### PR TITLE
feat(explorer): save searched namespace

### DIFF
--- a/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TableSelector.tsx
+++ b/packages/explorer/src/app/(explorer)/[chainName]/worlds/[worldAddress]/explore/TableSelector.tsx
@@ -36,6 +36,7 @@ export function TableSelector({ tables }: { tables?: Table[] }) {
   const { id: chainId } = useChain();
   const [selectedTableId, setTableId] = useQueryState("tableId");
   const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
   const selectedTableConfig = tables?.find(({ tableId }) => tableId === selectedTableId);
 
   useEffect(() => {
@@ -68,7 +69,12 @@ export function TableSelector({ tables }: { tables?: Table[] }) {
 
         <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
           <Command>
-            <CommandInput placeholder="Search tables..." className="font-mono" />
+            <CommandInput
+              placeholder="Search tables..."
+              className="font-mono"
+              value={searchValue}
+              onValueChange={setSearchValue}
+            />
             <CommandList>
               <CommandEmpty className="py-4 text-center font-mono text-sm">No table found.</CommandEmpty>
               <CommandGroup>


### PR DESCRIPTION
Save searched namespace so that context is not lost when re-opening namespace search menu.

![CleanShot 2025-01-20 at 17 41 59](https://github.com/user-attachments/assets/c59bbc51-5282-4766-b825-840393ec55ec)
