### PR TITLE
test: only snapshot anvil state in beforeEach

### DIFF
--- a/packages/common/src/account/kms/kmsKeyToAccount.test.ts
+++ b/packages/common/src/account/kms/kmsKeyToAccount.test.ts
@@ -8,11 +8,10 @@ import { waitForTransaction } from "../../test/waitForTransaction";
 import { getTransactionReceipt, sendTransaction, setBalance } from "viem/actions";
 
 describe.skipIf(!process.env.AWS_ENDPOINT_URL)("kmsKeyToAccount", () => {
+  beforeEach(snapshotAnvilState);
+
   let account: KmsAccount;
   let keyId: string;
-
-  beforeAll(snapshotAnvilState);
-  beforeEach(snapshotAnvilState);
 
   beforeAll(async () => {
     const client = new KMSClient({

--- a/packages/store-sync/src/stash/createStorageAdapter.test.ts
+++ b/packages/store-sync/src/stash/createStorageAdapter.test.ts
@@ -8,7 +8,6 @@ import { createStash } from "@latticexyz/stash/internal";
 import { createTestClient, snapshotAnvilState } from "with-anvil";
 
 describe("createStorageAdapter", async () => {
-  beforeAll(snapshotAnvilState);
   beforeEach(snapshotAnvilState);
 
   beforeAll(async () => {

--- a/packages/store-sync/src/zustand/createStorageAdapter.test.ts
+++ b/packages/store-sync/src/zustand/createStorageAdapter.test.ts
@@ -8,7 +8,6 @@ import { getBlockNumber } from "viem/actions";
 import { createTestClient, snapshotAnvilState } from "with-anvil";
 
 describe("createStorageAdapter", async () => {
-  beforeAll(snapshotAnvilState);
   beforeEach(snapshotAnvilState);
 
   beforeAll(async () => {

--- a/packages/store/ts/flattenStoreLogs.test.ts
+++ b/packages/store/ts/flattenStoreLogs.test.ts
@@ -7,7 +7,6 @@ import { summarizeLogs } from "./test/summarizeLogs";
 import { createTestClient, snapshotAnvilState } from "with-anvil";
 
 describe("flattenStoreLogs", async () => {
-  beforeAll(snapshotAnvilState);
   beforeEach(snapshotAnvilState);
 
   beforeAll(async () => {

--- a/packages/store/ts/getStoreLogs.test.ts
+++ b/packages/store/ts/getStoreLogs.test.ts
@@ -7,7 +7,6 @@ import { summarizeLogs } from "./test/summarizeLogs";
 import { createTestClient, snapshotAnvilState } from "with-anvil";
 
 describe("getStoreLogs", async () => {
-  beforeAll(snapshotAnvilState);
   beforeEach(snapshotAnvilState);
 
   beforeAll(async () => {

--- a/test/with-anvil/src/snapshotAnvilState.ts
+++ b/test/with-anvil/src/snapshotAnvilState.ts
@@ -1,10 +1,14 @@
 import { dumpState, loadState } from "viem/actions";
 import { createTestClient } from "./createTestClient";
+import { getAnvilRpcUrl } from "./getAnvilRpcUrl";
 
 export async function snapshotAnvilState() {
   const testClient = createTestClient();
+  const rpcUrl = getAnvilRpcUrl();
+  console.log("snapshotting", rpcUrl);
   const state = await dumpState(testClient);
   return async (): Promise<void> => {
+    console.log("reverting to snapshot", rpcUrl);
     await loadState(testClient, { state });
   };
 }


### PR DESCRIPTION
trying to address flaky tests in CI

this may leave stuff around in the chain from the deploy in `beforeAll`, so if this doesn't do the trick, we might try adding snapshots back into `beforeAll` but alongside the deploy like
```ts
beforeAll(async () => {
  const resetAnvilState = await snapshotAnvilState();
  await deployMockGame();
  return resetAnvilState;
});
```