### PR TITLE
fix(entrykit): accountkit session was json encoded

### DIFF
--- a/packages/entrykit/src/getSessionSigner.ts
+++ b/packages/entrykit/src/getSessionSigner.ts
@@ -8,7 +8,9 @@ export function getSessionSigner(userAddress: Address) {
     store.getState().signers[label] ??
     (() => {
       // attempt to reuse previous AccountKit session
-      const deprecatedPrivateKey = localStorage.getItem(`mud:appSigner:privateKey:${userAddress.toLowerCase()}`);
+      const deprecatedPrivateKey = localStorage
+        .getItem(`mud:appSigner:privateKey:${userAddress.toLowerCase()}`)
+        ?.replace(/^"(.*)"$/, "$1");
       const privateKey = isHex(deprecatedPrivateKey) ? deprecatedPrivateKey : generatePrivateKey();
       store.setState((state) => ({
         signers: {


### PR DESCRIPTION
stripping quotes with regex is easier than JSON parsing because we'd have to wrap the `JSON.parse` in a try/catch and I didn't want this to get that complex