### PR TITLE
feat(store-sync): make pending logs sync more resilient

### DIFF
--- a/.changeset/selfish-wolves-promise.md
+++ b/.changeset/selfish-wolves-promise.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+The sync stack now handles downtime in the pending logs API and reconnects once it's available again.

--- a/packages/entrykit/playground/common.ts
+++ b/packages/entrykit/playground/common.ts
@@ -1,12 +1,13 @@
 import { Hex } from "viem";
 import { anvil } from "viem/chains";
-import { garnet, redstone } from "@latticexyz/common/chains";
+import { garnet, pyrope, redstone } from "@latticexyz/common/chains";
 
 const testWorlds = {
   // TODO: get this from somewhere else, like playground deploy output
   [anvil.id]: "0x60e7e3caed67b9d2cca14519b6cd7700a7d4ee66",
   [redstone.id]: "0xf75b1b7bdb6932e487c4aa8d210f4a682abeacf0",
   [garnet.id]: "0x1d1BBb7e359a7425428adBe799d84601B221b4E8",
+  [pyrope.id]: "0xe8d5C603b4A501B6B5EAB46a14dA05f38e44F64f",
 } as Partial<Record<string, Hex>>;
 
 const searchParams = new URLSearchParams(window.location.search);

--- a/packages/stash/src/actions/applyUpdates.ts
+++ b/packages/stash/src/actions/applyUpdates.ts
@@ -3,11 +3,14 @@ import { Key, Stash, TableRecord, TableUpdates } from "../common";
 import { encodeKey } from "./encodeKey";
 import { Table } from "@latticexyz/config";
 import { registerTable } from "./registerTable";
