### PR TITLE
fix(create-mud): ensure gitignore is copied

### DIFF
--- a/packages/create-mud/scripts/copy-templates.ts
+++ b/packages/create-mud/scripts/copy-templates.ts
@@ -39,8 +39,8 @@ const __dirname = path.dirname(__filename);
 
     if (/package\.json$/.test(destPath)) {
       let source = await fs.readFile(sourcePath, "utf-8");
-      // Replace all MUD package links with mustache placeholder used by create-create-app
-      // that will be replaced with the latest MUD version number when the template is used.
+      // Replace all MUD package links with placeholder that we can use to later replace
+      // with the latest MUD version number when the template is used.
       source = source.replace(/"([^"]+)":\s*"(link|file):[^"]+"/g, (match, packageName) =>
         mudPackageNames.includes(packageName) ? `"${packageName}": "{{mud-version}}"` : match,
       );
@@ -51,8 +51,13 @@ const __dirname = path.dirname(__filename);
     }
     // Replace template workspace root `tsconfig.json` files (which have paths relative to monorepo)
     // with one that inherits our base tsconfig.
-    else if (/templates\/[^/]+\/tsconfig\.json/.test(destPath)) {
+    else if (/templates\/[^/]+\/tsconfig\.json$/.test(destPath)) {
       await fs.copyFile(path.join(__dirname, "tsconfig.base.json"), destPath);
+    }
+    // npm excludes .gitignore files during packaging/publishing, so we move this aside for now.
+    // When creating a project from the template, we'll move this back.
+    else if (/\.gitignore$/.test(destPath)) {
+      await fs.copyFile(sourcePath, destPath.replace(/\.gitignore$/, ".gitignore_"));
     } else {
       await fs.copyFile(sourcePath, destPath);
     }

--- a/packages/create-mud/src/bin/cli.ts
+++ b/packages/create-mud/src/bin/cli.ts
@@ -50,6 +50,8 @@ async function run() {
         if (/package\.json$/.test(sourceFile)) {
           const source = await fs.readFile(sourceFile, "utf-8");
           await fs.writeFile(destFile, source.replaceAll(/{{mud-version}}/g, args.mudVersion), "utf-8");
+        } else if (/\.gitignore_$/.test(sourceFile)) {
+          await fs.copyFile(sourceFile, destFile.replace(/_$/, ""));
         } else {
           await fs.copyFile(sourceFile, destFile);
         }


### PR DESCRIPTION
npm excludes `.gitignore` when packaging and publishing, so although these were getting copied with build, they were missing from npm artifacts:
https://www.npmjs.com/package/create-mud/v/2.2.17-86f455c0a09d5d8af64d030669ebf30ffa71420b?activeTab=code

we resolve this by moving the file aside and moving it back when creating the template

no changeset because these new templates aren't published yet and this fix is captured under existing changesets