### PR TITLE
feat(explorer): add support for custom indexer urls in explorer

### DIFF
--- a/packages/explorer/src/app/(explorer)/api/utils/getIndexerUrl.ts
+++ b/packages/explorer/src/app/(explorer)/api/utils/getIndexerUrl.ts
@@ -2,5 +2,5 @@ import { chainIdToName, supportedChainId, supportedChains } from "../../../../co
 
 export function getIndexerUrl(chainId: supportedChainId) {
   const chain = supportedChains[chainIdToName[chainId]];
-  return "indexerUrl" in chain ? chain.indexerUrl : undefined;
+  return process.env.INDEXER_URL ? process.env.INDEXER_URL : "indexerUrl" in chain ? chain.indexerUrl : undefined;
 }

--- a/packages/explorer/src/app/(explorer)/hooks/useIndexerForChainId.ts
+++ b/packages/explorer/src/app/(explorer)/hooks/useIndexerForChainId.ts
@@ -7,12 +7,11 @@ export function useIndexerForChainId(chainId: number) {
   validateChainId(chainId);
 
   const env = useEnv();
-  const indexerPort = env.INDEXER_PORT;
 
   if (chainId === anvil.id) {
     return {
       type: "sqlite" as const,
-      url: new URL("/q", `http://localhost:${indexerPort}`).toString(),
+      url: new URL("/q", `http://localhost:${env.DEV_INDEXER_PORT}`).toString(),
     };
   }
 
@@ -21,6 +20,6 @@ export function useIndexerForChainId(chainId: number) {
 
   return {
     type: "hosted" as const,
-    url: new URL("/q", chain.indexerUrl).toString(),
+    url: new URL("/q", env.INDEXER_URL ? env.INDEXER_URL : chain.indexerUrl).toString(),
   };
 }

--- a/packages/explorer/src/app/(explorer)/providers/ServerEnvProvider.tsx
+++ b/packages/explorer/src/app/(explorer)/providers/ServerEnvProvider.tsx
@@ -7,8 +7,9 @@ type ServerEnvProviderProps = {
 
 export function ServerEnvProvider({ children }: ServerEnvProviderProps) {
   const env = {
-    INDEXER_PORT: process.env.INDEXER_PORT || "3001",
+    DEV_INDEXER_PORT: process.env.DEV_INDEXER_PORT || "3001",
     CHAIN_ID: process.env.CHAIN_ID || "31337",
+    INDEXER_URL: process.env.INDEXER_URL || "",
   };
 
   return <EnvProvider env={env}>{children}</EnvProvider>;

--- a/packages/explorer/src/bin/explorer.ts
+++ b/packages/explorer/src/bin/explorer.ts
@@ -24,11 +24,16 @@ const argv = yargs(process.argv.slice(2))
       type: "number",
       default: process.env.PORT || 13690,
     },
-    indexerPort: {
+    devIndexerPort: {
       alias: "pi",
-      description: "Port number for the indexer",
+      description: "Port number for the development indexer",
       type: "number",
-      default: process.env.INDEXER_PORT || 3001,
+      default: process.env.DEV_INDEXER_PORT || 3001,
+    },
+    indexerUrl: {
+      alias: "iu",
+      description: "The indexer URL to use. Defaults to the one from the chain config",
+      type: "string",
     },
     hostname: {
       alias: "H",
@@ -60,7 +65,7 @@ const argv = yargs(process.argv.slice(2))
   })
   .parseSync();
 
-const { port, indexerPort, hostname, chainId, indexerDatabase, dev } = argv;
+const { port, devIndexerPort, indexerUrl, hostname, chainId, indexerDatabase, dev } = argv;
 const indexerDatabasePath = path.join(packageRoot, indexerDatabase);
 
 let explorerProcess: ChildProcess;
@@ -70,7 +75,8 @@ async function startExplorer() {
   const env = {
     ...process.env,
     CHAIN_ID: chainId.toString(),
-    INDEXER_PORT: indexerPort.toString(),
+    DEV_INDEXER_PORT: devIndexerPort.toString(),
+    INDEXER_URL: indexerUrl,
   };
 
   if (dev) {
@@ -115,7 +121,7 @@ async function startStoreIndexer() {
       ENABLE_UNSAFE_QUERY_API: "true",
       SQLITE_FILENAME: indexerDatabase,
       ...process.env,
-      PORT: indexerPort.toString(),
+      PORT: devIndexerPort.toString(),
     },
   });
 }


### PR DESCRIPTION
- Added a `INDEXER_URL` env to allow a custom indexer url to be used than the one set on the chain config
- Renamed `INDEXER_PORT` to `DEV_INDEXER_PORT` since its only used when the chain is anvil and the local sqlite indexer is run