### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/pages/world/balance.mdx
+++ b/docs/pages/world/balance.mdx
@@ -99,7 +99,7 @@ uint256 balance = Balances.get(<namespace>);
    import { console } from "forge-std/console.sol";
    ```
 
-   Standard [`forge` script](https://book.getfoundry.sh/tutorials/solidity-scripting) boilerplate.
+   Standard [`forge` script](https://book.getfoundry.sh/guides/scripting-with-solidity) boilerplate.
 
    ```solidity
    import { Balances } from "@latticexyz/world/src/codegen/tables/Balances.sol";

--- a/docs/pages/world/modules.mdx
+++ b/docs/pages/world/modules.mdx
@@ -3,7 +3,7 @@ import { CollapseCode } from "../../components/CollapseCode";
 # Modules
 
 Modules are onchain installation scripts that create resources and their associated configuration when called by a `World`.
-This is somewhat similar to one of the use cases for [foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting), except that modules are deployed onchain and can be used by any `World` on the same chain.
+This is somewhat similar to one of the use cases for [foundry scripts](https://book.getfoundry.sh/guides/scripting-with-solidity), except that modules are deployed onchain and can be used by any `World` on the same chain.
 
 ## Module installation
 


### PR DESCRIPTION
Hi! While reviewing the documentation, I noticed that two links to Foundry's scripting tutorials were broken. These links are important for developers who rely on Foundry's documentation to understand scripting and module installation.