### PR TITLE
fix(store-sync): backoff on failed connection, close websockets

### DIFF
--- a/.changeset/blue-gorillas-buy.md
+++ b/.changeset/blue-gorillas-buy.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+The preconfirmed logs stream now waits before reconnecting if a previous connection attempt failed.

--- a/packages/store-sync/src/createPreconfirmedBlockStream.ts
+++ b/packages/store-sync/src/createPreconfirmedBlockStream.ts
@@ -57,7 +57,7 @@ export function createPreconfirmedBlockStream(opts: PreconfirmedBlockStreamOptio
     switchMap(() =>
       createLatestBlockStream({ ...opts, fromBlock: restartBlockNumber }).pipe(
         catchError((e) => {
-          debug("Error in latest block stream", e);
+          debug("Error in latest block stream, recreating", e);
           recreateLatestStream$.next();
           return throwError(() => e);
         }),

--- a/packages/store-sync/src/watchLogs.ts
+++ b/packages/store-sync/src/watchLogs.ts
@@ -42,7 +42,6 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
 
       client = await getWebSocketRpcClient(getUncachedUrl(url), {
         keepAlive: true,
-        reconnect: { attempts: 100, delay: 1_000 },
       });
 
       // Start watching pending logs
@@ -109,8 +108,9 @@ export function watchLogs({ url, address, fromBlock }: WatchLogsInput): WatchLog
       debug("logs$ subscription closed, closing client");
       try {
         client?.close();
+        client?.socket?.close();
       } catch (e) {
-        debug("failed to close client", e);
+        debug("failed to close client/socket", e);
       }
     };
   });


### PR DESCRIPTION
* attempt to prevent dangling http connections we're seeing in wiresaw infra metrics
* wait before reconnecting if precious connection attempt failed