### PR TITLE
fix(store-sync): preconfirmedLogs can be undefined

### DIFF
--- a/packages/store-sync/src/createPreconfirmedBlockStream.ts
+++ b/packages/store-sync/src/createPreconfirmedBlockStream.ts
@@ -71,7 +71,7 @@ export function createPreconfirmedBlockStream(opts: PreconfirmedBlockStreamOptio
     ),
   );
 
-  let preconfirmedTransactionLogs: { [txHash: string]: Partial<StoreEventsLog>[] } = {};
+  let preconfirmedTransactionLogs: { [txHash: string]: Partial<StoreEventsLog>[] | undefined } = {};
   let preconfirmedLogsState: "initializing" | "initialized" | "waiting" = "waiting";
   let attempt = 0;
   const preconfirmedBlockLogs$ = recreatePreconfirmedStream$.pipe(

--- a/packages/store-sync/src/createPreconfirmedBlockStream.ts
+++ b/packages/store-sync/src/createPreconfirmedBlockStream.ts
@@ -152,7 +152,7 @@ export function createPreconfirmedBlockStream(opts: PreconfirmedBlockStreamOptio
                   numPreconfirmedLogs: preconfirmedLogs?.length,
                   numLatestLogs: latestLogs.length,
                   missingLogs: latestLogs.filter(
-                    (log) => !preconfirmedLogs.find((preconfirmedLog) => log.logIndex === preconfirmedLog.logIndex),
+                    (log) => !preconfirmedLogs?.find((preconfirmedLog) => log.logIndex === preconfirmedLog.logIndex),
                   ),
                 },
                 (_, value) => (typeof value === "bigint" ? value.toString() : value),


### PR DESCRIPTION
followup to #3762 

The type of `preconfirmedTransactionLogs[txHash]` was inferred at non-null, but it can be null if we haven't seen this transaction in the preconfirmed stream. 