### PR TITLE
fix(world): support generating libraries for systems without function registration

### DIFF
--- a/.changeset/poor-apples-roll.md
+++ b/.changeset/poor-apples-roll.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Support generating libraries for systems without function registration.


### PR DESCRIPTION
Currently it is not possible generate libraries for systems configured to not register as world functions. This restriction is not necessary, as libraries don't depend on the world's interface.