### PR TITLE
refactor(world): add default-reverting methods to Module

### DIFF
--- a/.changeset/clean-apricots-hide.md
+++ b/.changeset/clean-apricots-hide.md
@@ -1,0 +1,8 @@
+---
+"@latticexyz/world-module-callwithsignature": patch
+"@latticexyz/world-module-erc20": patch
+"@latticexyz/world-module-metadata": patch
+"@latticexyz/world-modules": patch
+---
+
+Removed unsupported install methods as these now automatically revert in the base `Module` contract.

--- a/.changeset/gorgeous-falcons-roll.md
+++ b/.changeset/gorgeous-falcons-roll.md
@@ -1,0 +1,17 @@
+---
+"@latticexyz/world": patch
+---
+
+The base `Module` contract now includes default implementations of `install` and `installRoot` that immediately revert, avoiding the need to implement these manually in each module.
+
+You may need to update your install methods with `override` when using this new base contract.
+
+```diff
+-function install(bytes memory) public {
++function install(bytes memory) public override {
+```
+
+```diff
+-function installRoot(bytes memory) public {
++function installRoot(bytes memory) public override {
+```

--- a/.changeset/gorgeous-falcons-roll.md
+++ b/.changeset/gorgeous-falcons-roll.md
@@ -4,7 +4,7 @@
 
 The base `Module` contract now includes default implementations of `install` and `installRoot` that immediately revert, avoiding the need to implement these manually in each module.
 
-You may need to update your install methods with `override` when using this new base contract.
+If you've written a module, you may need to update your install methods with `override` when using this new base contract.
 
 ```diff
 -function install(bytes memory) public {

--- a/docs/pages/guides/modules.mdx
+++ b/docs/pages/guides/modules.mdx
@@ -132,11 +132,7 @@ contract TimerModule is Module {
   ResourceId private immutable namespaceResource = WorldResourceIdLib.encodeNamespace(bytes14("timer"));
   ResourceId private immutable timerSystemResource = WorldResourceIdLib.encode(RESOURCE_SYSTEM, "timer", "TimerSystem");
 
-  function installRoot(bytes memory) public pure override {
-    revert Module_RootInstallNotSupported();
-  }
-
-  function install(bytes memory) public {
+  function install(bytes memory) public override {
     IWorld world = IWorld(_world());
 
     // Register the namespace.
@@ -210,15 +206,7 @@ We need these identifiers to register the namespace and `System`s.
 There is no point wasting gas on recalculating these values either, so it's best to do it once.
 
 ```solidity
