### PR TITLE
build: base tsup config

### DIFF
--- a/packages/abi-ts/tsup.config.ts
+++ b/packages/abi-ts/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/exports/internal.ts", "src/bin/abi-ts.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/block-logs-stream/tsup.config.ts
+++ b/packages/block-logs-stream/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/exports/index.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -3,6 +3,7 @@ import { globSync } from "glob";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { MudPackages } from "./src/common";
+import { baseConfig } from "../../tsup.config.base";
 
 const mudWorkspace = path.normalize(`${__dirname}/../..`);
 
@@ -18,19 +19,9 @@ const mudPackages: MudPackages = Object.fromEntries(
 );
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts", "src/mud.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
   env: {
     MUD_PACKAGES: JSON.stringify(mudPackages),
   },
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/common/tsup.config.ts
+++ b/packages/common/tsup.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     index: "src/index.ts",
     actions: "src/actions/index.ts",
@@ -13,15 +15,4 @@ export default defineConfig((opts) => ({
     kms: "src/exports/kms.ts",
     internal: "src/exports/internal.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/config/tsup.config.ts
+++ b/packages/config/tsup.config.ts
@@ -1,20 +1,11 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     index: "src/exports/index.ts",
     internal: "src/exports/internal.ts",
     "deprecated/node": "src/deprecated/node/index.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/create-mud/tsup.config.ts
+++ b/packages/create-mud/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/bin/cli.ts"],
-  target: "esnext",
-  format: ["esm"],
-  minify: true,
-  sourcemap: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/dev-tools/tsup.config.ts
+++ b/packages/dev-tools/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "tsup";
 import packageJson from "./package.json";
+import { baseConfig } from "../../tsup.config.base";
 
 // tsup doesn't bundle deps by default (https://tsup.egoist.dev/#excluding-packages),
 // but we want to do that for dev-tools because it's used as a standalone package.
@@ -13,21 +14,11 @@ const peerDeps = Object.keys(packageJson.peerDependencies);
 const bundledDeps = Object.keys(packageJson.dependencies).filter((dep) => !peerDeps.includes(dep));
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
   injectStyle: true,
   // bundle all non-peer deps
   noExternal: bundledDeps,
   // don't code split otherwise dep imports in bundle seem to break
   splitting: false,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/entrykit/tsup.config.ts
+++ b/packages/entrykit/tsup.config.ts
@@ -1,20 +1,13 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 // import packageJson from "./package.json";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   outDir: "dist/tsup",
   entry: ["src/exports/index.ts", "src/exports/internal.ts", "src/bin/deploy.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
   // Because we're injecting CSS via shadow DOM, we'll disable style injection and load CSS as a base64 string.
   // TODO: figure out how to do this conditionally for only specific imports?
   injectStyle: false,
   loader: { ".css": "text" },
-  dts: true,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/explorer/tsup.config.ts
+++ b/packages/explorer/tsup.config.ts
@@ -1,17 +1,8 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   tsconfig: "tsconfig.tsup.json",
   entry: ["src/bin/explorer.ts", "src/exports/observer.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: false,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/faucet/tsup.config.ts
+++ b/packages/faucet/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts", "src/bin/faucet-server.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/gas-report/tsup.config.ts
+++ b/packages/gas-report/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["ts/exports/internal.ts", "ts/bin/gas-report.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/protocol-parser/tsup.config.ts
+++ b/packages/protocol-parser/tsup.config.ts
@@ -1,19 +1,10 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     index: "src/exports/index.ts",
     internal: "src/exports/internal.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/recs/tsup.config.ts
+++ b/packages/recs/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts", "src/deprecated/index.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/schema-type/tsup.config.ts
+++ b/packages/schema-type/tsup.config.ts
@@ -1,22 +1,11 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     index: "src/typescript/exports/index.ts",
     internal: "src/typescript/exports/internal.ts",
     deprecated: "src/typescript/exports/deprecated.ts",
   },
-  outDir: "dist",
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  injectStyle: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/solhint-config-mud/tsup.config.ts
+++ b/packages/solhint-config-mud/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts"],
-  target: "esnext",
-  format: ["cjs"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/solhint-plugin-mud/tsup.config.ts
+++ b/packages/solhint-plugin-mud/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts"],
-  target: "esnext",
-  format: ["cjs"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/stash/tsup.config.ts
+++ b/packages/stash/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/exports/index.ts", "src/exports/internal.ts", "src/exports/react.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/store-indexer/tsup.config.ts
+++ b/packages/store-indexer/tsup.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: [
     "src/index.ts",
     "src/bin/postgres-frontend.ts",
@@ -8,15 +10,4 @@ export default defineConfig((opts) => ({
     "src/bin/postgres-decoded-indexer.ts",
     "src/bin/sqlite-indexer.ts",
   ],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/store-sync/tsup.config.ts
+++ b/packages/store-sync/tsup.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: [
     "src/index.ts",
     "src/sqlite/index.ts",
@@ -14,15 +16,4 @@ export default defineConfig((opts) => ({
     "src/exports/internal.ts",
     "src/exports/react.ts",
   ],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/store/tsup.config.ts
+++ b/packages/store/tsup.config.ts
@@ -1,21 +1,12 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
     index: "ts/exports/index.ts",
     internal: "ts/exports/internal.ts",
     codegen: "ts/codegen/index.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/index.ts"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/vite-plugin-mud/tsup.config.ts
+++ b/packages/vite-plugin-mud/tsup.config.ts
@@ -1,16 +1,7 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: ["src/**"],
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/world-module-callwithsignature/tsup.config.ts
+++ b/packages/world-module-callwithsignature/tsup.config.ts
@@ -1,19 +1,10 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
     internal: "ts/exports/internal.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/world-module-erc20/tsup.config.ts
+++ b/packages/world-module-erc20/tsup.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
-export default defineConfig({
+export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
     internal: "ts/exports/internal.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  dts: !process.env.TSUP_SKIP_DTS,
-  sourcemap: true,
-  clean: true,
-  minify: true,
-});
+}));

--- a/packages/world-module-metadata/tsup.config.ts
+++ b/packages/world-module-metadata/tsup.config.ts
@@ -1,18 +1,9 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/world-modules/tsup.config.ts
+++ b/packages/world-modules/tsup.config.ts
@@ -1,18 +1,9 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/packages/world/tsup.config.ts
+++ b/packages/world/tsup.config.ts
@@ -1,21 +1,12 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.config.base";
 
 export default defineConfig((opts) => ({
+  ...baseConfig(opts),
   entry: {
     "mud.config": "mud.config.ts",
     index: "ts/exports/index.ts",
     internal: "ts/exports/internal.ts",
     node: "ts/node/index.ts",
   },
-  target: "esnext",
-  format: ["esm"],
-  sourcemap: true,
-  minify: true,
-  // don't generate DTS during watch mode because it's slow
-  // we're likely using TS source in this mode anyway
-  dts: !opts.watch,
-  // don't clean during watch mode to avoid removing
-  // previously-built DTS files, which other build tasks
-  // depend on
-  clean: !opts.watch,
 }));

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -1,0 +1,20 @@
+import { Options } from "tsup";
+
+/**
+ * Shared tsup config across all packages.
+ * @dev Be careful adjusting this config!
+ */
+export function baseConfig(opts: Options): Options {
+  return {
+    target: "esnext",
+    format: ["esm"],
+    sourcemap: true,
+    // don't generate DTS during watch mode because it's slow
+    // we're likely using TS source in this mode anyway
+    dts: !opts.watch,
+    // don't clean during watch mode to avoid removing
+    // previously-built DTS files, which other build tasks
+    // depend on
+    clean: !opts.watch,
+  };
+}


### PR DESCRIPTION
pulled out of https://github.com/latticexyz/mud/pull/3561

intentionally removed minifying because it's 1) much harder to dig through dist source and 2) doesn't improve the package size much and 3) makes build take longer 

likely that the end-user bundle will minify anyway