### PR TITLE
chore(store-indexer): start frontend with decoded backend

### DIFF
--- a/.changeset/lemon-rivers-run.md
+++ b/.changeset/lemon-rivers-run.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-indexer": patch
+---
+
+`pnpm start:postgres-decoded` now starts both the indexer backend and frontend.

--- a/packages/store-indexer/package.json
+++ b/packages/store-indexer/package.json
@@ -37,7 +37,7 @@
     "dev": "tsup --watch",
     "lint": "eslint .",
     "start:postgres": "concurrently -n indexer,frontend -c cyan,magenta 'tsx src/bin/postgres-indexer' 'tsx src/bin/postgres-frontend'",
-    "start:postgres-decoded": "tsx src/bin/postgres-decoded-indexer",
+    "start:postgres-decoded": "concurrently -n indexer,frontend -c cyan,magenta 'tsx src/bin/postgres-decoded-indexer' 'tsx src/bin/postgres-frontend'",
     "start:postgres-decoded:local": "DATABASE_URL=postgres://127.0.0.1/postgres RPC_HTTP_URL=http://127.0.0.1:8545 pnpm start:postgres-decoded",
     "start:postgres-decoded:testnet": "DATABASE_URL=postgres://127.0.0.1/postgres RPC_HTTP_URL=https://rpc.holesky.redstone.xyz pnpm start:postgres-decoded",
     "start:postgres:local": "DATABASE_URL=postgres://127.0.0.1/postgres RPC_HTTP_URL=http://127.0.0.1:8545 pnpm start:postgres",


### PR DESCRIPTION
`pnpm start:postgres` starts both indexer backend and frontend, `pnpm start:postgres-decoded` was just starting the backend (but docs said it starts both)