### PR TITLE
fix(entrykit): top-up flow and session enable state

### DIFF
--- a/packages/entrykit/src/onboarding/Session.tsx
+++ b/packages/entrykit/src/onboarding/Session.tsx
@@ -21,7 +21,7 @@ export type Props = StepContentProps & {
 export function Session({ isActive, isExpanded, connector, userClient, registerSpender, registerDelegation }: Props) {
   const sessionClient = useShowQueryError(useSessionClient(userClient.account.address));
   const setup = useShowMutationError(useSetupSession({ userClient, connector }));
-  const hasSession = !registerDelegation && !registerDelegation;
+  const hasSession = !registerSpender && !registerDelegation;
   const { data: prerequisites } = usePrerequisites(userClient.account.address);
   const { hasAllowance, hasGasBalance, hasQuarryGasBalance } = prerequisites ?? {};
 

--- a/packages/entrykit/src/onboarding/deposit/ChainSelect.tsx
+++ b/packages/entrykit/src/onboarding/deposit/ChainSelect.tsx
@@ -11,6 +11,7 @@ import { ChevronDownIcon } from "../../icons/ChevronDownIcon";
 import { Input } from "../../ui/Input";
 import { ChainIcon } from "./ChainIcon";
 import { useRelay } from "./useRelay";
+import { useEntryKitConfig } from "../../EntryKitConfigProvider";
 import { useShowQueryError } from "../../errors/useShowQueryError";
 import { useChainBalances } from "./useChainBalances";
 import { Balance } from "../../ui/Balance";
@@ -31,6 +32,7 @@ export function ChainSelect({ value, onChange }: Props) {
   const theme = useTheme();
   const { frame } = useFrame();
   const { chains, switchChain } = useSwitchChain();
+  const { chainId: destinationChainId } = useEntryKitConfig();
   const relay = useRelay();
   const relayChains = relay.data?.chains;
 
@@ -43,8 +45,8 @@ export function ChainSelect({ value, onChange }: Props) {
           relayChain,
         } satisfies ChainWithRelay;
       })
-      .filter((c) => c.relayChain);
-  }, [chains, relayChains]);
+      .filter((c) => c.id === destinationChainId || c.relayChain);
+  }, [chains, relayChains, destinationChainId]);
 
   const selectedChain = sourceChains.find((c) => c.id === value)!;
   const { data: chainsBalances, isLoading } = useShowQueryError(useChainBalances({ chains: sourceChains }));


### PR DESCRIPTION
This PR fixes two onboarding regressions in EntryKit around top-ups and session setup.

It updates the top-up chain selector to keep the configured destination chain available even when Relay does not return metadata for it, which restores same-chain direct deposits. It also fixes the session step’s enabled-state check so the UI only shows `Enabled` when both spender registration and delegation are complete, instead of disabling the action early.