### PR TITLE
fix(store-sync): block stream retry backoff

### DIFF
--- a/.changeset/funny-otters-explode.md
+++ b/.changeset/funny-otters-explode.md
@@ -1,0 +1,5 @@
+---
+"@latticexyz/store-sync": patch
+---
+
+Fixed an issue where losing connection would get stuck in a retry loop.

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -239,6 +239,7 @@ export async function createStoreSync({
     debug("creating block stream");
     return createBlockStream({ ...opts, blockTag: followBlockTag });
   }).pipe(
+    // TODO: detect network online and reset this
     retry({
       delay: (error, retryCount) => {
         const backoff = Math.min(4_000, 2 ** retryCount * 50);

--- a/packages/store-sync/src/createStoreSync.ts
+++ b/packages/store-sync/src/createStoreSync.ts
@@ -33,8 +33,9 @@ import {
   mergeWith,
   ignoreElements,
   switchMap,
-  Subject,
-  startWith,
+  ReplaySubject,
+  timer,
+  retry,
 } from "rxjs";
 import { debug as parentDebug } from "./debug";
 import { SyncStep } from "./SyncStep";
@@ -233,20 +234,26 @@ export async function createStoreSync({
   );
 
   let latestBlockNumber: bigint | null = null;
-  const recreateLatestBlockStream$ = new Subject<void>();
-  const latestBlock$ = recreateLatestBlockStream$.pipe(
-    startWith(undefined),
-    switchMap(() =>
-      createBlockStream({ ...opts, blockTag: followBlockTag }).pipe(
-        catchError((error) => {
-          debug("error in latestBlock$, recreating");
-          recreateLatestBlockStream$.next();
-          return throwError(() => error);
-        }),
-      ),
-    ),
-    shareReplay(1),
+
+  const latestBlock$ = defer(() => {
+    debug("creating block stream");
+    return createBlockStream({ ...opts, blockTag: followBlockTag });
+  }).pipe(
+    retry({
+      delay: (error, retryCount) => {
+        const backoff = Math.min(4_000, 2 ** retryCount * 50);
+        return timer(backoff);
+      },
+      resetOnSuccess: true,
+    }),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnError: true,
+      resetOnComplete: false,
+      resetOnRefCountZero: true,
+    }),
   );
+
   const latestBlockNumber$ = latestBlock$.pipe(
     map((block) => block.number),
     tap((blockNumber) => {


### PR DESCRIPTION
if you lose connection (internet connection or remote server dies), this retry loop will get stuck in an infinite loop, block the main thread, and make the browser/tab unresponsive