### PR TITLE
feat(cli): load env based on foundry profile

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "build": "pnpm run build:js && pnpm run build:test-tables",
-    "build:js": "tsup && chmod +x ./dist/mud.js",
+    "build:js": "tsup",
     "build:test-tables": "tsx ./scripts/generate-test-tables.ts",
     "clean": "pnpm run clean:js && pnpm run clean:test-tables",
     "clean:js": "shx rm -rf dist",
@@ -59,7 +59,7 @@
     "chalk": "^5.0.1",
     "chokidar": "^3.5.3",
     "debug": "^4.3.4",
-    "dotenv": "^16.0.3",
+    "dotenv": "^16.4.7",
     "execa": "^9.5.2",
     "find-up": "^6.3.0",
     "glob": "^10.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,8 +185,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4
       dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
+        specifier: ^16.4.7
+        version: 16.4.7
       execa:
         specifier: ^9.5.2
         version: 9.5.2
@@ -1503,9 +1503,6 @@ importers:
       '@latticexyz/world-modules':
         specifier: workspace:*
         version: link:../../packages/world-modules
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
       ds-test:
         specifier: https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0
         version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
@@ -1530,9 +1527,6 @@ importers:
       '@latticexyz/world-modules':
         specifier: workspace:*
         version: link:../../packages/world-modules
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
       ds-test:
         specifier: https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0
         version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
@@ -1557,9 +1551,6 @@ importers:
       '@latticexyz/world-modules':
         specifier: workspace:*
         version: link:../../packages/world-modules
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
       ds-test:
         specifier: https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0
         version: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
@@ -7092,6 +7083,10 @@ packages:
 
   dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
   drizzle-orm@0.28.5:
@@ -19892,6 +19887,8 @@ snapshots:
       webidl-conversions: 7.0.0
 
   dotenv@16.0.3: {}
+
+  dotenv@16.4.7: {}
 
   drizzle-orm@0.28.5(@opentelemetry/api@1.8.0)(@types/better-sqlite3@7.6.4)(@types/sql.js@1.4.4)(better-sqlite3@8.6.0)(kysely@0.26.3)(postgres@3.3.5)(sql.js@1.8.0):
     optionalDependencies:

--- a/test/mock-game-contracts/package.json
+++ b/test/mock-game-contracts/package.json
@@ -18,7 +18,6 @@
     "@latticexyz/store": "workspace:*",
     "@latticexyz/world": "workspace:*",
     "@latticexyz/world-modules": "workspace:*",
-    "dotenv": "^16.0.3",
     "ds-test": "https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#74cfb77e308dd188d2f58864aaf44963ae6b88b1"
   }

--- a/test/puppet-modules/package.json
+++ b/test/puppet-modules/package.json
@@ -15,7 +15,6 @@
     "@latticexyz/store": "workspace:*",
     "@latticexyz/world": "workspace:*",
     "@latticexyz/world-modules": "workspace:*",
-    "dotenv": "^16.0.3",
     "ds-test": "https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#74cfb77e308dd188d2f58864aaf44963ae6b88b1"
   }

--- a/test/system-libraries/package.json
+++ b/test/system-libraries/package.json
@@ -15,7 +15,6 @@
     "@latticexyz/store": "workspace:*",
     "@latticexyz/world": "workspace:*",
     "@latticexyz/world-modules": "workspace:*",
-    "dotenv": "^16.0.3",
     "ds-test": "https://github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
     "forge-std": "https://github.com/foundry-rs/forge-std.git#74cfb77e308dd188d2f58864aaf44963ae6b88b1"
   }


### PR DESCRIPTION
closes https://github.com/latticexyz/mud/issues/3565

I am not in love with this approach because it adds an implicit `--profile` flag to all our commands, but there's not really another way to do this because
- we need to load the env files before importing commands (due to how debug and other libs use env on import)
- to avoid unnecessarily overriding env vars (like ones passed directly into the command), we have to load env files in order of most-specific to least-specific (which means we need to know the value of the `--profile` flag ahead of time)


