### PR TITLE
feat(entrykit): loosen min gas balance

### DIFF
--- a/.changeset/famous-experts-deliver.md
+++ b/.changeset/famous-experts-deliver.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/entrykit": patch
+---
+
+Loosened minimum gas balance requirement in onboarding to allow for any gas balance above zero.

--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -16,4 +16,4 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: nightly
+        version: 1.1.0

--- a/.github/actions/setup-prerequisites/action.yml
+++ b/.github/actions/setup-prerequisites/action.yml
@@ -16,4 +16,4 @@ runs:
     - name: Setup foundry
       uses: foundry-rs/foundry-toolchain@v1
       with:
-        version: 1.1.0
+        version: v1.1.0

--- a/packages/entrykit/src/onboarding/GasBalance.tsx
+++ b/packages/entrykit/src/onboarding/GasBalance.tsx
@@ -55,7 +55,7 @@ export function GasBalance({ isActive, isExpanded, sessionAddress }: Props) {
         ) : relayChain != null ? (
           // TODO: convert this to a <ButtonLink>
           <a
-            href={`${relayChain.bridgeUrl}?${new URLSearchParams({ toAddress: sessionAddress })}`}
+            href={`${relayChain.bridgeUrl}?${new URLSearchParams({ toAddress: sessionAddress, amount: "0.01" })}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/packages/entrykit/src/onboarding/GasBalance.tsx
+++ b/packages/entrykit/src/onboarding/GasBalance.tsx
@@ -1,4 +1,4 @@
-import { Hex } from "viem";
+import { Hex, parseEther } from "viem";
 import { PendingIcon } from "../icons/PendingIcon";
 import { Button } from "../ui/Button";
 import { Balance } from "../ui/Balance";
@@ -6,7 +6,7 @@ import { useBalance, useWatchBlockNumber } from "wagmi";
 import { useEntryKitConfig } from "../EntryKitConfigProvider";
 import relayChains from "../data/relayChains.json";
 import { useSetBalance } from "./useSetBalance";
-import { RelayChains, minGasBalance } from "./common";
+import { RelayChains } from "./common";
 import { TruncatedHex } from "../ui/TruncatedHex";
 import { useShowMutationError } from "../errors/useShowMutationError";
 import { useShowQueryError } from "../errors/useShowQueryError";
@@ -46,7 +46,7 @@ export function GasBalance({ isActive, isExpanded, sessionAddress }: Props) {
             onClick={() =>
               setBalance.mutate({
                 address: sessionAddress,
-                value: minGasBalance + (balance.data?.value ?? 0n),
+                value: parseEther("0.01") + (balance.data?.value ?? 0n),
               })
             }
           >

--- a/packages/entrykit/src/onboarding/common.ts
+++ b/packages/entrykit/src/onboarding/common.ts
@@ -1,14 +1,10 @@
 import { ReactNode } from "react";
-import { parseEther } from "viem";
 
 export type Step = {
   id: string;
   isComplete: boolean;
   content: (props: { isActive: boolean; isExpanded: boolean }) => ReactNode;
 };
-
-// TODO: move to chain config?
-export const minGasBalance = parseEther("0.01");
 
 export type RelayChain = {
   bridgeUrl: string;

--- a/packages/entrykit/src/onboarding/quarry/Allowance.tsx
+++ b/packages/entrykit/src/onboarding/quarry/Allowance.tsx
@@ -1,11 +1,10 @@
-import { Hex } from "viem";
+import { Hex, parseEther } from "viem";
 import { useAllowance } from "./useAllowance";
 import { PendingIcon } from "../../icons/PendingIcon";
 import { useClaimGasPass } from "./useClaimGasPass";
 import { Button } from "../../ui/Button";
 import { Balance } from "../../ui/Balance";
 import { useEffect } from "react";
-import { minGasBalance } from "../common";
 import { useShowQueryError } from "../../errors/useShowQueryError";
 import { useShowMutationError } from "../../errors/useShowMutationError";
 
@@ -30,7 +29,7 @@ export function Allowance({ isActive, isExpanded, userAddress }: Props) {
         claimGasPass.status === "idle" &&
         allowance.isSuccess &&
         allowance.data != null &&
-        allowance.data < minGasBalance
+        allowance.data < parseEther("0.01")
       ) {
         claimGasPass.mutate(userAddress);
       }

--- a/packages/entrykit/src/onboarding/usePrerequisites.ts
+++ b/packages/entrykit/src/onboarding/usePrerequisites.ts
@@ -1,4 +1,3 @@
-import { minGasBalance } from "./common";
 import { getAllowanceQueryOptions } from "./quarry/useAllowance";
 import { getSpenderQueryOptions } from "./quarry/useSpender";
 import { getDelegationQueryOptions } from "./useDelegation";
@@ -48,9 +47,9 @@ export function getPrequisitesQueryOptions({
               queryClient.fetchQuery(getDelegationQueryOptions({ client, worldAddress, userAddress, sessionAddress })),
             ]);
             // TODO: figure out better approach than null for allowance/spender when no quarry paymaster
-            const hasAllowance = allowance == null || allowance >= minGasBalance;
+            const hasAllowance = allowance == null || allowance >= 0n;
             const isSpender = spender == null ? true : spender;
-            const hasGasBalance = sessionBalance == null || sessionBalance.value >= minGasBalance;
+            const hasGasBalance = sessionBalance == null || sessionBalance.value >= 0n;
             return {
               sessionAddress,
               hasAllowance,


### PR DESCRIPTION
min gas balance wasn't a requirement for returning a complete session account but was required for getting through onboarding steps in entrykit

for now, we'll remove the min gas balance and just require anything >0
