### PR TITLE
fix(store): fix internal revert incompatibilities

### DIFF
--- a/packages/cli/contracts/test/Tablegen.t.sol
+++ b/packages/cli/contracts/test/Tablegen.t.sol
@@ -174,7 +174,7 @@ contract TablegenTest is Test, StoreMock {
     assertEq(Singleton.lengthV4, 1);
     assertEq(Singleton.getItemV4(0), 5);
     vm.expectRevert(abi.encodeWithSelector(IStoreErrors.Store_IndexOutOfBounds.selector, 4, 4));
-    assertEq(Singleton.getItemV4(1), 0);
+    Singleton.getItemV4(1);
   }
 
   function testOffchain() public {

--- a/packages/store/test/StoreCoreDynamic.t.sol
+++ b/packages/store/test/StoreCoreDynamic.t.sol
@@ -208,7 +208,6 @@ contract StoreCoreDynamicTest is Test, GasReporter, StoreMock {
     assertEq(length, thirdDataBytes.length);
   }
 
-  /// forge-config: default.allow_internal_expect_revert = true
   function testGetDynamicFieldSlice() public {
     ResourceId tableId = _tableId;
     bytes32[] memory keyTuple = _keyTuple;
@@ -234,10 +233,10 @@ contract StoreCoreDynamicTest is Test, GasReporter, StoreMock {
     // Expect a revert if the end index is out of bounds
     uint256 length = secondDataBytes.length;
     vm.expectRevert(abi.encodeWithSelector(IStoreErrors.Store_IndexOutOfBounds.selector, length, length));
-    StoreCore.getDynamicFieldSlice(tableId, keyTuple, 0, 0, length + 1);
+    this.getDynamicFieldSlice(tableId, keyTuple, 0, 0, length + 1);
 
     // Expect a revert if the start index is out of bounds
     vm.expectRevert(abi.encodeWithSelector(IStoreErrors.Store_IndexOutOfBounds.selector, length, length));
-    StoreCore.getDynamicFieldSlice(tableId, keyTuple, 0, length, length);
+    this.getDynamicFieldSlice(tableId, keyTuple, 0, length, length);
   }
 }

--- a/packages/store/test/StoreCoreGas.t.sol
+++ b/packages/store/test/StoreCoreGas.t.sol
@@ -599,7 +599,6 @@ contract StoreCoreGasTest is Test, GasReporter, StoreMock {
     endGasReport();
   }
 
-  /// forge-config: default.allow_internal_expect_revert = true
   function testAccessEmptyData() public {
     ResourceId tableId = _tableId;
 
@@ -629,7 +628,7 @@ contract StoreCoreGasTest is Test, GasReporter, StoreMock {
     endGasReport();
 
     vm.expectRevert(abi.encodeWithSelector(IStoreErrors.Store_IndexOutOfBounds.selector, 0, 0));
-    StoreCore.getDynamicFieldSlice(tableId, keyTuple, 0, 0, 0);
+    this.getDynamicFieldSlice(tableId, keyTuple, 0, 0, 0);
   }
 
   function testHooks() public {

--- a/packages/world/test/AccessControl.t.sol
+++ b/packages/world/test/AccessControl.t.sol
@@ -93,9 +93,7 @@ contract AccessControlTest is Test, GasReporter, StoreMock {
     vm.expectRevert(
       abi.encodeWithSelector(IWorldErrors.World_AccessDenied.selector, tableId.toString(), address(this))
     );
-    startGasReport("AccessControl: requireAccess (this address)");
     AccessControl.requireAccess(tableId, address(this));
-    endGasReport();
   }
 
   /// forge-config: default.allow_internal_expect_revert = true


### PR DESCRIPTION
An internal revert halts everything after it in the test
So the second internal revert will never be reached
Any other code after an internal revert will also never be reached

So I make some store calls public (most already are, those tests were unnecessary exceptions)

And remove some unreachable unimportant code in a couple other places