-function installRoot(bytes memory) public pure override {
-  revert Module_RootInstallNotSupported();
-}
-```
-
-We do _not_ need root privileges, so it's best if we [don't have them](https://en.wikipedia.org/wiki/Principle_of_least_privilege).
-
-```solidity
-  function install(bytes memory) public {
+  function install(bytes memory) public override {
     IWorld world = IWorld(_world());
 
     // Register the namespace.

--- a/docs/pages/world/reference/internal/init-module.mdx
+++ b/docs/pages/world/reference/internal/init-module.mdx
@@ -60,16 +60,6 @@ _Registers core tables, systems, and function selectors in the World._
 function installRoot(bytes memory) public override;
 ```
 
-#### install
-
-Non-root installation of the module.
-
-_Installation is only supported at root level, so this function will always revert._
-
-```solidity
-function install(bytes memory) public pure;
-```
-
 #### \_registerTables
 
 Register World's tables.

--- a/docs/pages/world/reference/module.mdx
+++ b/docs/pages/world/reference/module.mdx
@@ -78,3 +78,38 @@ function requireNotInstalled(address moduleAddress, bytes memory encodedArgs) in
 | --------------- | --------- | ------------------------------------------------------ |
 | `moduleAddress` | `address` | The address of the module.                             |
 | `encodedArgs`   | `bytes`   | The ABI encoded arguments for the module installation. |
+
+#### installRoot
+
+Installs the module as a root module.
+
+_This function is invoked by the World contract during `installRootModule` process.
+The module expects to be called via the World contract and thus installs itself on the `msg.sender`._
+
+```solidity
+function installRoot(bytes memory encodedArgs) public virtual;
+```
+
+**Parameters**
+
+| Name          | Type    | Description                                                                   |
+| ------------- | ------- | ----------------------------------------------------------------------------- |
+| `encodedArgs` | `bytes` | The ABI encoded arguments that may be needed during the installation process. |
+
+#### install
+
+Installs the module.
+
+_This function is invoked by the World contract during `installModule` process.
+The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
+Logic might differ from `installRoot`, for example, this might accept namespace parameters._
+
+```solidity
+function install(bytes memory encodedArgs) public virtual;
+```
+
+**Parameters**
+
+| Name          | Type    | Description                                                                   |
+| ------------- | ------- | ----------------------------------------------------------------------------- |
+| `encodedArgs` | `bytes` | The ABI encoded arguments that may be needed during the installation process. |

--- a/packages/world-module-callwithsignature/src/CallWithSignatureModule.sol
+++ b/packages/world-module-callwithsignature/src/CallWithSignatureModule.sol
@@ -14,7 +14,7 @@ import { DELEGATION_SYSTEM_ID } from "./constants.sol";
 contract CallWithSignatureModule is Module {
   CallWithSignatureSystem private immutable callWithSignatureSystem = new CallWithSignatureSystem();
 
-  function installRoot(bytes memory encodedArgs) public {
+  function installRoot(bytes memory encodedArgs) public override {
     requireNotInstalled(__self, encodedArgs);
 
     IBaseWorld world = IBaseWorld(_world());
@@ -40,9 +40,5 @@ contract CallWithSignatureModule is Module {
       )
     );
     if (!success) revertWithBytes(data);
-  }
-
-  function install(bytes memory) public pure {
-    revert Module_NonRootInstallNotSupported();
   }
 }

--- a/packages/world-module-erc20/src/experimental/ERC20Module.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Module.sol
@@ -18,7 +18,7 @@ contract ERC20Module is Module {
   error ERC20Module_InvalidNamespace(bytes14 namespace);
   error ERC20Module_NamespaceAlreadyExists(bytes14 namespace);
 
-  function install(bytes memory encodedArgs) public {
+  function install(bytes memory encodedArgs) public override {
     // TODO: we should probably check just for namespace, not for all args
     requireNotInstalled(__self, encodedArgs);
 
@@ -51,10 +51,6 @@ contract ERC20Module is Module {
     world.transferOwnership(namespaceId, _msgSender());
 
     ERC20RegistryLib.register(world, namespaceId, address(token));
-  }
-
-  function installRoot(bytes memory) public pure {
-    revert Module_RootInstallNotSupported();
   }
 }
 

--- a/packages/world-module-metadata/src/MetadataModule.sol
+++ b/packages/world-module-metadata/src/MetadataModule.sol
@@ -22,11 +22,7 @@ contract MetadataModule is Module {
 
   MetadataSystem private immutable metadataSystem = new MetadataSystem();
 
-  function installRoot(bytes memory) public pure {
-    revert Module_RootInstallNotSupported();
-  }
-
-  function install(bytes memory args) public {
+  function install(bytes memory args) public override {
     // naive check to ensure this is only installed once
     // TODO: update this + deployer to be idempotent
     requireNotInstalled(__self, args);

--- a/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
+++ b/packages/world-modules/src/modules/erc20-puppet/ERC20Module.sol
@@ -24,7 +24,7 @@ import { ERC20Metadata, ERC20MetadataData } from "./tables/ERC20Metadata.sol";
 contract ERC20Module is Module {
   error ERC20Module_InvalidNamespace(bytes14 namespace);
 
-  function install(bytes memory encodedArgs) public {
+  function install(bytes memory encodedArgs) public override {
     // Require the module to not be installed with these args yet
     requireNotInstalled(__self, encodedArgs);
 
@@ -57,10 +57,6 @@ contract ERC20Module is Module {
       ERC20Registry.register(ERC20_REGISTRY_TABLE_ID);
     }
     ERC20Registry.set(ERC20_REGISTRY_TABLE_ID, namespaceId, puppet);
-  }
-
-  function installRoot(bytes memory) public pure {
-    revert Module_RootInstallNotSupported();
   }
 }
 

--- a/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
@@ -27,7 +27,7 @@ import { ERC721Metadata, ERC721MetadataData } from "./tables/ERC721Metadata.sol"
 contract ERC721Module is Module {
   error ERC721Module_InvalidNamespace(bytes14 namespace);
 
-  function install(bytes memory encodedArgs) public {
+  function install(bytes memory encodedArgs) public override {
     // Require the module to not be installed with these args yet
     requireNotInstalled(__self, encodedArgs);
 
@@ -60,10 +60,6 @@ contract ERC721Module is Module {
       ERC721Registry.register(ERC721_REGISTRY_TABLE_ID);
     }
     ERC721Registry.set(ERC721_REGISTRY_TABLE_ID, namespaceId, puppet);
-  }
-
-  function installRoot(bytes memory) public pure {
-    revert Module_RootInstallNotSupported();
   }
 }
 

--- a/packages/world-modules/src/modules/keysintable/KeysInTableModule.sol
+++ b/packages/world-modules/src/modules/keysintable/KeysInTableModule.sol
@@ -103,8 +103,4 @@ contract KeysInTableModule is Module {
       )
     );
   }
-
-  function install(bytes memory) public pure {
-    revert Module_NonRootInstallNotSupported();
-  }
 }

--- a/packages/world-modules/src/modules/keyswithvalue/KeysWithValueModule.sol
+++ b/packages/world-modules/src/modules/keyswithvalue/KeysWithValueModule.sol
@@ -35,7 +35,7 @@ contract KeysWithValueModule is Module {
   // from the source table id (passed as argument to the hook methods)
   KeysWithValueHook private immutable hook = new KeysWithValueHook();
 
-  function installRoot(bytes memory encodedArgs) public {
+  function installRoot(bytes memory encodedArgs) public override {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
     requireNotInstalled(__self, encodedArgs);
@@ -95,9 +95,5 @@ contract KeysWithValueModule is Module {
       )
     );
     if (!success) revertWithBytes(returnData);
-  }
-
-  function install(bytes memory) public pure {
-    revert Module_NonRootInstallNotSupported();
   }
 }

--- a/packages/world-modules/src/modules/puppet/PuppetModule.sol
+++ b/packages/world-modules/src/modules/puppet/PuppetModule.sol
@@ -23,7 +23,7 @@ contract PuppetModule is Module {
   PuppetDelegationControl private immutable puppetDelegationControl = new PuppetDelegationControl();
   PuppetFactorySystem private immutable puppetFactorySystem = new PuppetFactorySystem();
 
-  function installRoot(bytes memory) public {
+  function installRoot(bytes memory) public override {
     IBaseWorld world = IBaseWorld(_world());
 
     // Register namespace
@@ -48,7 +48,7 @@ contract PuppetModule is Module {
     if (!success) revertWithBytes(returnData);
   }
 
-  function install(bytes memory) public {
+  function install(bytes memory) public override {
     IBaseWorld world = IBaseWorld(_world());
 
     // Register namespace

--- a/packages/world-modules/src/modules/std-delegations/StandardDelegationsModule.sol
+++ b/packages/world-modules/src/modules/std-delegations/StandardDelegationsModule.sol
@@ -24,7 +24,7 @@ contract StandardDelegationsModule is Module {
   SystemboundDelegationControl private immutable systemboundDelegationControl = new SystemboundDelegationControl();
   TimeboundDelegationControl private immutable timeboundDelegationControl = new TimeboundDelegationControl();
 
-  function installRoot(bytes memory) public {
+  function installRoot(bytes memory) public override {
     IBaseWorld world = IBaseWorld(_world());
 
     // Register tables
@@ -47,9 +47,5 @@ contract StandardDelegationsModule is Module {
       abi.encodeCall(world.registerSystem, (TIMEBOUND_DELEGATION, timeboundDelegationControl, true))
     );
     if (!success) revertWithBytes(returnData);
-  }
-
-  function install(bytes memory) public pure {
-    revert Module_NonRootInstallNotSupported();
   }
 }

--- a/packages/world-modules/src/modules/uniqueentity/UniqueEntityModule.sol
+++ b/packages/world-modules/src/modules/uniqueentity/UniqueEntityModule.sol
@@ -22,7 +22,7 @@ contract UniqueEntityModule is Module {
   // known tables, we can deploy it once and register it in multiple Worlds.
   UniqueEntitySystem private immutable uniqueEntitySystem = new UniqueEntitySystem();
 
-  function installRoot(bytes memory encodedArgs) public {
+  function installRoot(bytes memory encodedArgs) public override {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
     requireNotInstalled(__self, encodedArgs);
@@ -51,7 +51,7 @@ contract UniqueEntityModule is Module {
     if (!success) revertWithBytes(data);
   }
 
-  function install(bytes memory encodedArgs) public {
+  function install(bytes memory encodedArgs) public override {
     // Naive check to ensure this is only installed once
     // TODO: only revert if there's nothing to do
     requireNotInstalled(__self, encodedArgs);

--- a/packages/world/src/Module.sol
+++ b/packages/world/src/Module.sol
@@ -50,4 +50,25 @@ abstract contract Module is IModule, WorldContextConsumer {
       revert Module_AlreadyInstalled();
     }
   }
+
+  /**
+   * @notice Installs the module as a root module.
+   * @dev This function is invoked by the World contract during `installRootModule` process.
+   * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
+   */
+  function installRoot(bytes memory encodedArgs) public virtual {
+    revert Module_RootInstallNotSupported();
+  }
+
+  /**
+   * @notice Installs the module.
+   * @dev This function is invoked by the World contract during `installModule` process.
+   * The module expects to be called via the World contract and thus installs itself on the `msg.sender`.
+   * Logic might differ from `installRoot`, for example, this might accept namespace parameters.
+   * @param encodedArgs The ABI encoded arguments that may be needed during the installation process.
+   */
+  function install(bytes memory encodedArgs) public virtual {
+    revert Module_NonRootInstallNotSupported();
+  }
 }

--- a/packages/world/src/modules/init/InitModule.sol
+++ b/packages/world/src/modules/init/InitModule.sol
@@ -69,14 +69,6 @@ contract InitModule is Module {
   }
 
   /**
-   * @notice Non-root installation of the module.
-   * @dev Installation is only supported at root level, so this function will always revert.
-   */
-  function install(bytes memory) public pure {
-    revert Module_NonRootInstallNotSupported();
-  }
-
-  /**
    * @notice Register World's tables.
    * @dev This internal function registers various tables and sets initial permissions.
    */


### PR DESCRIPTION
mostly a clean up thing that has been bugging me

this means module authors don't need to implement this revert on their own, they just have to implement the install method that is appropriate