### PR TITLE
fix(entrykit): make required gas balance non-zero

### DIFF
--- a/.changeset/seven-pets-sell.md
+++ b/.changeset/seven-pets-sell.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/entrykit": patch
+---
+
+Increased required balance/allowance to greater than zero.

--- a/packages/entrykit/src/onboarding/usePrerequisites.ts
+++ b/packages/entrykit/src/onboarding/usePrerequisites.ts
@@ -47,9 +47,9 @@ export function getPrequisitesQueryOptions({
               queryClient.fetchQuery(getDelegationQueryOptions({ client, worldAddress, userAddress, sessionAddress })),
             ]);
             // TODO: figure out better approach than null for allowance/spender when no quarry paymaster
-            const hasAllowance = allowance == null || allowance >= 0n;
+            const hasAllowance = allowance == null || allowance > 0n;
             const isSpender = spender == null ? true : spender;
-            const hasGasBalance = sessionBalance == null || sessionBalance.value >= 0n;
+            const hasGasBalance = sessionBalance == null || sessionBalance.value > 0n;
             return {
               sessionAddress,
               hasAllowance,


### PR DESCRIPTION
- Currently a balance of 0 passes the top up step, but the balance should be non-zero
- Otherwise it assumes the step is done, and doesnt show the app wallet address
- Also, the delegation tx fails and the user cant get pass the onboarding