### PR TITLE
fix(store-sync): skip invalid utf-8 characters in strings before inserting into postgres

### DIFF
--- a/.changeset/tall-days-doubt.md
+++ b/.changeset/tall-days-doubt.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Since Postgres doesn't support `\x00` bytes in strings, the decoded postgres indexer now removes `\x00` bytes from decoded strings.

--- a/packages/store-sync/src/postgres-decoded/cleanStrings.ts
+++ b/packages/store-sync/src/postgres-decoded/cleanStrings.ts
@@ -1,0 +1,10 @@
+import { SchemaToPrimitives, ValueSchema } from "@latticexyz/protocol-parser/internal";
+
+export function cleanStrings<TSchema extends ValueSchema>(
+  schema: TSchema,
+  value: SchemaToPrimitives<TSchema>,
+): SchemaToPrimitives<TSchema> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, value]) => [key, schema[key] === "string" ? value.replaceAll("\x00", "") : value]),
+  ) as SchemaToPrimitives<TSchema>;
+}

--- a/packages/store-sync/src/postgres-decoded/createStorageAdapter.ts
+++ b/packages/store-sync/src/postgres-decoded/createStorageAdapter.ts
@@ -13,6 +13,7 @@ import { setupTables } from "../postgres/setupTables";
 import { getTables } from "./getTables";
 import { hexToResource, resourceToLabel } from "@latticexyz/common";
 import { GetRpcClientOptions } from "@latticexyz/block-logs-stream";
+import { cleanStrings } from "./cleanStrings";
 
 // Currently assumes one DB per chain ID
 
@@ -93,11 +94,14 @@ export async function createStorageAdapter({
             continue;
           }
 
-          const value = decodeValueArgs(table.valueSchema, {
-            staticData: record.staticData ?? "0x",
-            encodedLengths: record.encodedLengths ?? "0x",
-            dynamicData: record.dynamicData ?? "0x",
-          });
+          const value = cleanStrings(
+            table.valueSchema,
+            decodeValueArgs(table.valueSchema, {
+              staticData: record.staticData ?? "0x",
+              encodedLengths: record.encodedLengths ?? "0x",
+              dynamicData: record.dynamicData ?? "0x",
+            }),
+          );
 
           debug("upserting record", {
             namespace: table.namespace,

--- a/packages/store-sync/src/postgres-decoded/removeNullCharacters.ts
+++ b/packages/store-sync/src/postgres-decoded/removeNullCharacters.ts
@@ -1,6 +1,6 @@
 import { SchemaToPrimitives, ValueSchema } from "@latticexyz/protocol-parser/internal";
 
-export function cleanStrings<TSchema extends ValueSchema>(
+export function removeNullCharacters<TSchema extends ValueSchema>(
   schema: TSchema,
   value: SchemaToPrimitives<TSchema>,
 ): SchemaToPrimitives<TSchema> {


### PR DESCRIPTION
Currently an invalid UTF-8 character in a `string` type column makes the decoded postgres indexer error with `PostgresError: invalid byte sequence for encoding "UTF8": 0x00`. This PR adds a cleanup step before upserting values into postgres to remove `0x00` characters.