### PR TITLE
fix(entrykit): session client uses smart account

### DIFF
--- a/.changeset/serious-rules-whisper.md
+++ b/.changeset/serious-rules-whisper.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/entrykit": patch
+---
+
+Clarified `SessionClient` type as using a `SmartAccount` under the hood so that it can be used with smart account-related Viem actions.

--- a/packages/entrykit/src/common.ts
+++ b/packages/entrykit/src/common.ts
@@ -1,9 +1,12 @@
 import { resourceToHex } from "@latticexyz/common";
 import { Client, Chain, Transport, Account, parseAbi, ClientConfig, Address } from "viem";
 import worldConfig from "@latticexyz/world/mud.config";
+import { SmartAccount } from "viem/account-abstraction";
 
 export type ConnectedClient<chain extends Chain = Chain> = Client<Transport, chain, Account>;
-export type SessionClient<chain extends Chain = Chain> = ConnectedClient<chain> & { readonly userAddress: Address };
+export type SessionClient<chain extends Chain = Chain> = Client<Transport, chain, SmartAccount> & {
+  readonly userAddress: Address;
+};
 
 export const defaultClientConfig = {
   pollingInterval: 250,

--- a/packages/entrykit/src/getSessionAccount.ts
+++ b/packages/entrykit/src/getSessionAccount.ts
@@ -10,6 +10,7 @@ export async function getSessionAccount<chain extends Chain>({
   client: Client<Transport, chain>;
   userAddress: Address;
 }): Promise<SmartAccount> {
-  const sessionSigner = getSessionSigner(userAddress);
-  return await toSimpleSmartAccount({ client, owner: sessionSigner });
+  const signer = getSessionSigner(userAddress);
+  const account = await toSimpleSmartAccount({ client, owner: signer });
+  return account;
 }


### PR DESCRIPTION
if you try to use `sessionClient` with a function like `sendUserOperation`, it fails type checking