### PR TITLE
docs: fix template link

### DIFF
--- a/docs/pages/guides/hello-world/add-chain-client.mdx
+++ b/docs/pages/guides/hello-world/add-chain-client.mdx
@@ -7,7 +7,7 @@ Note that this is not required if you are going to use Lattice chains, [redstone
 
 ## Setup
 
-[Create a new MUD application from the template](../../templates/typescript/getting-started).
+[Create a new MUD application from the template](../../templates/typescript/vanilla).
 Use the vanilla template.
 
 ```sh copy


### PR DESCRIPTION
Replaced the outdated link to the non-existent "getting-started" file with the correct "vanilla" template guide in the add-chain-client tutorial. This ensures users are directed to the appropriate setup instructions for the vanilla TypeScript template.