### PR TITLE
fix(entrykit): add a defined check for window

### DIFF
--- a/packages/entrykit/src/store.ts
+++ b/packages/entrykit/src/store.ts
@@ -26,4 +26,7 @@ function listener(event: StorageEvent) {
     store.persist.rehydrate();
   }
 }
-window.addEventListener("storage", listener);
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", listener);
+}


### PR DESCRIPTION
Without this check, importing entrykit in a nodejs environment will cause the following errors:
```
ReferenceError: window is not defined
    at eval (../../../src/store.ts:30:0)
```