### PR TITLE
fix(world): support functions with missing argument names in system libraries

### DIFF
--- a/.changeset/thin-insects-draw.md
+++ b/.changeset/thin-insects-draw.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/world": patch
+---
+
+Adds support for functions with missing argument names in system libraries.

--- a/packages/world/ts/node/render-solidity/renderSystemLibrary.ts
+++ b/packages/world/ts/node/render-solidity/renderSystemLibrary.ts
@@ -22,9 +22,11 @@ export function renderSystemLibrary(options: RenderSystemLibraryOptions) {
     storeImportPath,
   } = options;
 
-  // Remove `payable` from stateMutability for library functions
   const functions = functionsInput.map((func) => ({
     ...func,
+    // Format parameters (add auxiliary argument names, replace calldata location)
+    parameters: formatParams(func.parameters),
+    // Remove `payable` from stateMutability for library functions
     stateMutability: func.stateMutability.replace("payable", ""),
   }));
 
@@ -158,7 +160,7 @@ function renderErrors(errors: ContractInterfaceError[]) {
 function renderUserTypeFunction(contractFunction: ContractInterfaceFunction, userTypeName: string) {
   const { name, parameters, stateMutability, returnParameters } = contractFunction;
 
-  const args = [`${userTypeName} self`, ...parameters].map((arg) => arg.replace(/ calldata /, " memory "));
+  const args = [`${userTypeName} self`, ...parameters];
 
   const functionSignature = `
     function ${name}(
@@ -183,7 +185,7 @@ function renderCallWrapperFunction(
 ) {
   const { name, parameters, stateMutability, returnParameters } = contractFunction;
 
-  const args = [`CallWrapper memory self`, ...parameters].map((arg) => arg.replace(/ calldata /, " memory "));
+  const args = [`CallWrapper memory self`, ...parameters];
 
   const functionSignature = `
     function ${name}(
@@ -236,7 +238,7 @@ function renderRootCallWrapperFunction(contractFunction: ContractInterfaceFuncti
     return "";
   }
 
-  const args = ["RootCallWrapper memory self", ...parameters].map((arg) => arg.replace(/ calldata /, " memory "));
+  const args = ["RootCallWrapper memory self", ...parameters];
 
   const functionSignature = `
     function ${name}(
@@ -311,4 +313,17 @@ function renderReturnParameters(returnParameters: string[]) {
   if (returnParameters.length == 0) return "";
 
   return `returns (${renderArguments(returnParameters)})`;
+}
+
+function formatParams(params: string[]) {
+  // Use auxiliary argument names for arguments without names
+  let auxCount = 0;
+
+  return params
+    .map((arg) => arg.replace(/ calldata /, " memory "))
+    .map((arg) => {
+      const items = arg.split(" ");
+      const needsAux = items.length === 1 || (items.length === 2 && items[1] === "memory");
+      return needsAux ? `${arg} __aux${auxCount++}` : arg;
+    });
 }


### PR DESCRIPTION
This is needed so that systems can have functions with arguments that don't have a name (useful if you are making the system inherit from an interface and are not using all args). In the current implementation you would get a compile error due to the encoding of the system calls.