### PR TITLE
fix(cli): fix custom world deployment

### DIFF
--- a/e2e/packages/contracts/mud.config.customworld.ts
+++ b/e2e/packages/contracts/mud.config.customworld.ts
@@ -1,0 +1,12 @@
+import { defineWorld } from "@latticexyz/world";
+import { rawMudConfig } from "./mud.config";
+
+export default defineWorld({
+  ...rawMudConfig,
+  deploy: {
+    customWorld: {
+      sourcePath: "src/CustomWorld.sol",
+      name: "CustomWorld",
+    },
+  },
+});

--- a/e2e/packages/contracts/mud.config.ts
+++ b/e2e/packages/contracts/mud.config.ts
@@ -1,6 +1,6 @@
 import { defineWorld } from "@latticexyz/world";
 
-export default defineWorld({
+export const rawMudConfig = {
   tables: {
     Number: {
       schema: {
@@ -65,4 +65,6 @@ export default defineWorld({
       },
     },
   },
-});
+} as const;
+
+export default defineWorld(rawMudConfig);

--- a/e2e/packages/contracts/package.json
+++ b/e2e/packages/contracts/package.json
@@ -7,7 +7,7 @@
     "build": "mud build",
     "clean": "forge clean && shx rm -rf src/**/codegen",
     "deploy:local": "mud deploy",
-    "test": "mud test",
+    "test": "mud test && mud test --skip-build --configPath=mud.config.customworld.ts",
     "test:ci": "pnpm run test"
   },
   "devDependencies": {

--- a/e2e/packages/contracts/src/CustomWorld.sol
+++ b/e2e/packages/contracts/src/CustomWorld.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.24;
+
+import { World } from "@latticexyz/world/src/World.sol";
+
+contract CustomWorld is World {}

--- a/packages/cli/src/deploy/deployCustomWorld.ts
+++ b/packages/cli/src/deploy/deployCustomWorld.ts
@@ -113,7 +113,12 @@ export async function deployCustomWorld({
     functionName: "transferOwnership",
     args: [resourceToHex({ type: "namespace", namespace: "", name: "" }), client.account.address],
   });
-  await waitForTransactions({ client, hashes: [transferOwnershipTx], debugLabel: "world ownership transfer" });
 
-  return { ...deploy, stateBlock: deploy.deployBlock };
+  debug("waiting for world ownership transfer");
+  const finalStateReceipt = await waitForTransactionReceipt(client, { hash: transferOwnershipTx });
+  if (finalStateReceipt.status === "reverted") {
+    throw new Error(`Transaction reverted: ${transferOwnershipTx}`);
+  }
+
+  return { ...deploy, stateBlock: finalStateReceipt.blockNumber };
 }


### PR DESCRIPTION
`deployCustomWorld` returns `stateBlock` that is at world contract creation, but that is before initialization or ownership transfer

Currently deploying any customWorld doesn't work because `ensureNamespaceOwner` gets this early `stateBlock` and doesn't see the updated ownership

In addition to the fix I add an e2e test for a simple CustomWorld identical to the normal world, to test that `deployCustomWorld` works at all (you can see it fail if you revert the fix)