### PR TITLE
feat(common): export getFeeRef

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -18,6 +18,7 @@ export * from "./sendTransaction";
 export * from "./spliceHex";
 export * from "./transportObserver";
 export * from "./writeContract";
+export * from "./getFeeRef";
 
 /** @deprecated use `getContract` instead */
 export { createContract } from "./deprecated/createContract";


### PR DESCRIPTION
`getFeeRef` handles auto refreshing the latest fees so should be exposed to clients so they can also make use of them.

For example, in Biomes we set the priority fee based on a base fee threshold.