### PR TITLE
feat(cli): warn when dev-contracts targets non-local chain

### DIFF
--- a/packages/cli/src/commands/dev-contracts.ts
+++ b/packages/cli/src/commands/dev-contracts.ts
@@ -56,6 +56,8 @@ const commandModule: CommandModule<typeof devOptions, InferredOptionTypes<typeof
       );
 
       rpc = "http://127.0.0.1:8545";
+    } else if (!rpc.includes("127.0.0.1") && !rpc.includes("localhost")) {
+      console.log(chalk.yellow("Warning: dev-contracts is intended for local development. Deploying to a non-local chain may cause unexpected failures."));
     }
 
     // Watch for changes


### PR DESCRIPTION
Fixes #3567 — adds a console warning when `mud dev-contracts` is used with a non-local RPC URL.