### PR TITLE
docs: fixed typo in tutorial text

### DIFF
--- a/docs/pages/guides/emojimon.mdx
+++ b/docs/pages/guides/emojimon.mdx
@@ -11,7 +11,7 @@ The Emojimon tutorial is a crash course in everything MUD but it is a particular
 
 - Onchain game development using the [ECS model](https://en.wikipedia.org/wiki/Entity_component_system).
 - How to create [tables](/world/tables), interact with them using [`System`s](/world/systems), and call them from the client.
-- Improve onchain UX by optimistically render user actions using overridable tables.
+- Improve onchain UX by optimistically rendering user actions using overridable tables.
 - Querying onchain data from the [MUD Store](/store/introduction).
 - Deploying all of the above to a testnet.
 


### PR DESCRIPTION
Corrected a typo in the tutorial where the phrase "optimistically render user actions using overridable tables" should have been "optimistically **rendering** user actions using overridable tables." The form of the verb was missing.