### PR TITLE
fix(entrykit): require bundler

### DIFF
--- a/.changeset/long-dolls-jam.md
+++ b/.changeset/long-dolls-jam.md
@@ -1,0 +1,21 @@
+---
+"@latticexyz/entrykit": patch
+---
+
+Using EntryKit without a configured bundler will now throw an error.
+
+Redstone, Garnet, Rhodolite, and Anvil chains come preconfigured. For other chains, you can a bundler RPC URL to your chain config via
+
+```ts
+import type { Chain } from "viem";
+
+const chain = {
+  ...
+  rpcUrls: {
+    ...
+    bundler: {
+      http: ["https://..."],
+    },
+  },  
+} as const satisfies Chain;
+```

--- a/.changeset/long-dolls-jam.md
+++ b/.changeset/long-dolls-jam.md
@@ -16,6 +16,6 @@ const chain = {
     bundler: {
       http: ["https://..."],
     },
-  },  
+  },
 } as const satisfies Chain;
 ```

--- a/.changeset/shy-adults-train.md
+++ b/.changeset/shy-adults-train.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Added bundler RPC URL to Garnet chain config.

--- a/packages/common/src/chains/garnet.ts
+++ b/packages/common/src/chains/garnet.ts
@@ -3,6 +3,10 @@ import type { MUDChain } from "./types";
 
 export const garnet = {
   ...garnetConfig,
+  rpcUrls: {
+    ...garnetConfig.rpcUrls,
+    bundler: garnetConfig.rpcUrls.default,
+  },
   iconUrls: ["https://redstone.xyz/chain-icons/garnet.png"],
   indexerUrl: "https://indexer.mud.garnetchain.com",
 } as const satisfies MUDChain;

--- a/packages/entrykit/src/EntryKitConfigProvider.tsx
+++ b/packages/entrykit/src/EntryKitConfigProvider.tsx
@@ -4,6 +4,7 @@ import { RainbowKitProvider, midnightTheme } from "@rainbow-me/rainbowkit";
 import { EntryKitConfig } from "./config/output";
 import { Chain } from "viem";
 import { useChains } from "wagmi";
+import { getBundlerTransport } from "./getBundlerTransport";
 
 type ContextValue = EntryKitConfig & {
   chain: Chain;
@@ -26,6 +27,9 @@ export function EntryKitConfigProvider({ config, children }: Props) {
   const chains = useChains();
   const chain = chains.find(({ id }) => id === config.chainId);
   if (!chain) throw new Error(`Could not find configured chain for chain ID ${config.chainId}.`);
+
+  // This throws when no we can't find a bundler to talk to, so use it to validate the chain.
+  getBundlerTransport(chain);
 
   return (
     <RainbowKitProvider


### PR DESCRIPTION
"no bundler" error was being swallowed and resulted in an infinite spinner (will fix the error visibility seperately)

it now looks like:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/7ae4f864-da3b-48b6-91c7-92ed490133e5" />

also added bundler config to garnet chain