### PR TITLE
fix(block-logs-stream): add missing check for validateBlockRange

### DIFF
--- a/packages/block-logs-stream/src/getLogs.ts
+++ b/packages/block-logs-stream/src/getLogs.ts
@@ -33,7 +33,7 @@ export async function getLogs(opts: GetLogsOptions): Promise<Log[]> {
     ],
   });
 
-  if (!opts.internal_clientOptions || !opts.internal_clientOptions.validateBlockRange) {
+  if (!opts.internal_clientOptions?.validateBlockRange) {
     const logs = await getRpcClient(opts).request(logsRequest);
     return logs.map((log) => formatLog(log));
   }

--- a/packages/block-logs-stream/src/getLogs.ts
+++ b/packages/block-logs-stream/src/getLogs.ts
@@ -33,7 +33,7 @@ export async function getLogs(opts: GetLogsOptions): Promise<Log[]> {
     ],
   });
 
-  if (!opts.internal_clientOptions) {
+  if (!opts.internal_clientOptions || !opts.internal_clientOptions.validateBlockRange) {
     const logs = await getRpcClient(opts).request(logsRequest);
     return logs.map((log) => formatLog(log));
   }


### PR DESCRIPTION
There's a check for `internal_clientOptions` being defined but not if `validateBlockRange` is set to true in `getLogs`