### PR TITLE
fix(cli): support verifying systems with linked libraries

### DIFF
--- a/.changeset/famous-doors-listen.md
+++ b/.changeset/famous-doors-listen.md
@@ -2,4 +2,4 @@
 "@latticexyz/cli": patch
 ---
 
-The `verify` cli command will be able to verify systems with library link references
+The `verify` command should now be able to correctly verify systems using public libraries.

--- a/.changeset/famous-doors-listen.md
+++ b/.changeset/famous-doors-listen.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+The `verify` cli command will be able to verify systems with library link references


### PR DESCRIPTION
The `verify` command currently looks up system addresses using the bytecode artifact without considering library link references. This fix uses the same lookup logic as the `deploy` command to inject these references into the bytecode used for create2 address lookup.