### PR TITLE
fix(common): explicit error in contractToInterface

### DIFF
--- a/packages/common/src/codegen/utils/contractToInterface.ts
+++ b/packages/common/src/codegen/utils/contractToInterface.ts
@@ -165,6 +165,8 @@ function flattenTypeName(typeName: TypeName | null): { name: string; stateMutabi
       length = typeName.length.number;
     } else if (typeName.length?.type === "Identifier") {
       length = typeName.length.name;
+    } else if (typeName.length?.type) {
+      throw new MUDError(`Complex expressions not supported in static array length`);
     }
 
     const { name, stateMutability } = flattenTypeName(typeName.baseTypeName);


### PR DESCRIPTION
Currently this is essentially an uncaught bug that causes `uint256[1 + 2 + 3]` to become `uint256[]`, which leads to incorrect system interfaces and libraries
Very minor issue, I imagine people rarely if ever use expressions in static arrays, but an explicit error is better than a weird bug I guess

To actually fix this error and support complex expressions requires `unparse` of some sort, which solidity-parser doesn't have

nomic's slang does have `unparse`, and is generally much better (and recently 1.0, which is why I didn't use it for `contractToInterface` initially)
btw if you want I can migrate `contractToInterface` to slang when I have time, shouldn't be hard