### PR TITLE
Fix broken link to Garnet documentation

### DIFF
--- a/docs/pages/indexer/sql.mdx
+++ b/docs/pages/indexer/sql.mdx
@@ -6,7 +6,7 @@ import { Callout } from "nextra/components";
 
 <FilterTypes />
 
-If there is a SQL-enabled indexer instance serving a blockchain, as there is for [Redstone](https://redstone.xyz/) and [Garnet](https://garnetchain.com/docs/what-is-redstone), you can use it to:
+If there is a SQL-enabled indexer instance serving a blockchain, as there is for [Redstone](https://redstone.xyz/) and [Garnet](https://garnet.redstone.xyz/docs/what-is-redstone), you can use it to:
 
 - Run queries on the data of any `World` on that blockchain.
 - [Speed up the initial hydration](#mud-state-hydration-via-sql-api) by reducing the amount of data that needs to be synchronized.


### PR DESCRIPTION
Replaced the outdated Garnet documentation link (https://garnetchain.com/docs/what-is-redstone) with the current correct URL (https://garnet.redstone.xyz/docs/what-is-redstone) in the SQL API docs. This resolves a 404 error and ensures users are directed to the up-to-date Garnet documentation.