### PR TITLE
fix: remove wiresaw from pyrope chain definition

### DIFF
--- a/.changeset/dry-yaks-kiss.md
+++ b/.changeset/dry-yaks-kiss.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/common": patch
+---
+
+Removed the `wiresaw` RPC URL from the Pyrope chain config, since Wiresaw is not deployed to Pyrope yet.

--- a/packages/common/src/chains/pyrope.ts
+++ b/packages/common/src/chains/pyrope.ts
@@ -19,8 +19,6 @@ export const pyrope = {
   rpcUrls: {
     default: defaultRpcUrls,
     bundler: defaultRpcUrls,
-    quarryPassIssuer: defaultRpcUrls,
-    wiresaw: defaultRpcUrls,
   },
   contracts: {
     ...chainConfig.contracts,


### PR DESCRIPTION
There is no wiresaw deployed to Pyrope yet, but the wiresaw rpc url in the chain config caused the sync stack to wait for wiresaw events.