### PR TITLE
fix(world): support expectRevert and unusual nameless arguments in system libraries

### DIFF
--- a/packages/world-module-metadata/src/codegen/experimental/systems/MetadataSystemLib.sol
+++ b/packages/world-module-metadata/src/codegen/experimental/systems/MetadataSystemLib.sol
@@ -41,7 +41,7 @@ library MetadataSystemLib {
     MetadataSystemType self,
     ResourceId resource,
     bytes32 tag
-  ) internal view returns (bytes memory) {
+  ) internal view returns (bytes memory __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).getResourceTag(resource, tag);
   }
 
@@ -57,7 +57,7 @@ library MetadataSystemLib {
     CallWrapper memory self,
     ResourceId resource,
     bytes32 tag
-  ) internal view returns (bytes memory) {
+  ) internal view returns (bytes memory __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert MetadataSystemLib_CallingFromRootSystem();
 
@@ -102,7 +102,7 @@ library MetadataSystemLib {
     RootCallWrapper memory self,
     ResourceId resource,
     bytes32 tag
-  ) internal view returns (bytes memory) {
+  ) internal view returns (bytes memory __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_getResourceTag_ResourceId_bytes32.getResourceTag, (resource, tag));
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);

--- a/packages/world-module-metadata/src/codegen/experimental/systems/MetadataSystemLib.sol
+++ b/packages/world-module-metadata/src/codegen/experimental/systems/MetadataSystemLib.sol
@@ -69,7 +69,10 @@ library MetadataSystemLib {
     if (!success) revertWithBytes(returnData);
 
     bytes memory result = abi.decode(returnData, (bytes));
-    return abi.decode(result, (bytes));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes));
+    }
   }
 
   function setResourceTag(CallWrapper memory self, ResourceId resource, bytes32 tag, bytes memory value) internal {
@@ -103,7 +106,10 @@ library MetadataSystemLib {
     bytes memory systemCall = abi.encodeCall(_getResourceTag_ResourceId_bytes32.getResourceTag, (resource, tag));
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
-    return abi.decode(result, (bytes));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes));
+    }
   }
 
   function setResourceTag(RootCallWrapper memory self, ResourceId resource, bytes32 tag, bytes memory value) internal {

--- a/packages/world/src/codegen/experimental/systems/BatchCallSystemLib.sol
+++ b/packages/world/src/codegen/experimental/systems/BatchCallSystemLib.sol
@@ -64,7 +64,10 @@ library BatchCallSystemLib {
     bytes memory result = self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
-    return abi.decode(result, (bytes[]));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes[]));
+    }
   }
 
   function batchCallFrom(
@@ -79,7 +82,10 @@ library BatchCallSystemLib {
     bytes memory result = self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
-    return abi.decode(result, (bytes[]));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes[]));
+    }
   }
 
   function batchCall(
@@ -89,7 +95,10 @@ library BatchCallSystemLib {
     bytes memory systemCall = abi.encodeCall(_batchCall_SystemCallDataArray.batchCall, (systemCalls));
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
-    return abi.decode(result, (bytes[]));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes[]));
+    }
   }
 
   function batchCallFrom(
@@ -99,7 +108,10 @@ library BatchCallSystemLib {
     bytes memory systemCall = abi.encodeCall(_batchCallFrom_SystemCallFromDataArray.batchCallFrom, (systemCalls));
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
-    return abi.decode(result, (bytes[]));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes[]));
+    }
   }
 
   function callFrom(BatchCallSystemType self, address from) internal pure returns (CallWrapper memory) {

--- a/packages/world/src/codegen/experimental/systems/WorldRegistrationSystemLib.sol
+++ b/packages/world/src/codegen/experimental/systems/WorldRegistrationSystemLib.sol
@@ -193,7 +193,10 @@ library WorldRegistrationSystemLib {
     bytes memory result = self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
-    return abi.decode(result, (bytes4));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes4));
+    }
   }
 
   function registerRootFunctionSelector(
@@ -213,7 +216,10 @@ library WorldRegistrationSystemLib {
     bytes memory result = self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
-    return abi.decode(result, (bytes4));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes4));
+    }
   }
 
   function registerDelegation(
@@ -320,7 +326,10 @@ library WorldRegistrationSystemLib {
     );
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
-    return abi.decode(result, (bytes4));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes4));
+    }
   }
 
   function registerRootFunctionSelector(
@@ -335,7 +344,10 @@ library WorldRegistrationSystemLib {
     );
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
-    return abi.decode(result, (bytes4));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (bytes4));
+    }
   }
 
   function registerDelegation(

--- a/packages/world/ts/node/render-solidity/renderSystemLibrary.ts
+++ b/packages/world/ts/node/render-solidity/renderSystemLibrary.ts
@@ -308,7 +308,10 @@ function renderAbiDecode(expression: string, returnParameters: string[]) {
   const returnTypes = returnParameters.map((param) => param.split(" ")[0]).join(", ");
   return `
     bytes memory result = ${expression};
-    return abi.decode(result, (${returnTypes}));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (${returnTypes}));
+    }
   `;
 }
 

--- a/test/system-libraries/src/codegen/world/IASystem.sol
+++ b/test/system-libraries/src/codegen/world/IASystem.sol
@@ -28,6 +28,10 @@ interface IASystem {
 
   function a__setAddress() external returns (address);
 
+  function a__getValueWithRevert() external pure returns (uint256);
+
+  function a__setAddressWithRevert() external returns (address);
+
   function a__setValuesStaticArray(uint256[1] memory values) external;
 
   function a__setValuesStaticArray(uint256[2] memory values) external;

--- a/test/system-libraries/src/codegen/world/IASystem.sol
+++ b/test/system-libraries/src/codegen/world/IASystem.sol
@@ -28,6 +28,13 @@ interface IASystem {
 
   function a__setAddress() external returns (address);
 
+  function a__setWithNamelessParameters(
+    address payable,
+    bytes calldata b,
+    bytes calldata,
+    string[] memory
+  ) external returns (address payable, bytes calldata, string[] memory);
+
   function a__getValueWithRevert() external pure returns (uint256);
 
   function a__setAddressWithRevert() external returns (address);

--- a/test/system-libraries/src/namespaces/a/ASystem.sol
+++ b/test/system-libraries/src/namespaces/a/ASystem.sol
@@ -45,6 +45,17 @@ contract ASystem is System {
     return addr;
   }
 
+  function setWithNamelessParameters(
+    address payable,
+    bytes calldata b,
+    bytes calldata,
+    string[] memory
+  ) external returns (address payable, bytes calldata, string[] memory) {
+    address addr = _msgSender();
+    AddressValue.set(addr);
+    return (payable(addr), b, new string[](0));
+  }
+
   function getValueWithRevert() external pure returns (uint256) {
     revert("reverted successfully");
   }

--- a/test/system-libraries/src/namespaces/a/ASystem.sol
+++ b/test/system-libraries/src/namespaces/a/ASystem.sol
@@ -45,6 +45,16 @@ contract ASystem is System {
     return addr;
   }
 
+  function getValueWithRevert() external pure returns (uint256) {
+    revert("reverted successfully");
+  }
+
+  function setAddressWithRevert() external returns (address) {
+    address addr = _msgSender();
+    AddressValue.set(addr);
+    revert("reverted successfully");
+  }
+
   function setValuesStaticArray(uint256[1] memory values) external {
     Value.set(values[0]);
   }

--- a/test/system-libraries/src/namespaces/a/codegen/systems/ASystemLib.sol
+++ b/test/system-libraries/src/namespaces/a/codegen/systems/ASystemLib.sol
@@ -57,23 +57,33 @@ library ASystemLib {
     return CallWrapper(self.toResourceId(), address(0)).setPositions(positions);
   }
 
-  function getValue(ASystemType self) internal view returns (uint256) {
+  function getValue(ASystemType self) internal view returns (uint256 __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).getValue();
   }
 
-  function getTwoValues(ASystemType self) internal view returns (uint256, uint256) {
+  function getTwoValues(ASystemType self) internal view returns (uint256 __auxRet0, uint256 __auxRet1) {
     return CallWrapper(self.toResourceId(), address(0)).getTwoValues();
   }
 
-  function setAddress(ASystemType self) internal returns (address) {
+  function setAddress(ASystemType self) internal returns (address __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).setAddress();
   }
 
-  function getValueWithRevert(ASystemType self) internal view returns (uint256) {
+  function setWithNamelessParameters(
+    ASystemType self,
+    address payable __auxArg0,
+    bytes memory b,
+    bytes memory __auxArg1,
+    string[] memory __auxArg2
+  ) internal returns (address payable __auxRet0, bytes memory __auxRet1, string[] memory __auxRet2) {
+    return CallWrapper(self.toResourceId(), address(0)).setWithNamelessParameters(__auxArg0, b, __auxArg1, __auxArg2);
+  }
+
+  function getValueWithRevert(ASystemType self) internal view returns (uint256 __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).getValueWithRevert();
   }
 
-  function setAddressWithRevert(ASystemType self) internal returns (address) {
+  function setAddressWithRevert(ASystemType self) internal returns (address __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).setAddressWithRevert();
   }
 
@@ -139,7 +149,7 @@ library ASystemLib {
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function getValue(CallWrapper memory self) internal view returns (uint256) {
+  function getValue(CallWrapper memory self) internal view returns (uint256 __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
 
@@ -157,7 +167,7 @@ library ASystemLib {
     }
   }
 
-  function getTwoValues(CallWrapper memory self) internal view returns (uint256, uint256) {
+  function getTwoValues(CallWrapper memory self) internal view returns (uint256 __auxRet0, uint256 __auxRet1) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
 
@@ -175,7 +185,7 @@ library ASystemLib {
     }
   }
 
-  function setAddress(CallWrapper memory self) internal returns (address) {
+  function setAddress(CallWrapper memory self) internal returns (address __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
 
@@ -190,7 +200,31 @@ library ASystemLib {
     }
   }
 
-  function getValueWithRevert(CallWrapper memory self) internal view returns (uint256) {
+  function setWithNamelessParameters(
+    CallWrapper memory self,
+    address payable __auxArg0,
+    bytes memory b,
+    bytes memory __auxArg1,
+    string[] memory __auxArg2
+  ) internal returns (address payable __auxRet0, bytes memory __auxRet1, string[] memory __auxRet2) {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall = abi.encodeCall(
+      _setWithNamelessParameters_address_bytes_bytes_stringArray.setWithNamelessParameters,
+      (__auxArg0, b, __auxArg1, __auxArg2)
+    );
+
+    bytes memory result = self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (address, bytes, string[]));
+    }
+  }
+
+  function getValueWithRevert(CallWrapper memory self) internal view returns (uint256 __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
 
@@ -208,7 +242,7 @@ library ASystemLib {
     }
   }
 
-  function setAddressWithRevert(CallWrapper memory self) internal returns (address) {
+  function setAddressWithRevert(CallWrapper memory self) internal returns (address __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert ASystemLib_CallingFromRootSystem();
 
@@ -281,7 +315,7 @@ library ASystemLib {
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function getValue(RootCallWrapper memory self) internal view returns (uint256) {
+  function getValue(RootCallWrapper memory self) internal view returns (uint256 __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_getValue.getValue, ());
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
@@ -291,7 +325,7 @@ library ASystemLib {
     }
   }
 
-  function getTwoValues(RootCallWrapper memory self) internal view returns (uint256, uint256) {
+  function getTwoValues(RootCallWrapper memory self) internal view returns (uint256 __auxRet0, uint256 __auxRet1) {
     bytes memory systemCall = abi.encodeCall(_getTwoValues.getTwoValues, ());
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
@@ -301,7 +335,7 @@ library ASystemLib {
     }
   }
 
-  function setAddress(RootCallWrapper memory self) internal returns (address) {
+  function setAddress(RootCallWrapper memory self) internal returns (address __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_setAddress.setAddress, ());
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
@@ -311,7 +345,26 @@ library ASystemLib {
     }
   }
 
-  function getValueWithRevert(RootCallWrapper memory self) internal view returns (uint256) {
+  function setWithNamelessParameters(
+    RootCallWrapper memory self,
+    address payable __auxArg0,
+    bytes memory b,
+    bytes memory __auxArg1,
+    string[] memory __auxArg2
+  ) internal returns (address payable __auxRet0, bytes memory __auxRet1, string[] memory __auxRet2) {
+    bytes memory systemCall = abi.encodeCall(
+      _setWithNamelessParameters_address_bytes_bytes_stringArray.setWithNamelessParameters,
+      (__auxArg0, b, __auxArg1, __auxArg2)
+    );
+
+    bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (address, bytes, string[]));
+    }
+  }
+
+  function getValueWithRevert(RootCallWrapper memory self) internal view returns (uint256 __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_getValueWithRevert.getValueWithRevert, ());
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
@@ -321,7 +374,7 @@ library ASystemLib {
     }
   }
 
-  function setAddressWithRevert(RootCallWrapper memory self) internal returns (address) {
+  function setAddressWithRevert(RootCallWrapper memory self) internal returns (address __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_setAddressWithRevert.setAddressWithRevert, ());
 
     bytes memory result = SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
@@ -417,6 +470,15 @@ interface _getTwoValues {
 
 interface _setAddress {
   function setAddress() external;
+}
+
+interface _setWithNamelessParameters_address_bytes_bytes_stringArray {
+  function setWithNamelessParameters(
+    address payable __auxArg0,
+    bytes memory b,
+    bytes memory __auxArg1,
+    string[] memory __auxArg2
+  ) external;
 }
 
 interface _getValueWithRevert {

--- a/test/system-libraries/src/namespaces/b/codegen/systems/BSystemLib.sol
+++ b/test/system-libraries/src/namespaces/b/codegen/systems/BSystemLib.sol
@@ -66,7 +66,10 @@ library BSystemLib {
     if (!success) revertWithBytes(returnData);
 
     bytes memory result = abi.decode(returnData, (bytes));
-    return abi.decode(result, (uint256));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (uint256));
+    }
   }
 
   function setValueInA(RootCallWrapper memory self, ASystemThing memory thing) internal {
@@ -78,7 +81,10 @@ library BSystemLib {
     bytes memory systemCall = abi.encodeCall(_getValueFromA.getValueFromA, ());
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
-    return abi.decode(result, (uint256));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (uint256));
+    }
   }
 
   function callFrom(BSystemType self, address from) internal pure returns (CallWrapper memory) {

--- a/test/system-libraries/src/namespaces/b/codegen/systems/BSystemLib.sol
+++ b/test/system-libraries/src/namespaces/b/codegen/systems/BSystemLib.sol
@@ -40,7 +40,7 @@ library BSystemLib {
     return CallWrapper(self.toResourceId(), address(0)).setValueInA(thing);
   }
 
-  function getValueFromA(BSystemType self) internal view returns (uint256) {
+  function getValueFromA(BSystemType self) internal view returns (uint256 __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).getValueFromA();
   }
 
@@ -54,7 +54,7 @@ library BSystemLib {
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function getValueFromA(CallWrapper memory self) internal view returns (uint256) {
+  function getValueFromA(CallWrapper memory self) internal view returns (uint256 __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert BSystemLib_CallingFromRootSystem();
 
@@ -77,7 +77,7 @@ library BSystemLib {
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function getValueFromA(RootCallWrapper memory self) internal view returns (uint256) {
+  function getValueFromA(RootCallWrapper memory self) internal view returns (uint256 __auxRet0) {
     bytes memory systemCall = abi.encodeCall(_getValueFromA.getValueFromA, ());
 
     bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);

--- a/test/system-libraries/src/namespaces/root/codegen/systems/RootSystemLib.sol
+++ b/test/system-libraries/src/namespaces/root/codegen/systems/RootSystemLib.sol
@@ -68,7 +68,10 @@ library RootSystemLib {
     if (!success) revertWithBytes(returnData);
 
     bytes memory result = abi.decode(returnData, (bytes));
-    return abi.decode(result, (uint256));
+    // skip decoding an empty result, which can happen after expectRevert
+    if (result.length != 0) {
+      return abi.decode(result, (uint256));
+    }
   }
 
   function setValueInA(RootCallWrapper memory self, ASystemThing memory thing) internal {

--- a/test/system-libraries/src/namespaces/root/codegen/systems/RootSystemLib.sol
+++ b/test/system-libraries/src/namespaces/root/codegen/systems/RootSystemLib.sol
@@ -42,7 +42,7 @@ library RootSystemLib {
     return CallWrapper(self.toResourceId(), address(0)).setValueInA(thing);
   }
 
-  function getValueFromA(RootSystemType self) internal view returns (uint256) {
+  function getValueFromA(RootSystemType self) internal view returns (uint256 __auxRet0) {
     return CallWrapper(self.toResourceId(), address(0)).getValueFromA();
   }
 
@@ -56,7 +56,7 @@ library RootSystemLib {
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function getValueFromA(CallWrapper memory self) internal view returns (uint256) {
+  function getValueFromA(CallWrapper memory self) internal view returns (uint256 __auxRet0) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert RootSystemLib_CallingFromRootSystem();
 

--- a/test/system-libraries/test/Libraries.t.sol
+++ b/test/system-libraries/test/Libraries.t.sol
@@ -60,6 +60,15 @@ contract LibrariesTest is MudTest {
     assertEq(Value.get(), 2);
     aSystem.setValuesStaticArray([uint256(1), 2, 3]);
     assertEq(Value.get(), 3);
+
+    bytes memory bytesArgument = "test bytes";
+    (, bytes memory bytesResult, ) = aSystem.setWithNamelessParameters(
+      payable(0),
+      bytesArgument,
+      bytesArgument,
+      new string[](0)
+    );
+    assertEq(bytesResult, bytesArgument);
   }
 
   function testCanCallSystemFromOtherSystem() public {

--- a/test/system-libraries/test/Libraries.t.sol
+++ b/test/system-libraries/test/Libraries.t.sol
@@ -95,4 +95,12 @@ contract LibrariesTest is MudTest {
     assertEq(aSystem.getValue(), value);
     assertEq(rootSystem.getValueFromA(), value);
   }
+
+  function testCanExpectRevert() public {
+    vm.expectRevert("reverted successfully");
+    aSystem.getValueWithRevert();
+
+    vm.expectRevert("reverted successfully");
+    aSystem.setAddressWithRevert();
+  }
 }


### PR DESCRIPTION
4 issues:
1. Using `vm.expectRevert` before a system library call always fails with a confusing `EvmError: Revert`, because the call is unexpectedly successful, but with an empty `result`, which breaks `abi.decode(result, (...))`
2. When an `address payable` parameter doesn't have a name, `address` is parsed as its type, and `payable` as its name
3. When a dynamic type (e.g. `bytes calldata`) parameter doesn't have a name, `/ calldata /` in `formatParams` doesn't capture it because there is no whitespace at the end
4. When a return parameter has `calldata` location, it doesn't get replaced with `memory`, unlike arguments

2-4 are obviously related and fixed by the changes to `formatParams`, and formatting `returnParameters` too 

1 is much less related, but the fix for it is - after I conditionally skip `return` if `result.length == 0`, this causes the solidity warning `Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable. solidity(6321)`.
And using the same `formatParameters` for `returnParameters`, including aux names, avoids the warning by naming the variables

I thought it'd be more convenient to review this way, but I can separate the expectRevert stuff if you don't like it
