### PR TITLE
Revert "fix(entrykit): don't wait for connector when returning session client"

### DIFF
--- a/packages/entrykit/src/useSessionClientReady.ts
+++ b/packages/entrykit/src/useSessionClientReady.ts
@@ -1,14 +1,18 @@
 // Exported `useSessionClient` variant and only provides the session client once all prerequisites are met.
 
-import { useAccount } from "wagmi";
+import { useConnectorClient } from "wagmi";
 import { useSessionClient } from "./useSessionClient";
+import { useEntryKitConfig } from "./EntryKitConfigProvider";
 import { usePrerequisites } from "./onboarding/usePrerequisites";
 import { UseQueryResult } from "@tanstack/react-query";
 import { SessionClient } from "./common";
 
 export function useSessionClientReady(): UseQueryResult<SessionClient | undefined> {
-  const { address: userAddress } = useAccount();
+  const { chainId } = useEntryKitConfig();
+  const userClient = useConnectorClient({ chainId });
+  if (userClient.error) console.error("Error retrieving user client", userClient.error);
 
+  const userAddress = userClient.data?.account.address;
   const prerequisites = usePrerequisites(userAddress);
   const sessionClient = useSessionClient(userAddress);
 


### PR DESCRIPTION
Reverts latticexyz/mud#3768

For some reason, this causes the ConnectKit modal to open automatically, which is not what we want. Need to do a deeper dive into this.

<img width="533" alt="image" src="https://github.com/user-attachments/assets/c0cfeef5-95a6-45e9-bd09-de6f34ed3ef7" />
