### PR TITLE
fix(entrykit): don't wait for connector when returning session client

### DIFF
--- a/packages/entrykit/src/useSessionClientReady.ts
+++ b/packages/entrykit/src/useSessionClientReady.ts
@@ -1,18 +1,14 @@
 // Exported `useSessionClient` variant and only provides the session client once all prerequisites are met.
 
-import { useConnectorClient } from "wagmi";
+import { useAccount } from "wagmi";
 import { useSessionClient } from "./useSessionClient";
-import { useEntryKitConfig } from "./EntryKitConfigProvider";
 import { usePrerequisites } from "./onboarding/usePrerequisites";
 import { UseQueryResult } from "@tanstack/react-query";
 import { SessionClient } from "./common";
 
 export function useSessionClientReady(): UseQueryResult<SessionClient | undefined> {
-  const { chainId } = useEntryKitConfig();
-  const userClient = useConnectorClient({ chainId });
-  if (userClient.error) console.error("Error retrieving user client", userClient.error);
+  const { address: userAddress } = useAccount();
 
-  const userAddress = userClient.data?.account.address;
   const prerequisites = usePrerequisites(userAddress);
   const sessionClient = useSessionClient(userAddress);
 


### PR DESCRIPTION
We don't need the connector until the modal is open and we're requesting signatures from the user. This avoids a flash of unconnected state. 