### PR TITLE
test(world-module-metadata): fix flaky test

### DIFF
--- a/packages/world-module-metadata/test/MetadataModule.t.sol
+++ b/packages/world-module-metadata/test/MetadataModule.t.sol
@@ -112,10 +112,10 @@ contract MetadataModuleTest is Test, GasReporter {
   }
 
   function testTagUnownedResource(address caller) public {
-    world.registerDelegation(address(metadataModule), UNLIMITED_DELEGATION, new bytes(0));
-
     vm.assume(caller != address(0));
     vm.assume(caller != address(this));
+
+    world.registerDelegation(address(metadataModule), UNLIMITED_DELEGATION, new bytes(0));
 
     world.installModule(metadataModule, new bytes(0));
     ResourceId resource = NamespaceOwner._tableId;


### PR DESCRIPTION
not sure if this was the cause of the flaky test in https://github.com/latticexyz/mud/actions/runs/15822902836/job/44596043837 but seems like `vm.assume` should be at the beginning of this test function?