### PR TITLE
chore(world-modules): fix ERC721 comment typos

### DIFF
--- a/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/ERC721Module.sol
@@ -54,7 +54,7 @@ contract ERC721Module is Module {
     ResourceId namespaceId = WorldResourceIdLib.encodeNamespace(namespace);
     world.transferOwnership(namespaceId, _msgSender());
 
-    // Register the ERC721 in the ERC20Registry
+    // Register the ERC721 in the ERC721Registry
     if (!ResourceIds.getExists(ERC721_REGISTRY_TABLE_ID)) {
       world.registerNamespace(MODULE_NAMESPACE_ID);
       ERC721Registry.register(ERC721_REGISTRY_TABLE_ID);
@@ -80,7 +80,7 @@ library ERC721ModuleRegistrationLib {
     Balances.register(_balancesTableId(namespace));
     ERC721Metadata.register(_metadataTableId(namespace));
 
-    // Register a new ERC20System
+    // Register a new ERC721System
     world.registerSystem(_erc721SystemId(namespace), new ERC721System(), true);
   }
 }

--- a/packages/world-modules/src/modules/erc721-puppet/IERC721Mintable.sol
+++ b/packages/world-modules/src/modules/erc721-puppet/IERC721Mintable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/IERC20.sol)
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC721/ERC721.sol)
 pragma solidity >=0.8.24;
 
 import { IERC721 } from "./IERC721.sol";


### PR DESCRIPTION
`ERC721` rather than `IERC721` is intentional - OZ doesn't have mint in the interface