### PR TITLE
refactor(world-module-erc20): change erc20 module table names to pascal case

### DIFF
--- a/.changeset/ninety-beers-behave.md
+++ b/.changeset/ninety-beers-behave.md
@@ -2,4 +2,4 @@
 "@latticexyz/world-module-erc20": patch
 ---
 
-Changed erc20 module table names to pascal case for consistency.
+Updated table names to pascal case for consistency.

--- a/.changeset/ninety-beers-behave.md
+++ b/.changeset/ninety-beers-behave.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world-module-erc20": patch
+---
+
+Changed erc20 module table names to pascal case for consistency.

--- a/packages/world-module-erc20/src/experimental/Constants.sol
+++ b/packages/world-module-erc20/src/experimental/Constants.sol
@@ -6,7 +6,7 @@ import { ResourceId, WorldResourceIdLib } from "@latticexyz/world/src/WorldResou
 
 library ModuleConstants {
   bytes14 internal constant NAMESPACE = "erc20-module";
-  bytes16 internal constant REGISTRY_TABLE_NAME = "ERC20_REGISTRY";
+  bytes16 internal constant REGISTRY_TABLE_NAME = "ERC20Registry";
 
   function namespaceId() internal pure returns (ResourceId) {
     return WorldResourceIdLib.encodeNamespace(NAMESPACE);
@@ -18,19 +18,19 @@ library ModuleConstants {
 }
 
 library ERC20TableNames {
-  bytes16 internal constant TOTAL_SUPPLY = "TOTAL_SUPPLY";
+  bytes16 internal constant TOTAL_SUPPLY = "TotalSupply";
 
-  bytes16 internal constant BALANCES = "BALANCES";
+  bytes16 internal constant BALANCES = "Balances";
 
-  bytes16 internal constant ALLOWANCES = "ALLOWANCES";
+  bytes16 internal constant ALLOWANCES = "Allowances";
 
-  bytes16 internal constant METADATA = "METADATA";
+  bytes16 internal constant METADATA = "Metadata";
 }
 
 library OwnableTableNames {
-  bytes16 internal constant OWNER = "OWNER";
+  bytes16 internal constant OWNER = "Owner";
 }
 
 library PausableTableNames {
-  bytes16 internal constant PAUSED = "PAUSED";
+  bytes16 internal constant PAUSED = "Paused";
 }


### PR DESCRIPTION
This makes it consistent with other modules.