### PR TITLE
chore: increase react peer dep range

### DIFF
--- a/packages/stash/package.json
+++ b/packages/stash/package.json
@@ -58,13 +58,13 @@
     "viem": "2.30.5"
   },
   "peerDependencies": {
-    "react": "18.x",
+    "react": "18.x || 19.x",
     "viem": "2.x"
   },
   "publishConfig": {
     "access": "public"
   },
   "optionalPeerDependencies": {
-    "react": "18.x"
+    "react": "18.x || 19.x"
   }
 }

--- a/packages/store-sync/package.json
+++ b/packages/store-sync/package.json
@@ -115,7 +115,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "5.x",
-    "react": "18.x",
+    "react": "18.x || 19.x",
     "viem": "2.x",
     "wagmi": "2.x"
   },
@@ -132,5 +132,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "optionalPeerDependencies": {
+    "react": "18.x || 19.x"
   }
 }


### PR DESCRIPTION
we already had this range specified in entrykit but not in stash/store-sync, so pnpm was spitting out warnings
<img width="430" alt="image" src="https://github.com/user-attachments/assets/b33cb853-d016-4dec-b679-f317b684f7ce" />
