### PR TITLE
fix(cli): use execa directly instead of custom foundry wrappers

### DIFF
--- a/.changeset/hip-carpets-shave.md
+++ b/.changeset/hip-carpets-shave.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/cli": patch
+---
+
+Fixed forge/anvil/cast output for all CLI commands.

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -1,8 +1,8 @@
 import { tablegen } from "@latticexyz/store/codegen";
 import { buildSystemsManifest, worldgen } from "@latticexyz/world/node";
 import { World as WorldConfig } from "@latticexyz/world";
-import { forge } from "@latticexyz/common/foundry";
 import { execa } from "execa";
+import { printCommand } from "./utils/printCommand";
 
 type BuildOptions = {
   foundryProfile?: string;
@@ -17,7 +17,12 @@ type BuildOptions = {
 
 export async function build({ rootDir, config, foundryProfile }: BuildOptions): Promise<void> {
   await Promise.all([tablegen({ rootDir, config }), worldgen({ rootDir, config })]);
-  await forge(["build"], { profile: foundryProfile });
+  await printCommand(
+    execa("forge", ["build"], {
+      stdio: "inherit",
+      env: { FOUNDRY_PROFILE: foundryProfile ?? process.env.FOUNDRY_PROFILE },
+    }),
+  );
   await buildSystemsManifest({ rootDir, config });
-  await execa("mud", ["abi-ts"], { stdio: "inherit" });
+  await printCommand(execa("mud", ["abi-ts"], { stdio: "inherit" }));
 }

--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -1,5 +1,5 @@
 import type { CommandModule, InferredOptionTypes } from "yargs";
-import { anvil, getScriptDirectory, getSrcDirectory } from "@latticexyz/common/foundry";
+import { getScriptDirectory, getSrcDirectory } from "@latticexyz/common/foundry";
 import chalk from "chalk";
 import chokidar from "chokidar";
 import { loadConfig, resolveConfigPath } from "@latticexyz/config/node";
@@ -11,6 +11,8 @@ import { deployOptions, runDeploy } from "../runDeploy";
 import { BehaviorSubject, debounceTime, exhaustMap, filter } from "rxjs";
 import { Address } from "viem";
 import { isDefined } from "@latticexyz/common/utils";
+import { execa } from "execa";
+import { printCommand } from "../utils/printCommand";
 
 const devOptions = {
   rpc: deployOptions.rpc,
@@ -47,8 +49,12 @@ const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof
       const userHomeDir = homedir();
       rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
 
-      const anvilArgs = ["--block-time", "1", "--block-base-fee-per-gas", "0"];
-      anvil(anvilArgs);
+      await printCommand(
+        execa("anvil", ["--quiet", ["--block-time", "2"], ["--block-base-fee-per-gas", "0"]].flat(), {
+          stdio: "inherit",
+        }),
+      );
+
       rpc = "http://127.0.0.1:8545";
     }
 

--- a/packages/cli/src/commands/devnode.ts
+++ b/packages/cli/src/commands/devnode.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import path from "path";
 import type { CommandModule } from "yargs";
 import { execa } from "execa";
+import { printCommand } from "../utils/printCommand";
 
 type Options = {
   blocktime: number;
@@ -15,7 +16,7 @@ const commandModule: CommandModule<Options, Options> = {
 
   builder(yargs) {
     return yargs.options({
-      blocktime: { type: "number", default: 1, decs: "Interval in which new blocks are produced" },
+      blocktime: { type: "number", default: 2, decs: "Interval in which new blocks are produced" },
     });
   },
 
@@ -24,11 +25,11 @@ const commandModule: CommandModule<Options, Options> = {
     const userHomeDir = homedir();
     rmSync(path.join(userHomeDir, ".foundry", "anvil", "tmp"), { recursive: true, force: true });
 
-    const anvilArgs = ["-b", String(blocktime), "--block-base-fee-per-gas", "0"];
-    console.log(`Running: anvil ${anvilArgs.join(" ")}`);
-    const child = execa("anvil", anvilArgs, {
-      stdio: ["inherit", "inherit", "inherit"],
-    });
+    const child = printCommand(
+      execa("anvil", ["-b", String(blocktime), "--block-base-fee-per-gas", "0"], {
+        stdio: "inherit",
+      }),
+    );
 
     process.on("SIGINT", () => {
       console.log("\ngracefully shutting down from SIGINT (Crtl-C)");

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -33,9 +33,7 @@ const commandModule: CommandModule<typeof testOptions, TestOptions> = {
       printCommand(
         execa("anvil", ["--quiet", ["--port", String(opts.port)], ["--block-base-fee-per-gas", "0"]].flat(), {
           stdio: "inherit",
-          env: {
-            FOUNDRY_PROFILE: opts.profile ?? process.env.FOUNDRY_PROFILE,
-          },
+          env: { FOUNDRY_PROFILE: opts.profile ?? process.env.FOUNDRY_PROFILE },
         }),
       );
     }

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,7 +1,9 @@
 import type { CommandModule, InferredOptionTypes, Options } from "yargs";
-import { anvil, forge, getRpcUrl } from "@latticexyz/common/foundry";
+import { getRpcUrl } from "@latticexyz/common/foundry";
 import chalk from "chalk";
 import { deployOptions, runDeploy } from "../runDeploy";
+import { execa } from "execa";
+import { printCommand } from "../utils/printCommand";
 
 const testOptions = {
   ...deployOptions,
@@ -28,8 +30,14 @@ const commandModule: CommandModule<typeof testOptions, TestOptions> = {
   async handler(opts) {
     // Start an internal anvil process if no world address is provided
     if (!opts.worldAddress) {
-      const anvilArgs = ["--block-base-fee-per-gas", "0", "--port", String(opts.port)];
-      anvil(anvilArgs);
+      printCommand(
+        execa("anvil", ["--quiet", ["--port", String(opts.port)], ["--block-base-fee-per-gas", "0"]].flat(), {
+          stdio: "inherit",
+          env: {
+            FOUNDRY_PROFILE: opts.profile ?? process.env.FOUNDRY_PROFILE,
+          },
+        }),
+      );
     }
 
     const forkRpc = opts.worldAddress ? await getRpcUrl(opts.profile) : `http://127.0.0.1:${opts.port}`;
@@ -48,12 +56,15 @@ const commandModule: CommandModule<typeof testOptions, TestOptions> = {
 
     const userOptions = opts.forgeOptions?.replaceAll("\\", "").split(" ") ?? [];
     try {
-      await forge(["test", "--fork-url", forkRpc, ...userOptions], {
-        profile: opts.profile,
-        env: {
-          WORLD_ADDRESS: worldAddress,
-        },
-      });
+      await printCommand(
+        execa("forge", ["test", ["--fork-url", forkRpc], ...userOptions].flat(), {
+          stdio: "inherit",
+          env: {
+            FOUNDRY_PROFILE: opts.profile ?? process.env.FOUNDRY_PROFILE,
+            WORLD_ADDRESS: worldAddress,
+          },
+        }),
+      );
       process.exit(0);
     } catch (e) {
       console.error(e);

--- a/packages/cli/src/utils/printCommand.ts
+++ b/packages/cli/src/utils/printCommand.ts
@@ -1,0 +1,23 @@
+import chalk from "chalk";
+import { ChildProcess } from "node:child_process";
+
+/**
+ * Prints the command used to spawn a child process
+ * and returns the child process.
+ *
+ * Using it like this
+ *
+ * ```ts
+ * printCommand(execa("echo", ["hello"]));
+ * ```
+ *
+ * will output
+ *
+ * ```plain
+ * > echo hello
+ * ```
+ */
+export function printCommand<proc>(proc: proc extends ChildProcess ? proc : ChildProcess): proc {
+  console.log("\n" + chalk.gray("> " + proc.spawnargs.join(" ")));
+  return proc as never;
+}

--- a/packages/cli/src/verify/verifyContract.ts
+++ b/packages/cli/src/verify/verifyContract.ts
@@ -1,5 +1,6 @@
-import { forge } from "@latticexyz/common/foundry";
+import { execa } from "execa";
 import { Address } from "viem";
+import { printCommand } from "../utils/printCommand";
 
 type VerifyContractOptions = {
   name: string;
@@ -11,13 +12,18 @@ type VerifyContractOptions = {
 };
 
 export async function verifyContract(options: VerifyContractOptions) {
-  const args = ["verify-contract", options.address, options.name, "--rpc-url", options.rpc];
-
-  if (options.verifier) {
-    args.push("--verifier", options.verifier);
-  }
-  if (options.verifierUrl) {
-    args.push("--verifier-url", options.verifierUrl);
-  }
-  await forge(args, { cwd: options.cwd });
+  await printCommand(
+    execa(
+      "forge",
+      [
+        "verify-contract",
+        options.address,
+        options.name,
+        ["--rpc-url", options.rpc],
+        options.verifier ? ["--verifier", options.verifier] : [],
+        options.verifierUrl ? ["--verifier-url", options.verifierUrl] : [],
+      ].flat(),
+      { stdio: "inherit" },
+    ),
+  );
 }

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -78,25 +78,6 @@ export async function getRpcUrl(profile?: string): Promise<string> {
 }
 
 /**
- * Execute a forge command
- * @param args The arguments to pass to forge
- * @param options { profile?: The foundry profile to use; silent?: If true, nothing will be logged to the console }
- */
-export async function forge(
-  args: string[],
-  options?: { profile?: string; silent?: boolean; env?: NodeJS.ProcessEnv; cwd?: string },
-): Promise<void> {
-  const execOptions = {
-    env: { FOUNDRY_PROFILE: options?.profile, ...options?.env },
-    stdout: "inherit",
-    stderr: "pipe",
-    cwd: options?.cwd,
-  } satisfies Options;
-
-  await (options?.silent ? execa("forge", args, execOptions) : execLog("forge", args, execOptions));
-}
-
-/**
  * Execute a cast command
  * @param args The arguments to pass to cast
  * @returns Stdout of the command

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -1,4 +1,4 @@
-import { execa, Options } from "execa";
+import { execa } from "execa";
 
 export interface ForgeConfig {
   // project
@@ -75,40 +75,4 @@ export async function getRpcUrl(profile?: string): Promise<string> {
     (await getForgeConfig(profile)).eth_rpc_url ||
     "http://127.0.0.1:8545"
   );
-}
-
-/**
- * Start an anvil chain
- * @param args The arguments to pass to anvil
- * @returns Stdout of the command
- */
-export async function anvil(args: string[]): Promise<string> {
-  return execLog("anvil", args);
-}
-
-/**
- * Executes the given command, returns the stdout, and logs the command to the console.
- * Throws an error if the command fails.
- * @param command The command to execute
- * @param args The arguments to pass to the command
- * @returns The stdout of the command
- */
-async function execLog(command: string, args: string[], options?: Options): Promise<string> {
-  const commandString = `${command} ${args.join(" ")}`;
-  try {
-    console.log(`running "${commandString}"`);
-    const { stdout } = await execa(command, args, {
-      ...options,
-      stdout: "pipe",
-      stderr: "pipe",
-      lines: false,
-      encoding: "utf8",
-    });
-    return stdout;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    let errorMessage = error?.stderr || error?.message || "";
-    errorMessage += `\nError running "${commandString}"`;
-    throw new Error(errorMessage);
-  }
 }

--- a/packages/common/src/foundry/index.ts
+++ b/packages/common/src/foundry/index.ts
@@ -78,17 +78,6 @@ export async function getRpcUrl(profile?: string): Promise<string> {
 }
 
 /**
- * Execute a cast command
- * @param args The arguments to pass to cast
- * @returns Stdout of the command
- */
-export async function cast(args: string[], options?: { profile?: string }): Promise<string> {
-  return execLog("cast", args, {
-    env: { FOUNDRY_PROFILE: options?.profile },
-  });
-}
-
-/**
  * Start an anvil chain
  * @param args The arguments to pass to anvil
  * @returns Stdout of the command


### PR DESCRIPTION
fixes https://github.com/latticexyz/mud/issues/3560

and improves output (color is preserved, commands are easier to identify)
<img width="505" alt="image" src="https://github.com/user-attachments/assets/46b4c296-a717-436e-a3ad-1bda2af9c7d4" />
<img width="598" alt="image" src="https://github.com/user-attachments/assets/83e9daae-a8f0-46ee-b763-6ba6a5f66760" />
