### PR TITLE
fix(store-sync): handle pending deletion in stash storage adapter

### DIFF
--- a/.changeset/hot-bananas-invite.md
+++ b/.changeset/hot-bananas-invite.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Pending deletions immediately followed by field updates are now handled correctly by the Stash storage adapter.

--- a/packages/store-sync/src/stash/createStorageAdapter.ts
+++ b/packages/store-sync/src/stash/createStorageAdapter.ts
@@ -46,7 +46,9 @@ export function createStorageAdapter({ stash }: CreateStorageAdapter): StorageAd
         updates.push((pendingRecords[id] = { table, key, value }));
       } else if (log.eventName === "Store_SpliceStaticData") {
         const previousValue = pendingRecords[id]
-          ? ({ ...pendingRecords[id].key, ...pendingRecords[id].value } as TableRecord)
+          ? pendingRecords[id].value
+            ? ({ ...pendingRecords[id].key, ...pendingRecords[id].value } as TableRecord)
+            : undefined
           : getRecord({ stash, table, key });
 
         const {


### PR DESCRIPTION
If there is a pending deletion, `value` is undefined. If there is another `Store_SpliceStaticData` update, we previously passed in a partial record (consisting of only the key) to `encodeValueArgs`, which would throw an error when trying to encode the missing fields. Now we're handling this case by setting the `previousValue` to `undefined`, just like it would be if the pending deletion was already applied.