### PR TITLE
refactor(world-consumer): remove namespace

### DIFF
--- a/.changeset/rich-islands-stare.md
+++ b/.changeset/rich-islands-stare.md
@@ -1,0 +1,8 @@
+---
+"@latticexyz/world-consumer": patch
+"@latticexyz/world-module-erc20": patch
+---
+
+`WorldConsumer` now doesn't store a single namespace. Instead, child contracts can keep track of namespaces and use the `onlyNamespace(namespace)` and `onlyNamespaceOwner(namespace)` modifiers for access control.
+
+ERC20 module was adapted to use this new version of `WorldConsumer`.

--- a/packages/world-consumer/src/examples/SimpleVault.sol
+++ b/packages/world-consumer/src/examples/SimpleVault.sol
@@ -17,15 +17,18 @@ interface IERC20 {
 /**
  * @title SimpleVault (NOT AUDITED)
  * @dev Simple example of a Vault that allows accounts with namespace access to transfer its tokens out
- * IMPORTANT: this contract expects an existing namespace
  */
 contract SimpleVault is WorldConsumer {
   error SimpleVault_TransferFailed();
 
-  constructor(IBaseWorld world, bytes14 namespace) WorldConsumer(world, namespace, false) {}
+  bytes14 immutable namespace;
+
+  constructor(IBaseWorld world, bytes14 _namespace) WorldConsumer(world) {
+    namespace = _namespace;
+  }
 
   // Only accounts with namespace access (e.g. namespace systems) can transfer the ERC20 tokens held by this contract
-  function transferTo(IERC20 token, address to, uint256 amount) external onlyWorld {
+  function transferTo(IERC20 token, address to, uint256 amount) external onlyNamespace(namespace) {
     require(token.transfer(to, amount), "Transfer failed");
   }
 

--- a/packages/world-consumer/test/WorldConsumer.t.sol
+++ b/packages/world-consumer/test/WorldConsumer.t.sol
@@ -30,10 +30,6 @@ contract MockWorldConsumer is WorldConsumer {
     return StoreSwitch.getStoreAddress();
   }
 
-  function grantNamespaceAccess(address to) external {
-    IBaseWorld(_world()).grantAccess(WorldResourceIdLib.encodeNamespace(namespace), to);
-  }
-
   function callableByAnyone() external view {}
 
   function onlyCallableByWorld() external view onlyWorld {}

--- a/packages/world-module-erc20/gas-report.json
+++ b/packages/world-module-erc20/gas-report.json
@@ -3,72 +3,114 @@
     "file": "test/ERC20BaseTest.t.sol:ERC20Test",
     "test": "testApprove",
     "name": "world_approve",
-    "gasUsed": 71093
+    "gasUsed": 71092
   },
   {
     "file": "test/ERC20BaseTest.t.sol:ERC20Test",
     "test": "testBurn",
     "name": "world_burn",
-    "gasUsed": 70710
+    "gasUsed": 70708
   },
   {
     "file": "test/ERC20BaseTest.t.sol:ERC20Test",
     "test": "testMint",
     "name": "world_mint",
-    "gasUsed": 109431
+    "gasUsed": 109495
   },
   {
     "file": "test/ERC20BaseTest.t.sol:ERC20Test",
     "test": "testTransfer",
     "name": "world_transfer",
-    "gasUsed": 82487
+    "gasUsed": 82440
   },
   {
     "file": "test/ERC20BaseTest.t.sol:ERC20Test",
     "test": "testTransferFrom",
     "name": "world_transferFrom",
-    "gasUsed": 99471
+    "gasUsed": 99468
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testApprove",
     "name": "world_approve",
-    "gasUsed": 71093
+    "gasUsed": 71092
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testBurn",
     "name": "world_burn",
-    "gasUsed": 70711
+    "gasUsed": 70709
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testBurnByAccount",
     "name": "world_burn",
-    "gasUsed": 71099
+    "gasUsed": 71140
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testMint",
     "name": "world_mint",
-    "gasUsed": 109497
+    "gasUsed": 109473
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testTransfer",
     "name": "world_transfer",
-    "gasUsed": 82487
+    "gasUsed": 82485
   },
   {
     "file": "test/ERC20Burnable.t.sol:ERC20BurnableTest",
     "test": "testTransferFrom",
     "name": "world_transferFrom",
-    "gasUsed": 99494
+    "gasUsed": 99491
   },
   {
     "file": "test/ERC20Module.t.sol:ERC20ModuleTest",
     "test": "testInstall",
     "name": "install erc20 module",
-    "gasUsed": 4798590
+    "gasUsed": 5217834
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testApprove",
+    "name": "world_approve",
+    "gasUsed": 71093
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testBurn",
+    "name": "world_burn",
+    "gasUsed": 75392
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testMint",
+    "name": "world_mint",
+    "gasUsed": 114157
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testPause",
+    "name": "world_pause",
+    "gasUsed": 70854
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testPause",
+    "name": "world_unpause",
+    "gasUsed": 44450
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testTransfer",
+    "name": "world_transfer",
+    "gasUsed": 87169
+  },
+  {
+    "file": "test/ERC20Pausable.t.sol:ERC20PausableTest",
+    "test": "testTransferFrom",
+    "name": "world_transferFrom",
+    "gasUsed": 104177
   }
 ]

--- a/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
+++ b/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
@@ -15,35 +15,35 @@ import { MUDERC20 } from "../experimental/MUDERC20.sol";
 contract ERC20PausableBurnable is MUDERC20, ERC20Pausable, ERC20Burnable {
   error ERC20PausableBurnable_AlreadyInitialized();
 
-  bytes14 immutable namespace;
+  bytes14 private immutable _namespace;
 
   constructor(
     IBaseWorld world,
-    bytes14 _namespace,
-    ResourceId _totalSupplyId,
-    ResourceId _balancesId,
-    ResourceId _allowancesId,
-    ResourceId _metadataId,
-    ResourceId _pausedId
-  ) WorldConsumer(world) MUDERC20(_totalSupplyId, _balancesId, _allowancesId, _metadataId) ERC20Pausable(_pausedId) {
+    bytes14 namespace,
+    ResourceId totalSupplyId,
+    ResourceId balancesId,
+    ResourceId allowancesId,
+    ResourceId metadataId,
+    ResourceId pausedId
+  ) WorldConsumer(world) MUDERC20(totalSupplyId, balancesId, allowancesId, metadataId) ERC20Pausable(pausedId) {
     // Namespace used for access control
-    namespace = _namespace;
+    _namespace = namespace;
   }
 
-  function initialize(string memory name, string memory symbol) external onlyNamespaceOwner(namespace) {
+  function initialize(string memory name, string memory symbol) external onlyNamespaceOwner(_namespace) {
     _MUDERC20_init(name, symbol);
     _Pausable_init();
   }
 
-  function mint(address to, uint256 value) public onlyNamespace(namespace) {
+  function mint(address to, uint256 value) public onlyNamespace(_namespace) {
     _mint(to, value);
   }
 
-  function pause() public onlyNamespace(namespace) {
+  function pause() public onlyNamespace(_namespace) {
     _pause();
   }
 
-  function unpause() public onlyNamespace(namespace) {
+  function unpause() public onlyNamespace(_namespace) {
     _unpause();
   }
 

--- a/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
+++ b/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
@@ -13,16 +13,24 @@ import { ERC20Burnable } from "../experimental/ERC20Burnable.sol";
 import { MUDERC20 } from "../experimental/MUDERC20.sol";
 
 contract ERC20PausableBurnable is MUDERC20, ERC20Pausable, ERC20Burnable {
+  error ERC20PausableBurnable_AlreadyInitialized();
+
   bytes14 immutable namespace;
 
   constructor(
     IBaseWorld world,
-    bytes14 _namespace
-  ) WorldConsumer(world) MUDERC20(_namespace) ERC20Pausable(_namespace) {
+    bytes14 _namespace,
+    ResourceId _totalSupplyId,
+    ResourceId _balancesId,
+    ResourceId _allowancesId,
+    ResourceId _metadataId,
+    ResourceId _pausedId
+  ) WorldConsumer(world) MUDERC20(_totalSupplyId, _balancesId, _allowancesId, _metadataId) ERC20Pausable(_pausedId) {
+    // Namespace used for access control
     namespace = _namespace;
   }
 
-  function initialize(string memory name, string memory symbol) external {
+  function initialize(string memory name, string memory symbol) external onlyNamespaceOwner(namespace) {
     MUDERC20._init(name, symbol);
     Pausable._init();
   }

--- a/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
+++ b/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
@@ -7,30 +7,35 @@ import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
 
+import { Pausable } from "../experimental/Pausable.sol";
 import { ERC20Pausable } from "../experimental/ERC20Pausable.sol";
 import { ERC20Burnable } from "../experimental/ERC20Burnable.sol";
 import { MUDERC20 } from "../experimental/MUDERC20.sol";
 
 contract ERC20PausableBurnable is MUDERC20, ERC20Pausable, ERC20Burnable {
+  bytes14 immutable namespace;
+
   constructor(
     IBaseWorld world,
-    bytes14 namespace,
-    string memory name,
-    string memory symbol
-  ) WorldConsumer(world, namespace, true) MUDERC20(name, symbol) {
-    // Transfer namespace ownership to the creator
-    world.transferOwnership(namespaceId, _msgSender());
+    bytes14 _namespace
+  ) WorldConsumer(world) MUDERC20(_namespace) ERC20Pausable(_namespace) {
+    namespace = _namespace;
   }
 
-  function mint(address to, uint256 value) public onlyNamespace {
+  function initialize(string memory name, string memory symbol) external {
+    MUDERC20._init(name, symbol);
+    Pausable._init();
+  }
+
+  function mint(address to, uint256 value) public onlyNamespace(namespace) {
     _mint(to, value);
   }
 
-  function pause() public onlyNamespace {
+  function pause() public onlyNamespace(namespace) {
     _pause();
   }
 
-  function unpause() public onlyNamespace {
+  function unpause() public onlyNamespace(namespace) {
     _unpause();
   }
 

--- a/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
+++ b/packages/world-module-erc20/src/examples/ERC20PausableBurnable.sol
@@ -31,8 +31,8 @@ contract ERC20PausableBurnable is MUDERC20, ERC20Pausable, ERC20Burnable {
   }
 
   function initialize(string memory name, string memory symbol) external onlyNamespaceOwner(namespace) {
-    MUDERC20._init(name, symbol);
-    Pausable._init();
+    _MUDERC20_init(name, symbol);
+    _Pausable_init();
   }
 
   function mint(address to, uint256 value) public onlyNamespace(namespace) {

--- a/packages/world-module-erc20/src/experimental/Constants.sol
+++ b/packages/world-module-erc20/src/experimental/Constants.sol
@@ -27,10 +27,6 @@ library ERC20TableNames {
   bytes16 internal constant METADATA = "Metadata";
 }
 
-library OwnableTableNames {
-  bytes16 internal constant OWNER = "Owner";
-}
-
 library PausableTableNames {
   bytes16 internal constant PAUSED = "Paused";
 }

--- a/packages/world-module-erc20/src/experimental/ERC20Module.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Module.sol
@@ -39,10 +39,15 @@ contract ERC20Module is Module {
 
     IBaseWorld world = IBaseWorld(_world());
 
-    ERC20PausableBurnable token = new ERC20PausableBurnable(world, namespace, name, symbol);
+    world.registerNamespace(namespaceId);
 
-    // Grant access to the token so it can write to tables after transferring ownership
+    ERC20PausableBurnable token = new ERC20PausableBurnable(world, namespace);
+
+    // Grant access to the token so it can register and write to tables after transferring ownership
     world.grantAccess(namespaceId, address(token));
+
+    // Register tables and set metadata
+    token.initialize(name, symbol);
 
     // Register token as a system so its functions can be called through the world
     world.registerSystem(systemId, token, true);

--- a/packages/world-module-erc20/src/experimental/ERC20Module.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Module.sol
@@ -80,7 +80,16 @@ library ERC20ModuleLib {
     ERC20Metadata.register(metadataId);
     Paused.register(pausedId);
 
-    return new ERC20PausableBurnable(world, namespace, totalSupplyId, balancesId, allowancesId, metadataId, pausedId);
+    return
+      new ERC20PausableBurnable({
+        world: world,
+        namespace: namespace,
+        totalSupplyId: totalSupplyId,
+        balancesId: balancesId,
+        allowancesId: allowancesId,
+        metadataId: metadataId,
+        pausedId: pausedId
+      });
   }
 
   function registerToken(IBaseWorld world, ResourceId namespaceId, address token) public {

--- a/packages/world-module-erc20/src/experimental/ERC20Module.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Module.sol
@@ -3,16 +3,22 @@ pragma solidity >=0.8.24;
 
 import { ResourceIds } from "@latticexyz/store/src/codegen/tables/ResourceIds.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
+import { RESOURCE_TABLE } from "@latticexyz/store/src/storeResourceTypes.sol";
 
 import { Module } from "@latticexyz/world/src/Module.sol";
 import { RESOURCE_SYSTEM } from "@latticexyz/world/src/worldResourceTypes.sol";
 import { WorldResourceIdLib } from "@latticexyz/world/src/WorldResourceId.sol";
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
-import { revertWithBytes } from "@latticexyz/world/src/revertWithBytes.sol";
 
 import { ERC20Registry } from "../codegen/tables/ERC20Registry.sol";
 import { ERC20PausableBurnable } from "../examples/ERC20PausableBurnable.sol";
-import { ModuleConstants } from "./Constants.sol";
+import { ModuleConstants, ERC20TableNames, PausableTableNames } from "./Constants.sol";
+
+import { ERC20Metadata, ERC20MetadataData } from "../codegen/tables/ERC20Metadata.sol";
+import { TotalSupply } from "../codegen/tables/TotalSupply.sol";
+import { Balances } from "../codegen/tables/Balances.sol";
+import { Allowances } from "../codegen/tables/Allowances.sol";
+import { Paused } from "../codegen/tables/Paused.sol";
 
 contract ERC20Module is Module {
   error ERC20Module_InvalidNamespace(bytes14 namespace);
@@ -41,26 +47,40 @@ contract ERC20Module is Module {
 
     world.registerNamespace(namespaceId);
 
-    ERC20PausableBurnable token = new ERC20PausableBurnable(world, namespace);
+    ERC20PausableBurnable token = ERC20ModuleLib.deployAndRegisterTables(world, namespace);
 
     // Grant access to the token so it can register and write to tables after transferring ownership
     world.grantAccess(namespaceId, address(token));
 
-    // Register tables and set metadata
+    // Set metadata and paused state
     token.initialize(name, symbol);
 
     // Register token as a system so its functions can be called through the world
     world.registerSystem(systemId, token, true);
 
-    // The token should have transferred the namespace ownership to this module in its constructor
-    world.transferOwnership(namespaceId, _msgSender());
-
-    ERC20RegistryLib.register(world, namespaceId, address(token));
+    ERC20ModuleLib.registerToken(world, namespaceId, address(token));
   }
 }
 
-library ERC20RegistryLib {
-  function register(IBaseWorld world, ResourceId namespaceId, address token) public {
+library ERC20ModuleLib {
+  function deployAndRegisterTables(IBaseWorld world, bytes14 namespace) public returns (ERC20PausableBurnable) {
+    ResourceId totalSupplyId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.TOTAL_SUPPLY);
+    ResourceId balancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.BALANCES);
+    ResourceId allowancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.ALLOWANCES);
+    ResourceId metadataId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.METADATA);
+    ResourceId pausedId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, PausableTableNames.PAUSED);
+
+    // Register each table
+    TotalSupply.register(totalSupplyId);
+    Balances.register(balancesId);
+    Allowances.register(allowancesId);
+    ERC20Metadata.register(metadataId);
+    Paused.register(pausedId);
+
+    return new ERC20PausableBurnable(world, namespace);
+  }
+
+  function registerToken(IBaseWorld world, ResourceId namespaceId, address token) public {
     ResourceId erc20RegistryTableId = ModuleConstants.registryTableId();
     if (!ResourceIds.getExists(erc20RegistryTableId)) {
       world.registerNamespace(ModuleConstants.namespaceId());

--- a/packages/world-module-erc20/src/experimental/ERC20Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Pausable.sol
@@ -6,6 +6,8 @@ import { Pausable } from "./Pausable.sol";
 import { MUDERC20 } from "./MUDERC20.sol";
 
 abstract contract ERC20Pausable is MUDERC20, Pausable {
+  constructor(bytes14 namespace) Pausable(namespace) {}
+
   function _update(address from, address to, uint256 value) internal virtual override whenNotPaused {
     super._update(from, to, value);
   }

--- a/packages/world-module-erc20/src/experimental/ERC20Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/ERC20Pausable.sol
@@ -2,11 +2,12 @@
 // Adapted from OpenZeppelin's [ERC20Pausable extenstion](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f989fff93168606c726bc5e831ef50dd6e543f45/contracts/token/ERC20/extensions/ERC20Pausable.sol)
 pragma solidity >=0.8.24;
 
+import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { Pausable } from "./Pausable.sol";
 import { MUDERC20 } from "./MUDERC20.sol";
 
 abstract contract ERC20Pausable is MUDERC20, Pausable {
-  constructor(bytes14 namespace) Pausable(namespace) {}
+  constructor(ResourceId pausedId) Pausable(pausedId) {}
 
   function _update(address from, address to, uint256 value) internal virtual override whenNotPaused {
     super._update(from, to, value);

--- a/packages/world-module-erc20/src/experimental/MUDERC20.sol
+++ b/packages/world-module-erc20/src/experimental/MUDERC20.sol
@@ -19,16 +19,16 @@ import { IERC20Errors } from "../interfaces/IERC20Errors.sol";
 import { ERC20TableNames } from "./Constants.sol";
 
 abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsumer {
-  ResourceId private immutable totalSupplyId;
-  ResourceId private immutable balancesId;
-  ResourceId private immutable allowancesId;
-  ResourceId private immutable metadataId;
+  ResourceId private immutable _totalSupplyId;
+  ResourceId private immutable _balancesId;
+  ResourceId private immutable _allowancesId;
+  ResourceId private immutable _metadataId;
 
-  constructor(ResourceId _totalSupplyId, ResourceId _balancesId, ResourceId _allowancesId, ResourceId _metadataId) {
-    totalSupplyId = _totalSupplyId;
-    balancesId = _balancesId;
-    allowancesId = _allowancesId;
-    metadataId = _metadataId;
+  constructor(ResourceId totalSupplyId, ResourceId balancesId, ResourceId allowancesId, ResourceId metadataId) {
+    _totalSupplyId = totalSupplyId;
+    _balancesId = balancesId;
+    _allowancesId = allowancesId;
+    _metadataId = metadataId;
   }
 
   /**
@@ -279,43 +279,43 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   }
 
   function _getName() internal view returns (string memory) {
-    return ERC20Metadata.getName(metadataId);
+    return ERC20Metadata.getName(_metadataId);
   }
 
   function _getSymbol() internal view returns (string memory) {
-    return ERC20Metadata.getSymbol(metadataId);
+    return ERC20Metadata.getSymbol(_metadataId);
   }
 
   function _getDecimals() internal view returns (uint8) {
-    return ERC20Metadata.getDecimals(metadataId);
+    return ERC20Metadata.getDecimals(_metadataId);
   }
 
   function _getTotalSupply() internal view returns (uint256) {
-    return TotalSupply.get(totalSupplyId);
+    return TotalSupply.get(_totalSupplyId);
   }
 
   function _getBalance(address account) internal view returns (uint256) {
-    return Balances.get(balancesId, account);
+    return Balances.get(_balancesId, account);
   }
 
   function _getAllowance(address owner, address spender) internal view returns (uint256) {
-    return Allowances.get(allowancesId, owner, spender);
+    return Allowances.get(_allowancesId, owner, spender);
   }
 
   function _setTotalSupply(uint256 value) internal virtual {
-    TotalSupply.set(totalSupplyId, value);
+    TotalSupply.set(_totalSupplyId, value);
   }
 
   function _setBalance(address account, uint256 value) internal virtual {
-    Balances.set(balancesId, account, value);
+    Balances.set(_balancesId, account, value);
   }
 
   function _setAllowance(address owner, address spender, uint256 value) internal virtual {
-    Allowances.set(allowancesId, owner, spender, value);
+    Allowances.set(_allowancesId, owner, spender, value);
   }
 
   function _setMetadata(string memory _name, string memory _symbol, uint8 _decimals) internal virtual {
     ERC20MetadataData memory metadata = ERC20MetadataData(_decimals, _name, _symbol);
-    ERC20Metadata.set(metadataId, metadata);
+    ERC20Metadata.set(_metadataId, metadata);
   }
 }

--- a/packages/world-module-erc20/src/experimental/MUDERC20.sol
+++ b/packages/world-module-erc20/src/experimental/MUDERC20.sol
@@ -24,20 +24,11 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   ResourceId internal immutable allowancesId;
   ResourceId internal immutable metadataId;
 
-  constructor(string memory _name, string memory _symbol) {
-    // Needs to be inlined in the constructor
+  constructor(bytes14 namespace) {
     totalSupplyId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.TOTAL_SUPPLY);
     balancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.BALANCES);
     allowancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.ALLOWANCES);
     metadataId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.METADATA);
-
-    // Register each table
-    TotalSupply.register(totalSupplyId);
-    Balances.register(balancesId);
-    Allowances.register(allowancesId);
-    ERC20Metadata.register(metadataId);
-
-    _setMetadata(_name, _symbol, 18);
   }
 
   /**
@@ -151,6 +142,16 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
     _transfer(from, to, value);
 
     return true;
+  }
+
+  function _init(string memory _name, string memory _symbol) internal {
+    // Register each table
+    TotalSupply.register(totalSupplyId);
+    Balances.register(balancesId);
+    Allowances.register(allowancesId);
+    ERC20Metadata.register(metadataId);
+
+    _setMetadata(_name, _symbol, 18);
   }
 
   /**

--- a/packages/world-module-erc20/src/experimental/MUDERC20.sol
+++ b/packages/world-module-erc20/src/experimental/MUDERC20.sol
@@ -2,6 +2,7 @@
 // Adapted from OpenZeppelin Contracts [token/ERC20/ERC20.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f989fff93168606c726bc5e831ef50dd6e543f45/contracts/token/ERC20/ERC20.sol)
 pragma solidity >=0.8.24;
 
+import { console } from "forge-std/console.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
 import { WorldResourceIdLib } from "@latticexyz/world/src/WorldResourceId.sol";
@@ -19,10 +20,10 @@ import { IERC20Errors } from "../interfaces/IERC20Errors.sol";
 import { ERC20TableNames } from "./Constants.sol";
 
 abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsumer {
-  ResourceId internal immutable totalSupplyId;
-  ResourceId internal immutable balancesId;
-  ResourceId internal immutable allowancesId;
-  ResourceId internal immutable metadataId;
+  ResourceId private immutable totalSupplyId;
+  ResourceId private immutable balancesId;
+  ResourceId private immutable allowancesId;
+  ResourceId private immutable metadataId;
 
   constructor(ResourceId _totalSupplyId, ResourceId _balancesId, ResourceId _allowancesId, ResourceId _metadataId) {
     totalSupplyId = _totalSupplyId;
@@ -283,6 +284,7 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   }
 
   function _getSymbol() internal view returns (string memory) {
+    console.logBytes32(metadataId.unwrap());
     return ERC20Metadata.getSymbol(metadataId);
   }
 

--- a/packages/world-module-erc20/src/experimental/MUDERC20.sol
+++ b/packages/world-module-erc20/src/experimental/MUDERC20.sol
@@ -24,11 +24,11 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   ResourceId internal immutable allowancesId;
   ResourceId internal immutable metadataId;
 
-  constructor(bytes14 namespace) {
-    totalSupplyId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.TOTAL_SUPPLY);
-    balancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.BALANCES);
-    allowancesId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.ALLOWANCES);
-    metadataId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, ERC20TableNames.METADATA);
+  constructor(ResourceId _totalSupplyId, ResourceId _balancesId, ResourceId _allowancesId, ResourceId _metadataId) {
+    totalSupplyId = _totalSupplyId;
+    balancesId = _balancesId;
+    allowancesId = _allowancesId;
+    metadataId = _metadataId;
   }
 
   /**
@@ -145,12 +145,6 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   }
 
   function _init(string memory _name, string memory _symbol) internal {
-    // Register each table
-    TotalSupply.register(totalSupplyId);
-    Balances.register(balancesId);
-    Allowances.register(allowancesId);
-    ERC20Metadata.register(metadataId);
-
     _setMetadata(_name, _symbol, 18);
   }
 

--- a/packages/world-module-erc20/src/experimental/MUDERC20.sol
+++ b/packages/world-module-erc20/src/experimental/MUDERC20.sol
@@ -2,7 +2,6 @@
 // Adapted from OpenZeppelin Contracts [token/ERC20/ERC20.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f989fff93168606c726bc5e831ef50dd6e543f45/contracts/token/ERC20/ERC20.sol)
 pragma solidity >=0.8.24;
 
-import { console } from "forge-std/console.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
 import { WorldResourceIdLib } from "@latticexyz/world/src/WorldResourceId.sol";
@@ -145,7 +144,7 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
     return true;
   }
 
-  function _init(string memory _name, string memory _symbol) internal {
+  function _MUDERC20_init(string memory _name, string memory _symbol) internal {
     _setMetadata(_name, _symbol, 18);
   }
 
@@ -284,7 +283,6 @@ abstract contract MUDERC20 is IERC20, IERC20Metadata, IERC20Errors, WorldConsume
   }
 
   function _getSymbol() internal view returns (string memory) {
-    console.logBytes32(metadataId.unwrap());
     return ERC20Metadata.getSymbol(metadataId);
   }
 

--- a/packages/world-module-erc20/src/experimental/Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/Pausable.sol
@@ -18,7 +18,7 @@ import { Paused as PausedTable } from "../codegen/tables/Paused.sol";
  * simply including this module, only once the modifiers are put in place.
  */
 abstract contract Pausable is WorldConsumer {
-  ResourceId private immutable pausedId;
+  ResourceId private immutable _pausedId;
 
   /**
    * @dev Emitted when the pause is triggered by `account`.
@@ -64,22 +64,22 @@ abstract contract Pausable is WorldConsumer {
     _;
   }
 
-  constructor(ResourceId _pausedId) {
-    pausedId = _pausedId;
+  constructor(ResourceId pausedId) {
+    _pausedId = pausedId;
   }
 
   /**
    * @dev Initializes the contract in unpaused state.
    */
   function _Pausable_init() internal {
-    PausedTable.set(pausedId, false);
+    PausedTable.set(_pausedId, false);
   }
 
   /**
    * @dev Returns true if the contract is paused, and false otherwise.
    */
   function paused() public view virtual returns (bool) {
-    return PausedTable.get(pausedId);
+    return PausedTable.get(_pausedId);
   }
 
   /**
@@ -108,7 +108,7 @@ abstract contract Pausable is WorldConsumer {
    * - The contract must not be paused.
    */
   function _pause() internal virtual whenNotPaused {
-    PausedTable.set(pausedId, true);
+    PausedTable.set(_pausedId, true);
     emit Paused(_msgSender());
   }
 
@@ -120,7 +120,7 @@ abstract contract Pausable is WorldConsumer {
    * - The contract must be paused.
    */
   function _unpause() internal virtual whenPaused {
-    PausedTable.set(pausedId, false);
+    PausedTable.set(_pausedId, false);
     emit Unpaused(_msgSender());
   }
 }

--- a/packages/world-module-erc20/src/experimental/Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/Pausable.sol
@@ -18,7 +18,7 @@ import { Paused as PausedTable } from "../codegen/tables/Paused.sol";
  * simply including this module, only once the modifiers are put in place.
  */
 abstract contract Pausable is WorldConsumer {
-  ResourceId internal immutable pausedId;
+  ResourceId private immutable pausedId;
 
   /**
    * @dev Emitted when the pause is triggered by `account`.

--- a/packages/world-module-erc20/src/experimental/Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/Pausable.sol
@@ -2,13 +2,11 @@
 // Adapted from OpenZeppelin Contracts [utils/Pausable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/f989fff93168606c726bc5e831ef50dd6e543f45/contracts/utils/Pausable.sol)
 pragma solidity >=0.8.24;
 
-import { RESOURCE_TABLE } from "@latticexyz/store/src/storeResourceTypes.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { WorldResourceIdLib } from "@latticexyz/world/src/WorldResourceId.sol";
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
 
 import { Paused as PausedTable } from "../codegen/tables/Paused.sol";
-import { PausableTableNames } from "./Constants.sol";
 
 /**
  * @dev Contract module which allows children to implement an emergency stop
@@ -66,15 +64,14 @@ abstract contract Pausable is WorldConsumer {
     _;
   }
 
-  constructor(bytes14 namespace) {
-    pausedId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, PausableTableNames.PAUSED);
+  constructor(ResourceId _pausedId) {
+    pausedId = _pausedId;
   }
 
   /**
    * @dev Initializes the contract in unpaused state.
    */
   function _init() internal {
-    PausedTable.register(pausedId);
     PausedTable.set(pausedId, false);
   }
 

--- a/packages/world-module-erc20/src/experimental/Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/Pausable.sol
@@ -43,15 +43,6 @@ abstract contract Pausable is WorldConsumer {
   error ExpectedPause();
 
   /**
-   * @dev Initializes the contract in unpaused state.
-   */
-  constructor() {
-    pausedId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, PausableTableNames.PAUSED);
-    PausedTable.register(pausedId);
-    PausedTable.set(pausedId, false);
-  }
-
-  /**
    * @dev Modifier to make a function callable only when the contract is not paused.
    *
    * Requirements:
@@ -73,6 +64,18 @@ abstract contract Pausable is WorldConsumer {
   modifier whenPaused() {
     _requirePaused();
     _;
+  }
+
+  constructor(bytes14 namespace) {
+    pausedId = WorldResourceIdLib.encode(RESOURCE_TABLE, namespace, PausableTableNames.PAUSED);
+  }
+
+  /**
+   * @dev Initializes the contract in unpaused state.
+   */
+  function _init() internal {
+    PausedTable.register(pausedId);
+    PausedTable.set(pausedId, false);
   }
 
   /**

--- a/packages/world-module-erc20/src/experimental/Pausable.sol
+++ b/packages/world-module-erc20/src/experimental/Pausable.sol
@@ -71,7 +71,7 @@ abstract contract Pausable is WorldConsumer {
   /**
    * @dev Initializes the contract in unpaused state.
    */
-  function _init() internal {
+  function _Pausable_init() internal {
     PausedTable.set(pausedId, false);
   }
 

--- a/packages/world-module-erc20/test/ERC20BaseTest.t.sol
+++ b/packages/world-module-erc20/test/ERC20BaseTest.t.sol
@@ -13,6 +13,7 @@ import { ResourceAccess } from "@latticexyz/world/src/codegen/tables/ResourceAcc
 import { WorldResourceIdLib } from "@latticexyz/world/src/WorldResourceId.sol";
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
+import { revertWithBytes } from "@latticexyz/world/src/revertWithBytes.sol";
 
 import { StoreSwitch } from "@latticexyz/store/src/StoreSwitch.sol";
 
@@ -71,7 +72,12 @@ abstract contract ERC20BehaviorTest is Test, GasReporter, IERC20Events, IERC20Er
     IBaseWorld(world).registerNamespace(namespaceId);
     IBaseWorld(world).grantAccess(namespaceId, address(token));
 
-    token.initialize();
+    // Register tables and set metadata
+    (bool success, bytes memory returnData) = address(token).delegatecall(abi.encodeCall(MockERC20Base.initialize, ()));
+
+    if (!success) {
+      revertWithBytes(returnData);
+    }
 
     StoreSwitch.setStoreAddress(world);
   }

--- a/packages/world-module-erc20/test/ERC20BaseTest.t.sol
+++ b/packages/world-module-erc20/test/ERC20BaseTest.t.sol
@@ -45,7 +45,7 @@ contract MockERC20Base is MUDERC20 {
   constructor(IBaseWorld world) WorldConsumer(world) MUDERC20(totalSupplyId, balancesId, allowancesId, metadataId) {}
 
   function initialize() public virtual {
-    MUDERC20._init("Token", "TKN");
+    _MUDERC20_init("Token", "TKN");
   }
 
   function __mint(address to, uint256 amount) public {

--- a/packages/world-module-erc20/test/ERC20Burnable.t.sol
+++ b/packages/world-module-erc20/test/ERC20Burnable.t.sol
@@ -17,11 +17,13 @@ import { MUDERC20 } from "../src/experimental/MUDERC20.sol";
 import { ERC20Burnable } from "../src/experimental/ERC20Burnable.sol";
 import { MockERC20Base, ERC20BehaviorTest } from "./ERC20BaseTest.t.sol";
 
-contract MockERC20Burnable is MockERC20Base, ERC20Burnable {}
+contract MockERC20Burnable is MockERC20Base, ERC20Burnable {
+  constructor(IBaseWorld world) MockERC20Base(world) {}
+}
 
 contract ERC20BurnableTest is ERC20BehaviorTest {
-  function createToken() internal override returns (MockERC20Base) {
-    return new MockERC20Burnable();
+  function createToken(IBaseWorld world) internal override returns (MockERC20Base) {
+    return new MockERC20Burnable(world);
   }
 
   function testBurnByAccount() public {

--- a/packages/world-module-erc20/test/ERC20Module.t.sol
+++ b/packages/world-module-erc20/test/ERC20Module.t.sol
@@ -62,9 +62,6 @@ contract ERC20ModuleTest is Test, GasReporter {
     // Module should transfer token namespace ownership to the creator
     assertEq(NamespaceOwner.get(erc20NamespaceId), address(this), "Token did not transfer ownership");
 
-    assertEq(WorldConsumer(token).namespace(), TestConstants.ERC20_NAMESPACE);
-    assertEq(WorldConsumer(token).namespaceId().unwrap(), erc20NamespaceId.unwrap());
-
     vm.expectRevert(IModuleErrors.Module_AlreadyInstalled.selector);
     world.installModule(erc20Module, args);
   }

--- a/packages/world-module-erc20/test/ERC20Module.t.sol
+++ b/packages/world-module-erc20/test/ERC20Module.t.sol
@@ -20,6 +20,7 @@ import { ResourceAccess } from "@latticexyz/world/src/codegen/tables/ResourceAcc
 import { WorldConsumer } from "@latticexyz/world-consumer/src/experimental/WorldConsumer.sol";
 
 import { ModuleConstants } from "../src/experimental/Constants.sol";
+import { MUDERC20 } from "../src/experimental/MUDERC20.sol";
 import { ERC20Module } from "../src/experimental/ERC20Module.sol";
 import { ERC20Registry } from "../src/codegen/tables/ERC20Registry.sol";
 
@@ -61,6 +62,9 @@ contract ERC20ModuleTest is Test, GasReporter {
 
     // Module should transfer token namespace ownership to the creator
     assertEq(NamespaceOwner.get(erc20NamespaceId), address(this), "Token did not transfer ownership");
+
+    assertEq(MUDERC20(token).name(), "myERC20Token");
+    assertEq(MUDERC20(token).symbol(), "MTK");
 
     vm.expectRevert(IModuleErrors.Module_AlreadyInstalled.selector);
     world.installModule(erc20Module, args);

--- a/packages/world-module-erc20/test/ERC20Pausable.t.sol
+++ b/packages/world-module-erc20/test/ERC20Pausable.t.sol
@@ -26,7 +26,7 @@ contract MockERC20Pausable is MockERC20Base, ERC20Pausable(pausedId) {
 
   function initialize() public override {
     MockERC20Base.initialize();
-    Pausable._init();
+    _Pausable_init();
   }
 
   function pause() public {

--- a/packages/world-module-erc20/test/ERC20Pausable.t.sol
+++ b/packages/world-module-erc20/test/ERC20Pausable.t.sol
@@ -16,16 +16,14 @@ import { IERC20Errors } from "../src/interfaces/IERC20Errors.sol";
 import { IERC20Events } from "../src/interfaces/IERC20Events.sol";
 import { MUDERC20 } from "../src/experimental/MUDERC20.sol";
 import { Pausable, ERC20Pausable } from "../src/experimental/ERC20Pausable.sol";
-import { MockERC20Base, ERC20BehaviorTest, namespace } from "./ERC20BaseTest.t.sol";
-
-ResourceId constant pausedId = ResourceId.wrap(bytes32(abi.encodePacked(RESOURCE_TABLE, namespace, bytes16("Paused"))));
+import { MockERC20Base, ERC20BehaviorTest, namespace, pausedId } from "./ERC20BaseTest.t.sol";
 
 // Mock to include mint and burn functions
 contract MockERC20Pausable is MockERC20Base, ERC20Pausable(pausedId) {
   constructor(IBaseWorld world) MockERC20Base(world) {}
 
   function initialize() public override {
-    MockERC20Base.initialize();
+    super.initialize();
     _Pausable_init();
   }
 
@@ -42,7 +40,7 @@ contract MockERC20Pausable is MockERC20Base, ERC20Pausable(pausedId) {
   }
 }
 
-abstract contract ERC20PausableBehaviorTest is ERC20BehaviorTest {
+contract ERC20PausableTest is ERC20BehaviorTest {
   function createToken(IBaseWorld world) internal override returns (MockERC20Base) {
     return new MockERC20Pausable(world);
   }

--- a/packages/world-module-erc20/test/ERC20Pausable.t.sol
+++ b/packages/world-module-erc20/test/ERC20Pausable.t.sol
@@ -12,10 +12,15 @@ import { IERC20Errors } from "../src/interfaces/IERC20Errors.sol";
 import { IERC20Events } from "../src/interfaces/IERC20Events.sol";
 import { MUDERC20 } from "../src/experimental/MUDERC20.sol";
 import { Pausable, ERC20Pausable } from "../src/experimental/ERC20Pausable.sol";
-import { MockERC20Base, ERC20BehaviorTest } from "./ERC20BaseTest.t.sol";
+import { TestConstants, MockERC20Base, ERC20BehaviorTest } from "./ERC20BaseTest.t.sol";
 
 // Mock to include mint and burn functions
-contract MockERC20Pausable is MockERC20Base, ERC20Pausable {
+contract MockERC20Pausable is MockERC20Base, ERC20Pausable(TestConstants.ERC20_NAMESPACE) {
+  function initialize() public override {
+    MockERC20Base.initialize();
+    Pausable._init();
+  }
+
   function pause() public {
     _pause();
   }

--- a/packages/world-module-erc20/test/ERC20Pausable.t.sol
+++ b/packages/world-module-erc20/test/ERC20Pausable.t.sol
@@ -5,6 +5,10 @@ import { Test } from "forge-std/Test.sol";
 import { console } from "forge-std/console.sol";
 
 import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
+
+import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
+import { RESOURCE_TABLE } from "@latticexyz/store/src/storeResourceTypes.sol";
+
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 
 import { ERC20MetadataData } from "../src/codegen/tables/ERC20Metadata.sol";
@@ -12,10 +16,14 @@ import { IERC20Errors } from "../src/interfaces/IERC20Errors.sol";
 import { IERC20Events } from "../src/interfaces/IERC20Events.sol";
 import { MUDERC20 } from "../src/experimental/MUDERC20.sol";
 import { Pausable, ERC20Pausable } from "../src/experimental/ERC20Pausable.sol";
-import { TestConstants, MockERC20Base, ERC20BehaviorTest } from "./ERC20BaseTest.t.sol";
+import { MockERC20Base, ERC20BehaviorTest, namespace } from "./ERC20BaseTest.t.sol";
+
+ResourceId constant pausedId = ResourceId.wrap(bytes32(abi.encodePacked(RESOURCE_TABLE, namespace, bytes16("Paused"))));
 
 // Mock to include mint and burn functions
-contract MockERC20Pausable is MockERC20Base, ERC20Pausable(TestConstants.ERC20_NAMESPACE) {
+contract MockERC20Pausable is MockERC20Base, ERC20Pausable(pausedId) {
+  constructor(IBaseWorld world) MockERC20Base(world) {}
+
   function initialize() public override {
     MockERC20Base.initialize();
     Pausable._init();
@@ -35,8 +43,8 @@ contract MockERC20Pausable is MockERC20Base, ERC20Pausable(TestConstants.ERC20_N
 }
 
 abstract contract ERC20PausableBehaviorTest is ERC20BehaviorTest {
-  function createToken() internal override returns (MockERC20Base) {
-    return new MockERC20Pausable();
+  function createToken(IBaseWorld world) internal override returns (MockERC20Base) {
+    return new MockERC20Pausable(world);
   }
 
   function testPause() public {


### PR DESCRIPTION
- WorldConsumer now doesn't keep track of a namespace
  - Added `onlyNamespace(namespace)` and `onlyNamespaceOwner(namespace)` modifiers
- MUDERC20:
  - now receives table ids as constructor args
  - example token deployed by module now has an `initialize()` function that can only be called by namespaceOwner. This function sets the metadata and initial paused state.
 