### PR TITLE
fix(store-sync): handle user ops in waitForTransaction

### DIFF
--- a/.changeset/empty-shoes-thank.md
+++ b/.changeset/empty-shoes-thank.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Updated `waitForTransaction` to handle receipt status for user operations.

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -344,16 +344,16 @@ export async function createStoreSync({
     const hasTransaction$ = recentStoredBlocks$.pipe(
       // We use `mergeMap` instead of `concatMap` here to send the fetch request immediately when a new block range appears,
       // instead of sending the next request only when the previous one completed.
-      mergeMap(async (blocks) => {
-        for (const block of blocks) {
-          // If storage adapter block had Store event logs associated with tx, it must have succeeded.
-          if (block.logs.some((log) => log.transactionHash === tx)) {
-            return { blockNumber: block.blockNumber, status: "success", transactionHash: tx } as const;
+      mergeMap(async (storedBlocks) => {
+        for (const storedBlock of storedBlocks) {
+          // If stored block had Store event logs associated with tx, it must have succeeded.
+          if (storedBlock.logs.some((log) => log.transactionHash === tx)) {
+            return { blockNumber: storedBlock.blockNumber, status: "success", transactionHash: tx } as const;
           }
         }
 
         try {
-          const lastStoredBlock = blocks[0];
+          const lastStoredBlock = storedBlocks[0];
           debug("fetching tx receipt for block", lastStoredBlock.blockNumber);
           const receipt = await getAction(publicClient, getTransactionReceipt, "getTransactionReceipt")({ hash: tx });
 

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -346,10 +346,9 @@ export async function createStoreSync({
       // instead of sending the next request only when the previous one completed.
       mergeMap(async (blocks) => {
         for (const block of blocks) {
-          // If block had Store event logs associated with tx, it must have succeeded.
-          const hasStoreLogs = block.logs.some((log) => log.transactionHash === tx);
-          if (hasStoreLogs) {
-            return { blockNumber: block.blockNumber, status: "success" as const, transactionHash: tx };
+          // If storage adapter block had Store event logs associated with tx, it must have succeeded.
+          if (block.logs.some((log) => log.transactionHash === tx)) {
+            return { blockNumber: block.blockNumber, status: "success", transactionHash: tx } as const;
           }
         }
 


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/3516

I don't love that we're kinda lying about the `status` of a transaction in the return value of this, but given that it's our own `WaitForTransactionResult`, this seems fine?