### PR TITLE
build: use turbo in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . /app
 WORKDIR /app
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run -r build
+RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run build --force
 
 FROM mud AS store-indexer
 WORKDIR /app/packages/store-indexer


### PR DESCRIPTION
I think the error I am seeing in https://github.com/latticexyz/mud/actions/runs/12892450708/job/35947142354 is due to race conditions? Going to switch this over to turbo to see if that helps