+import { Log } from "viem";
 
 export type PendingStashUpdate<table extends Table = Table> = {
   table: table;
   key: Key<table>;
   value: undefined | Partial<TableRecord<table>>;
+  // TODO: remove later, just for debugging
+  log?: Log;
 };
 
 export type ApplyUpdatesArgs = {

--- a/packages/stash/src/actions/applyUpdates.ts
+++ b/packages/stash/src/actions/applyUpdates.ts
@@ -30,7 +30,7 @@ export function applyUpdates({ stash, updates }: ApplyUpdatesArgs): void {
   const pendingUpdates = pendingStashUpdates.get(stash) ?? {};
   if (!pendingStashUpdates.has(stash)) pendingStashUpdates.set(stash, pendingUpdates);
 
-  for (const { table, key, value } of updates) {
+  for (const { table, key, value, log } of updates) {
     if (stash.get().config[table.namespaceLabel]?.[table.label] == null) {
       registerTable({ stash, table });
     }
@@ -66,6 +66,7 @@ export function applyUpdates({ stash, updates }: ApplyUpdatesArgs): void {
       key,
       previous: prevRecord,
       current: nextRecord,
+      log,
     });
   }
 

--- a/packages/stash/src/actions/setRecord.ts
+++ b/packages/stash/src/actions/setRecord.ts
@@ -1,16 +1,24 @@
 import { Table } from "@latticexyz/config";
 import { Key, TableRecord, Stash } from "../common";
 import { applyUpdates } from "./applyUpdates";
+import { Log } from "viem";
 
 export type SetRecordArgs<table extends Table = Table> = {
   stash: Stash;
   table: table;
   key: Key<table>;
   value: Partial<TableRecord<table>>;
+  log?: Log;
 };
 
 export type SetRecordResult = void;
 
-export function setRecord<table extends Table>({ stash, table, key, value }: SetRecordArgs<table>): SetRecordResult {
-  applyUpdates({ stash, updates: [{ table, key, value }] });
+export function setRecord<table extends Table>({
+  stash,
+  table,
+  key,
+  value,
+  log,
+}: SetRecordArgs<table>): SetRecordResult {
+  applyUpdates({ stash, updates: [{ table, key, value, log }] });
 }

--- a/packages/stash/src/common.ts
+++ b/packages/stash/src/common.ts
@@ -1,6 +1,7 @@
 import { getKeySchema, getSchemaPrimitives } from "@latticexyz/protocol-parser/internal";
 import { Table } from "@latticexyz/config";
 import { QueryFragment } from "./queryFragments";
+import { Log } from "viem";
 
 export type StoreConfig = {
   namespaces: {
@@ -134,6 +135,7 @@ export type TableUpdate<table extends Table = Table> = {
   key: Key<table>;
   previous: TableRecord<table> | undefined;
   current: TableRecord<table> | undefined;
+  log?: Log;
 };
 
 export type TableUpdates<table extends Table = Table> = TableUpdate<table>[];

--- a/packages/store-sync/src/README.md
+++ b/packages/store-sync/src/README.md
@@ -1,0 +1,22 @@
+# Approach
+
+#### If pending logs are not available
+
+- Initialize snapshot
+- Initialize log stream from latest block
+  - Catch up logs between snapshot and latest block
+  - Attempt to stream logs from indexer
+  - On failure, fallback to streaming logs from RPC
+- Release initial, catchup and ongoing stream to subscribers
+
+#### If pending logs are available
+
+- Initialize from snapshot
+- Open a pending log stream
+  - On error recreate the stream
+- Open a fallback log stream (indexer or RPC)
+- Catch up logs between snapshot and latest block
+- Cache processed log indices from pending logs stream
+- On every new block from the fallback logs stream
+  - Verify that all logs have already been processed in the pending logs stream
+  - If missing logs are found, release the missing logs to subscribers and recreate the pending logs stream

--- a/packages/store-sync/src/common.ts
+++ b/packages/store-sync/src/common.ts
@@ -111,10 +111,12 @@ export type SyncOptions = GetRpcClientOptions & {
     logs: readonly StorageAdapterLog[];
   };
   /**
-   * Optional flag to disable chunking during the initial hydration.
-   * Note: if atomicity of updates is important, set this to `true`, as chunking can lead to updates that happened in the same block being split across multiple chunks.
+   * Optional flag to define the chunking behavior during the initial hydration. Defaults to `true`.
+   * Chunking is useful to avoid blocking the main thread for too long, but it can lead to updates that happened in the same block being split across multiple chunks.
+   * If chunking is enabled, clients should account for this by waiting for full hydration before using the update stream.
+   * If atomicity of updates is important and blocking the main thread is not an issue, set this to `false`.
    */
-  disableChunking?: boolean;
+  enableHydrationChunking?: boolean;
 };
 
 export type WaitForTransactionResult = Pick<TransactionReceipt, "blockNumber" | "status" | "transactionHash">;

--- a/packages/store-sync/src/common.ts
+++ b/packages/store-sync/src/common.ts
@@ -110,6 +110,11 @@ export type SyncOptions = GetRpcClientOptions & {
     blockNumber: bigint;
     logs: readonly StorageAdapterLog[];
   };
+  /**
+   * Optional flag to disable chunking during the initial hydration.
+   * Note: if atomicity of updates is important, set this to `true`, as chunking can lead to updates that happened in the same block being split across multiple chunks.
+   */
+  disableChunking?: boolean;
 };
 
 export type WaitForTransactionResult = Pick<TransactionReceipt, "blockNumber" | "status" | "transactionHash">;

--- a/packages/store-sync/src/createPendingBlockStream.ts
+++ b/packages/store-sync/src/createPendingBlockStream.ts
@@ -1,0 +1,220 @@
+import {
+  catchError,
+  combineLatest,
+  concatMap,
+  from,
+  map,
+  mergeMap,
+  Observable,
+  of,
+  Subject,
+  tap,
+  throwError,
+  switchMap,
+  merge,
+  filter,
+  startWith,
+} from "rxjs";
+import { StorageAdapterBlock, StoreEventsLog, SyncFilter } from "./common";
+import { watchLogs } from "./watchLogs";
+import { Hex } from "viem";
+import { fromEventSource } from "./fromEventSource";
+import { isLogsApiResponse } from "./indexer-client/isLogsApiResponse";
+import { toStorageAdapterBlock } from "./indexer-client/toStorageAdapterBlock";
+import { fetchAndStoreLogs } from "./fetchAndStoreLogs";
+import { storeEventsAbi } from "@latticexyz/store";
+import { bigIntMax } from "@latticexyz/common/utils";
+import { getRpcClient, GetRpcClientOptions } from "@latticexyz/block-logs-stream";
+import { debug } from "./debug";
+
+type PendingBlockStreamOptions = GetRpcClientOptions & {
+  fromBlock: bigint;
+  pendingLogsUrl: string;
+  indexerUrl?: string;
+  chainId: number;
+  address?: Hex;
+  filters: SyncFilter[];
+  latestBlockNumber$: Observable<bigint>;
+  maxBlockRange?: bigint;
+};
+
+export function createPendingBlockStream(opts: PendingBlockStreamOptions): Observable<StorageAdapterBlock> {
+  const recreatePendingStream$ = new Subject<void>();
+  const recreateLatestStream$ = new Subject<void>();
+
+  let restartBlockNumber = opts.fromBlock;
+  let initialCatchUpBlockNumber: bigint | undefined = undefined;
+  getRpcClient(opts)
+    .request({ method: "eth_blockNumber" })
+    .then((blockNumber) => {
+      console.log("initial catch up block number", BigInt(blockNumber));
+      initialCatchUpBlockNumber = BigInt(blockNumber);
+    });
+
+  const latestBlock$ = recreateLatestStream$.pipe(
+    startWith(undefined),
+    switchMap(() =>
+      createLatestBlockStream({ ...opts, fromBlock: restartBlockNumber }).pipe(
+        catchError((e) => {
+          debug("Error in latest block stream, recreating", e);
+          recreateLatestStream$.next();
+          return throwError(() => e);
+        }),
+      ),
+    ),
+  );
+
+  let processedBlockLogs: { [blockNumber: string]: { [logIndex: number]: boolean } } = {};
+  let pendingLogsState: "initializing" | "initialized" | "waiting" = "waiting";
+  const pendingLogs$ = recreatePendingStream$.pipe(
+    tap(() => {
+      debug("initializing pending logs stream");
+      pendingLogsState = "initializing";
+      processedBlockLogs = {};
+    }),
+    switchMap(() =>
+      watchLogs({
+        ...opts,
+        url: opts.pendingLogsUrl,
+        fromBlock: restartBlockNumber,
+      }).logs$.pipe(
+        catchError((e) => {
+          debug("Error in pending logs stream, recreating", e);
+          recreatePendingStream$.next();
+          return throwError(() => e);
+        }),
+      ),
+    ),
+    tap((block) => {
+      debug("pending logs stream initialized");
+      pendingLogsState = "initialized";
+      restartBlockNumber = block.blockNumber;
+      const seenLogs = (processedBlockLogs[String(block.blockNumber)] ??= {});
+      block.logs.forEach((log) => {
+        seenLogs[log.logIndex!] = true;
+      });
+      debug("got pending block", block.blockNumber, "with", block.logs.length, "logs");
+    }),
+  );
+
+  const missingLogs$ = latestBlock$.pipe(
+    map((block) => {
+      const seenLogs = processedBlockLogs[String(block.blockNumber)] ?? {};
+      const missingLogs = block.logs.filter((log) => !seenLogs[log.logIndex!]);
+      debug(
+        "got latest block",
+        block.blockNumber,
+        "with",
+        block.logs.length,
+        "logs (",
+        missingLogs.length,
+        "new logs)",
+      );
+      return { blockNumber: block.blockNumber, logs: missingLogs };
+    }),
+    tap(({ blockNumber }) => {
+      delete processedBlockLogs[String(blockNumber)];
+      restartBlockNumber = blockNumber + 1n;
+      if (
+        pendingLogsState === "waiting" && // pending logs stream not initialized yet
+        initialCatchUpBlockNumber != null && // initial catch up block fetched
+        blockNumber >= initialCatchUpBlockNumber // initial catch up block reached
+      ) {
+        debug("initial catch up block number reached, creating pending stream");
+        recreatePendingStream$.next();
+        return;
+      }
+    }),
+    filter(({ logs }) => logs.length > 0),
+    tap(({ blockNumber }) => {
+      if (pendingLogsState === "initializing") {
+        debug("pending logs stream is initializing, not recreating");
+        return;
+      }
+      if (pendingLogsState === "initialized") {
+        debug("missing logs found in latest block", blockNumber, "recreating pending stream");
+        recreatePendingStream$.next();
+        return;
+      }
+      debug("catching up, pending logs stream not initialized yet");
+    }),
+  );
+
+  return merge(pendingLogs$, missingLogs$);
+}
+
+// TODO: reduce duplication with indexer/rpc stream in `createStoreSync.ts`
+function createLatestBlockStream({
+  fromBlock,
+  indexerUrl,
+  chainId,
+  address,
+  filters,
+  latestBlockNumber$,
+  maxBlockRange,
+  ...opts
+}: PendingBlockStreamOptions): Observable<StorageAdapterBlock> {
+  const indexerBlocks$ = indexerUrl
+    ? of(indexerUrl).pipe(
+        mergeMap((indexerUrl) => {
+          const url = new URL(
+            `api/logs-live?${new URLSearchParams({
+              input: JSON.stringify({ chainId, address, filters }),
+              block_num: fromBlock.toString(),
+              include_tx_hash: "true",
+            })}`,
+            indexerUrl,
+          );
+          return fromEventSource<string>(url);
+        }),
+        map((messageEvent) => {
+          const data = JSON.parse(messageEvent.data);
+          if (!isLogsApiResponse(data)) {
+            throw new Error("Received unexpected from indexer:" + messageEvent.data);
+          }
+          return toStorageAdapterBlock(data);
+        }),
+      )
+    : throwError(() => new Error("No indexer URL provided"));
+
+  let lastBlockNumberProcessed = 0n;
+  const ethRpcBlocks$ = combineLatest([of(fromBlock), latestBlockNumber$]).pipe(
+    map(([startBlock, endBlock]) => ({ startBlock, endBlock })),
+    concatMap((range) => {
+      const storedBlocks = fetchAndStoreLogs({
+        ...opts,
+        address,
+        events: storeEventsAbi,
+        maxBlockRange,
+        fromBlock: lastBlockNumberProcessed
+          ? bigIntMax(range.startBlock, lastBlockNumberProcessed + 1n)
+          : range.startBlock,
+        toBlock: range.endBlock,
+        logFilter: filters.length
+          ? (log: StoreEventsLog): boolean =>
+              filters.some(
+                (filter) =>
+                  filter.tableId === log.args.tableId &&
+                  (filter.key0 == null || filter.key0 === log.args.keyTuple[0]) &&
+                  (filter.key1 == null || filter.key1 === log.args.keyTuple[1]),
+              )
+          : undefined,
+        storageAdapter: () => Promise.resolve(),
+      });
+      return from(storedBlocks);
+    }),
+    tap((block) => {
+      lastBlockNumberProcessed = block.blockNumber;
+    }),
+  );
+
+  const latestBlock$ = indexerBlocks$.pipe(
+    catchError((error) => {
+      debug("failed to stream logs from indexer:", error.message);
+      debug("falling back to streaming logs from ETH RPC");
+      return ethRpcBlocks$;
+    }),
+  );
+
+  return latestBlock$;
+}

--- a/packages/store-sync/src/createPendingBlockStream.ts
+++ b/packages/store-sync/src/createPendingBlockStream.ts
@@ -86,7 +86,7 @@ export function createPendingBlockStream(opts: PendingBlockStreamOptions): Obser
       ),
     ),
     tap((block) => {
-      debug("pending block", block.blockNumber, "with", block.logs.length, "logs");
+      debug("pending block", block);
       pendingLogsState = "initialized";
       restartBlockNumber = block.blockNumber;
       const seenLogs = (processedBlockLogs[String(block.blockNumber)] ??= {});
@@ -105,14 +105,16 @@ export function createPendingBlockStream(opts: PendingBlockStreamOptions): Obser
       delete processedBlockLogs[String(block.blockNumber)];
       restartBlockNumber = block.blockNumber + 1n;
 
+      debug("latest block", processedBlockLogs);
+
       debug(
-        "got latest block",
+        "comparing latest block",
         block.blockNumber,
         "with",
         block.logs.length,
         "logs (",
         missingBlock ? "missing block," : "block seen,",
-        `${missingLogs.length} new logs`,
+        missingLogs.length > 0 ? `${missingLogs.length} missing logs` : "no new logs",
         ")",
       );
 

--- a/packages/store-sync/src/createPendingBlockStream.ts
+++ b/packages/store-sync/src/createPendingBlockStream.ts
@@ -86,7 +86,6 @@ export function createPendingBlockStream(opts: PendingBlockStreamOptions): Obser
       ),
     ),
     tap((block) => {
-      debug("pending block", block);
       pendingLogsState = "initialized";
       restartBlockNumber = block.blockNumber;
       const seenLogs = (processedBlockLogs[String(block.blockNumber)] ??= {});
@@ -104,8 +103,6 @@ export function createPendingBlockStream(opts: PendingBlockStreamOptions): Obser
       const missingLogs = block.logs.filter((log) => !seenLogs[log.logIndex!]);
       delete processedBlockLogs[String(block.blockNumber)];
       restartBlockNumber = block.blockNumber + 1n;
-
-      debug("latest block", processedBlockLogs);
 
       debug(
         "comparing latest block",

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -75,7 +75,7 @@ export async function createStoreSync({
   maxBlockRange,
   initialState,
   initialBlockLogs,
-  disableChunking,
+  enableHydrationChunking = true,
   ...opts
 }: CreateStoreSyncOptions): Promise<SyncResult> {
   const filters: SyncFilter[] =
@@ -159,10 +159,7 @@ export async function createStoreSync({
         message: "Hydrating from snapshot",
       });
 
-      if (disableChunking) {
-        debug("hydrating all logs without chunking");
-        await storageAdapter({ blockNumber, logs });
-      } else {
+      if (!enableHydrationChunking) {
         // Split snapshot operations into chunks so we can update the progress callback (and ultimately render visual progress for the user).
         // This isn't ideal if we want to e.g. batch load these into a DB in a single DB tx, but we'll take it.
         //
@@ -184,6 +181,9 @@ export async function createStoreSync({
           // We wait for idle callback here to give rendering a chance to complete.
           await waitForIdle();
         }
+      } else {
+        debug("hydrating all logs without chunking");
+        await storageAdapter({ blockNumber, logs });
       }
 
       onProgress?.({

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -32,6 +32,9 @@ import {
   throwError,
   mergeWith,
   ignoreElements,
+  switchMap,
+  Subject,
+  startWith,
 } from "rxjs";
 import { debug as parentDebug } from "./debug";
 import { SyncStep } from "./SyncStep";
@@ -41,10 +44,10 @@ import { fromEventSource } from "./fromEventSource";
 import { fetchAndStoreLogs } from "./fetchAndStoreLogs";
 import { isLogsApiResponse } from "./indexer-client/isLogsApiResponse";
 import { toStorageAdapterBlock } from "./indexer-client/toStorageAdapterBlock";
-import { watchLogs } from "./watchLogs";
 import { getAction } from "viem/utils";
 import { getChainId, getTransactionReceipt } from "viem/actions";
 import packageJson from "../package.json";
+import { createPendingBlockStream } from "./createPendingBlockStream";
 
 const debug = parentDebug.extend("createStoreSync");
 
@@ -201,7 +204,20 @@ export async function createStoreSync({
   );
 
   let latestBlockNumber: bigint | null = null;
-  const latestBlock$ = createBlockStream({ ...opts, blockTag: followBlockTag }).pipe(shareReplay(1));
+  const recreateLatestBlockStream$ = new Subject<void>();
+  const latestBlock$ = recreateLatestBlockStream$.pipe(
+    startWith(undefined),
+    switchMap(() =>
+      createBlockStream({ ...opts, blockTag: followBlockTag }).pipe(
+        catchError((error) => {
+          debug("error in latestBlock$, recreating");
+          recreateLatestBlockStream$.next();
+          return throwError(() => error);
+        }),
+      ),
+    ),
+    shareReplay(1),
+  );
   const latestBlockNumber$ = latestBlock$.pipe(
     map((block) => block.number),
     tap((blockNumber) => {
@@ -217,15 +233,22 @@ export async function createStoreSync({
   const pendingLogsWebSocketUrl = publicClient.chain?.rpcUrls?.wiresaw?.webSocket?.[0];
   const storedPendingLogs$ = pendingLogsWebSocketUrl
     ? startBlock$.pipe(
-        mergeMap((startBlock) => watchLogs({ url: pendingLogsWebSocketUrl, address, fromBlock: startBlock }).logs$),
+        switchMap((startBlock) =>
+          createPendingBlockStream({
+            ...opts,
+            fromBlock: startBlock,
+            pendingLogsUrl: pendingLogsWebSocketUrl,
+            chainId,
+            filters,
+            address,
+            latestBlockNumber$,
+            indexerUrl,
+          }),
+        ),
         concatMap(async (block) => {
           await storageAdapter(block);
           return block;
         }),
-        mergeWith(
-          // The watchLogs API doesn't emit on empty logs, but consumers expect an emission on empty logs
-          latestBlockNumber$.pipe(map((blockNumber) => ({ blockNumber, logs: [] }))),
-        ),
       )
     : throwError(() => new Error("No pending logs WebSocket RPC URL provided"));
 

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -75,6 +75,7 @@ export async function createStoreSync({
   maxBlockRange,
   initialState,
   initialBlockLogs,
+  disableChunking,
   ...opts
 }: CreateStoreSyncOptions): Promise<SyncResult> {
   const filters: SyncFilter[] =
@@ -158,26 +159,31 @@ export async function createStoreSync({
         message: "Hydrating from snapshot",
       });
 
-      // Split snapshot operations into chunks so we can update the progress callback (and ultimately render visual progress for the user).
-      // This isn't ideal if we want to e.g. batch load these into a DB in a single DB tx, but we'll take it.
-      //
-      // Split into 50 equal chunks (for better `onProgress` updates) but only if we have 100+ items per chunk
-      const chunkSize = Math.max(100, Math.floor(logs.length / 50));
-      const chunks = Array.from(chunk(logs, chunkSize));
-      for (const [i, chunk] of chunks.entries()) {
-        await storageAdapter({ blockNumber, logs: chunk });
-        onProgress?.({
-          step: SyncStep.SNAPSHOT,
-          percentage: ((i + 1) / chunks.length) * 100,
-          latestBlockNumber: 0n,
-          lastBlockNumberProcessed: blockNumber,
-          message: "Hydrating from snapshot",
-        });
-
-        // RECS is a synchronous API so hydrating in a loop like this blocks downstream render cycles
-        // that would display the percentage climbing up to 100.
-        // We wait for idle callback here to give rendering a chance to complete.
-        await waitForIdle();
+      if (disableChunking) {
+        debug("hydrating all logs without chunking");
+        await storageAdapter({ blockNumber, logs });
+      } else {
+        // Split snapshot operations into chunks so we can update the progress callback (and ultimately render visual progress for the user).
+        // This isn't ideal if we want to e.g. batch load these into a DB in a single DB tx, but we'll take it.
+        //
+        // Split into 50 equal chunks (for better `onProgress` updates) but only if we have 100+ items per chunk
+        const chunkSize = Math.max(100, Math.floor(logs.length / 50));
+        const chunks = Array.from(chunk(logs, chunkSize));
+        for (const [i, chunk] of chunks.entries()) {
+          debug(`hydrating chunk ${i}/${chunks.length}`);
+          await storageAdapter({ blockNumber, logs: chunk });
+          onProgress?.({
+            step: SyncStep.SNAPSHOT,
+            percentage: ((i + 1) / chunks.length) * 100,
+            latestBlockNumber: 0n,
+            lastBlockNumberProcessed: blockNumber,
+            message: "Hydrating from snapshot",
+          });
+          // RECS is a synchronous API so hydrating in a loop like this blocks downstream render cycles
+          // that would display the percentage climbing up to 100.
+          // We wait for idle callback here to give rendering a chance to complete.
+          await waitForIdle();
+        }
       }
 
       onProgress?.({

--- a/packages/store-sync/src/sql/common.ts
+++ b/packages/store-sync/src/sql/common.ts
@@ -10,6 +10,10 @@ export type TableQuery = {
    * Note: requires an indexer with SQL API
    */
   sql: string;
+  /**
+   * Optionally filter to only include records updated in this block or earlier.
+   */
+  toBlock?: bigint;
 };
 
 export type LogFilter = {

--- a/packages/store-sync/src/stash/computeUpdates.ts
+++ b/packages/store-sync/src/stash/computeUpdates.ts
@@ -8,7 +8,7 @@ import {
   getValueSchema,
 } from "@latticexyz/protocol-parser/internal";
 import { spliceHex } from "@latticexyz/common";
-import { Hex, concatHex, size } from "viem";
+import { Hex, Log, concatHex, size } from "viem";
 import { Table } from "@latticexyz/config";
 import { StorageAdapterBlock, emptyValueArgs } from "../common";
 import { debug } from "./debug";
@@ -62,7 +62,7 @@ export function computeUpdates({
 
     if (log.eventName === "Store_SetRecord") {
       const value = decodeValueArgs(valueSchema, log.args);
-      updates.push((pendingRecords[id] = { table, key, value }));
+      updates.push((pendingRecords[id] = { table, key, value, log: log as Log }));
     } else if (log.eventName === "Store_SpliceStaticData") {
       const previousValue = getPendingRecord(id, table, key);
       const {
@@ -78,7 +78,7 @@ export function computeUpdates({
         dynamicData,
       });
 
-      updates.push((pendingRecords[id] = { table, key, value }));
+      updates.push((pendingRecords[id] = { table, key, value, log: log as Log }));
     } else if (log.eventName === "Store_SpliceDynamicData") {
       const previousValue = getPendingRecord(id, table, key);
       const { staticData, dynamicData: previousDynamicData } = previousValue
@@ -92,9 +92,9 @@ export function computeUpdates({
         dynamicData,
       });
 
-      updates.push((pendingRecords[id] = { table, key, value }));
+      updates.push((pendingRecords[id] = { table, key, value, log: log as Log }));
     } else if (log.eventName === "Store_DeleteRecord") {
-      updates.push((pendingRecords[id] = { table, key, value: undefined }));
+      updates.push((pendingRecords[id] = { table, key, value: undefined, log: log as Log }));
     }
   }
 

--- a/packages/store-sync/src/watchLogs.ts
+++ b/packages/store-sync/src/watchLogs.ts
@@ -30,56 +30,19 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
 
   let resumeBlock = fromBlock;
 
-  let pingTimer: ReturnType<typeof setTimeout> | undefined = undefined;
-  // how often to ping to keep socket alive
-  const pingInterval = 3000;
-  // how long to wait for ping response before we attempt to reconnect
-  const pingTimeout = 5000;
-
   const logs$ = new Observable<StorageAdapterBlock>((subscriber) => {
-    debug("logs$ subscribed");
+    debug("wiresaw_watchLogs subscribed, starting from", fromBlock);
 
     let client: SocketRpcClient<WebSocket>;
 
     async function setupClient(): Promise<void> {
-      debug("setupClient called");
-
-      // Buffer the live logs received until the gap from `startBlock` to `currentBlock` is closed
+      // Buffer the live logs received until the gap from `fromBlock` to `currentBlock` is closed
       let caughtUp = false;
       const logBuffer: StoreEventsLog[] = [];
 
-      client = await getWebSocketRpcClient(url, { keepAlive: false });
-      debug("got websocket rpc client");
-
-      async function ping(): Promise<void> {
-        try {
-          debug("pinging socket");
-          await client.requestAsync({ body: { method: "net_version" }, timeout: pingTimeout });
-        } catch (error) {
-          debug("ping failed, closing...", error);
-          client.close();
-        }
-      }
-
-      function schedulePing(): void {
-        debug("scheduling next ping");
-        pingTimer = setTimeout(() => ping().then(schedulePing), pingInterval);
-      }
-
-      schedulePing();
-
-      client.socket.addEventListener("error", (error) => {
-        debug("socket error, closing...", error);
-        client.close();
-      });
-
-      client.socket.addEventListener("close", async () => {
-        debug("socket close, setting up new client...");
-        clearTimeout(pingTimer);
-        setupClient().catch((error) => {
-          debug("error trying to setup new client", error);
-          subscriber.error(error);
-        });
+      client = await getWebSocketRpcClient(getUncachedUrl(url), {
+        keepAlive: true,
+        reconnect: { attempts: 100, delay: 1_000 },
       });
 
       // Start watching pending logs
@@ -94,31 +57,26 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
       debug("got watchLogs subscription", subscriptionId);
 
       // Listen for wiresaw_watchLogs subscription
-      // Need to use low level methods since viem's socekt client only handles `eth_subscription` messages.
+      // Need to use low level methods since viem's socket client only handles `eth_subscription` messages.
       // (https://github.com/wevm/viem/blob/f81d497f2afc11b9b81a79057d1f797694b69793/src/utils/rpc/socket.ts#L178)
       client.socket.addEventListener("message", (message) => {
         const response = JSON.parse(message.data);
         if ("error" in response) {
-          debug("JSON-RPC error, returning error to subscriber");
-          subscriber.error(response.error);
+          debug("JSON-RPC error", response.error);
           return;
         }
 
         // Parse the logs from wiresaw_watchLogs
         if ("params" in response && response.params.subscription === subscriptionId) {
-          debug("parsing logs");
           const result: WatchLogsEvent = response.params.result;
           const formattedLogs = result.logs.map((log) => formatLog(log));
           const parsedLogs = parseEventLogs({ abi: storeEventsAbi, logs: formattedLogs });
           const blockNumber = BigInt(result.blockNumber);
-          debug("got logs", parsedLogs, "for pending block", blockNumber);
           if (caughtUp) {
-            debug("handing off logs to subscriber");
             subscriber.next({ blockNumber, logs: parsedLogs });
             // Since this the event's block number corresponds to a pending block, we have to refetch this block in case of a restart
             resumeBlock = blockNumber;
           } else {
-            debug("buffering logs");
             logBuffer.push(...parsedLogs);
           }
           return;
@@ -127,11 +85,10 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
 
       // Catch up to the pending logs
       try {
-        debug("fetching initial logs");
         const initialLogs = await fetchInitialLogs({ client, address, fromBlock: resumeBlock, topics });
-        debug("got initial logs", initialLogs);
+        debug("got", initialLogs.logs.length, "initial logs");
         const logs = [...initialLogs.logs, ...logBuffer].sort(logSort);
-        debug("combining with log buffer", logs);
+        debug("combining with buffer of", logBuffer.length, "logs");
         const blockNumber = logs.at(-1)?.blockNumber ?? initialLogs.blockNumber;
         subscriber.next({ blockNumber, logs });
         // Since this the block number can correspond to a pending block, we have to refetch this block in case of a restart
@@ -149,9 +106,12 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
     });
 
     return () => {
-      debug("logs$ subscription closed");
-      clearTimeout(pingTimer);
-      client?.close();
+      debug("logs$ subscription closed, closing client");
+      try {
+        client?.close();
+      } catch (e) {
+        debug("failed to close client", e);
+      }
     };
   });
 
@@ -175,6 +135,8 @@ async function fetchInitialLogs({
     })
   ).result;
 
+  debug("fetching initial logs from", Number(fromBlock), "to", parseInt(latestBlockNumber));
+
   // Request all logs from `fromBlock` to the latest block number
   const rawInitialLogs: RpcLog[] = await client
     .requestAsync({
@@ -188,4 +150,10 @@ async function fetchInitialLogs({
   // Return all logs from `fromBlock` until the current pending block state as initial result
   const formattedLogs = rawInitialLogs.map((log) => formatLog(log));
   return { blockNumber: BigInt(latestBlockNumber), logs: parseEventLogs({ abi: storeEventsAbi, logs: formattedLogs }) };
+}
+
+function getUncachedUrl(url: string): string {
+  const uncachedUrl = new URL(url);
+  uncachedUrl.searchParams.append("timestamp", String(Date.now()));
+  return uncachedUrl.toString();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,7 +603,7 @@ importers:
         version: 3.1.3(@types/react-dom@18.2.7)(@types/react@18.2.22)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.6
-        version: 2.2.6(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(@upstash/redis@1.34.9)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
+        version: 2.2.6(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))
       '@tanstack/react-query':
         specifier: ^5.51.3
         version: 5.52.0(react@18.2.0)
@@ -669,7 +669,7 @@ importers:
         version: 1.12.0
       wagmi:
         specifier: 2.15.5
-        version: 2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(@upstash/redis@1.34.9)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
+        version: 2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
       yargs:
         specifier: ^17.7.1
         version: 17.7.2
@@ -1197,7 +1197,7 @@ importers:
         version: 10.34.0
       change-case:
         specifier: ^5.2.0
-        version: 5.2.0
+        version: 5.4.4
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -6305,9 +6305,6 @@ packages:
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
-  change-case@5.2.0:
-    resolution: {integrity: sha512-L6VzznESnMIKKdKhVzCG+KPz4+x1FWbjOs1AdhoHStV3qo8aySMRGPUoqC0aL1ThKaQNGhAu6ZfHL/QAyQRuiw==}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
@@ -15288,7 +15285,7 @@ snapshots:
       '@types/react': 18.2.22
       '@types/react-dom': 18.2.7
 
-  '@rainbow-me/rainbowkit@2.2.6(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(@upstash/redis@1.34.9)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))':
+  '@rainbow-me/rainbowkit@2.2.6(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8))':
     dependencies:
       '@tanstack/react-query': 5.52.0(react@18.2.0)
       '@vanilla-extract/css': 1.15.5
@@ -15301,7 +15298,7 @@ snapshots:
       react-remove-scroll: 2.6.2(@types/react@18.2.22)(react@18.2.0)
       ua-parser-js: 1.0.38
       viem: 2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
-      wagmi: 2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(@upstash/redis@1.34.9)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
+      wagmi: 2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -16319,7 +16316,7 @@ snapshots:
   '@swc/helpers@0.5.5':
     dependencies:
       '@swc/counter': 0.1.3
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@tanstack/query-core@5.52.0': {}
 
@@ -18472,8 +18469,6 @@ snapshots:
 
   chalk@5.3.0: {}
 
-  change-case@5.2.0: {}
-
   change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
@@ -19355,7 +19350,7 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -19367,7 +19362,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -19388,7 +19383,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.1.1(eslint@8.57.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -22502,15 +22497,15 @@ snapshots:
   react-remove-scroll-bar@2.3.4(@types/react@18.2.22)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.2.22)(react@18.2.0)
-      tslib: 2.7.0
+      react-style-singleton: 2.2.3(@types/react@18.2.22)(react@18.2.0)
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.2.22
 
   react-remove-scroll-bar@2.3.6(@types/react@18.2.22)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.2.22)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.2.22)(react@18.2.0)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.2.22
@@ -22548,10 +22543,10 @@ snapshots:
   react-remove-scroll@2.6.0(@types/react@18.2.22)(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-remove-scroll-bar: 2.3.6(@types/react@18.2.22)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.22)(react@18.2.0)
-      tslib: 2.7.0
-      use-callback-ref: 1.3.2(@types/react@18.2.22)(react@18.2.0)
+      react-remove-scroll-bar: 2.3.8(@types/react@18.2.22)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.2.22)(react@18.2.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.2.22)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.22)(react@18.2.0)
     optionalDependencies:
       '@types/react': 18.2.22
@@ -22560,7 +22555,7 @@ snapshots:
     dependencies:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.8(@types/react@18.2.22)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.22)(react@18.2.0)
+      react-style-singleton: 2.2.3(@types/react@18.2.22)(react@18.2.0)
       tslib: 2.8.1
       use-callback-ref: 1.3.3(@types/react@18.2.22)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.22)(react@18.2.0)
@@ -24202,7 +24197,7 @@ snapshots:
     dependencies:
       xml-name-validator: 4.0.0
 
-  wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(@upstash/redis@1.34.9)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
+  wagmi@2.15.5(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.52.0(react@18.2.0))(@types/react@18.2.22)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8):
     dependencies:
       '@tanstack/react-query': 5.52.0(react@18.2.0)
       '@wagmi/connectors': 5.8.4(@types/react@18.2.22)(@upstash/redis@1.34.9)(@wagmi/core@2.17.2(@tanstack/query-core@5.56.2)(@types/react@18.2.22)(react@18.2.0)(typescript@5.4.2)(use-sync-external-store@1.4.0(react@18.2.0))(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(typescript@5.4.2)(utf-8-validate@5.0.10)(viem@2.30.6(bufferutil@4.0.8)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)


### PR DESCRIPTION
- previously if there was an error in the pending logs stream the sync stack fell back to the `latest` block logs stream (from indexer or rpc), but it never tried to reconnect to the pending logs stream
- previously the sync stack wasn't detecting if the pending logs api was inactive and wasn't falling back to a `latest` block stream in that case