### PR TITLE
fix(docs): fixing typo for KMS key spec in KMS usage docs

### DIFF
--- a/docs/pages/best-practices/aws-kms.mdx
+++ b/docs/pages/best-practices/aws-kms.mdx
@@ -41,7 +41,7 @@ You can read additional details about this process [in the AWS documentation](ht
    | ------------------ | ------------------------------------- |
    | Key type           | Asymmetric                            |
    | Key usage          | Sign and verify                       |
-   | Key spec           | ECC_SECG_OP256K1                      |
+   | Key spec           | ECC_SECG_P256K1                      |
    | Alias              | Appname_world_owner_address           |
    | Key administrators | None                                  |
    | Key deletion       | Clear (only root can delete this key) |


### PR DESCRIPTION
Noticed that the Key spec described in the docs does not exist. 